### PR TITLE
Changed: Harden dotfiles automation and public config

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,138 @@
+---
+language: en-US
+early_access: false
+enable_free_tier: true
+
+reviews:
+  profile: chill
+  request_changes_workflow: true
+  high_level_summary: false
+  review_status: true
+  commit_status: true
+  fail_commit_status: false
+  changed_files_summary: true
+  estimate_code_review_effort: true
+  suggested_labels: true
+  auto_apply_labels: true
+  path_instructions:
+    - path: "agents/.agents/skills/**/SKILL.md"
+      instructions: |
+        These files are Codex skill instructions. Focus on accidental disclosure
+        of private context, credentials, internal-only paths, or personal data;
+        prompt clarity; scope control; and whether the skill asks agents to use
+        safe, reviewable workflows.
+    - path: "agents/.agents/skills/**/agents/*.{yaml,yml}"
+      instructions: |
+        These files expose skills to agent surfaces. Verify the YAML remains
+        minimal, parseable, non-secret, and aligned with the corresponding
+        skill instructions.
+    - path: "codex/.codex/config.toml"
+      instructions: |
+        Treat this as personal tool configuration. Look especially for secrets,
+        tokens, private endpoints, broad trusted paths, and surprising plugin or
+        runtime enablement.
+    - path: ".github/workflows/*.{yaml,yml}"
+      instructions: |
+        Audit GitHub Actions for pinned actions, least-privilege permissions,
+        shell injection risks, credential persistence, and unnecessary network
+        or write access.
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    drafts: true
+    base_branches:
+      - main
+  tools:
+    shellcheck:
+      enabled: true
+    markdownlint:
+      enabled: true
+    github-checks:
+      enabled: true
+      timeout_ms: 90000
+    gitleaks:
+      enabled: true
+    actionlint:
+      enabled: true
+    yamllint:
+      enabled: true
+    languagetool:
+      enabled: true
+
+    ast-grep:
+      enabled: false
+    biome:
+      enabled: false
+    brakeman:
+      enabled: false
+    buf:
+      enabled: false
+    checkmake:
+      enabled: false
+    checkov:
+      enabled: false
+    circleci:
+      enabled: false
+    clippy:
+      enabled: false
+    cppcheck:
+      enabled: false
+    detekt:
+      enabled: false
+    dotenvLint:
+      enabled: false
+    eslint:
+      enabled: false
+    flake8:
+      enabled: false
+    golangci-lint:
+      enabled: false
+    hadolint:
+      enabled: false
+    htmlhint:
+      enabled: false
+    luacheck:
+      enabled: false
+    oxc:
+      enabled: false
+    phpmd:
+      enabled: false
+    phpcs:
+      enabled: false
+    phpstan:
+      enabled: false
+    pmd:
+      enabled: false
+    prismaLint:
+      enabled: false
+    pylint:
+      enabled: false
+    regal:
+      enabled: false
+    rubocop:
+      enabled: false
+    ruff:
+      enabled: false
+    semgrep:
+      enabled: false
+    shopifyThemeCheck:
+      enabled: false
+    sqlfluff:
+      enabled: false
+    swiftlint:
+      enabled: false
+
+chat:
+  auto_reply: true
+
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "agents/.agents/skills/**"
+      - ".github/workflows/**"
+      - "codex/.codex/config.toml"
+      - "git/.gitconfig"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: verify
+    runs-on: macos-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Check shell syntax
+        run: bash -n bin/bootstrap.sh bin/verify.sh
+
+      - name: Parse Git config
+        run: git config --file git/.gitconfig --list >/dev/null
+
+      - name: Parse Codex config
+        run: |
+          python3 - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          with Path("codex/.codex/config.toml").open("rb") as config:
+              tomllib.load(config)
+          PY
+
+      - name: Parse YAML
+        run: |
+          ruby <<'RUBY'
+          require "psych"
+
+          paths = Dir.glob([
+            ".coderabbit.yml",
+            ".github/workflows/*.{yaml,yml}",
+            "agents/.agents/skills/**/agents/*.{yaml,yml}",
+          ])
+
+          paths.sort.each do |path|
+            Psych.safe_load(File.read(path), permitted_classes: [], aliases: false)
+          end
+          RUBY

--- a/agents/.agents/skills/rust-borrowed-view-audit/SKILL.md
+++ b/agents/.agents/skills/rust-borrowed-view-audit/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: rust-borrowed-view-audit
+description: Audit Rust APIs for opportunities to replace owned snapshots, caches, handles, and cloned topology with lifetime-bound borrowed views over canonical storage. Use when reviewing Rust libraries for stale-cache prevention, snapshot/view API design, transaction/rollback guard design, generation or identity checks, or performance/correctness tradeoffs around cloning versus borrowing.
+---
+
+# Rust Borrowed View Audit
+
+## Purpose
+
+Review Rust APIs for places where ownership, borrowing, and lifetimes can encode correctness invariants directly. Prefer borrowed views when they prevent stale use, cross-owner confusion, or mutation during observation without adding runtime bookkeeping.
+
+## Workflow
+
+1. Identify the canonical owner of each relation or data structure.
+   - Name the structure that is allowed to mutate the data.
+   - Treat all other structures as views, derived indexes, detached snapshots, or rollback state.
+   - If there is no clear canonical owner, call that out first.
+
+2. Classify each candidate API.
+   - **Borrowed view**: should borrow canonical storage and be lifetime-bound to it.
+   - **Owned snapshot**: should own data because it must outlive the source, cross threads independently, persist, or support detached analysis.
+   - **Derived index**: may own derived maps but should borrow canonical relations when possible.
+   - **Rollback state**: may own a clone or delta, but should usually be hidden behind a guard borrowing `&mut` canonical storage.
+   - **Handle/key**: may remain copyable, but must carry enough provenance or be validated at use boundaries.
+
+3. Look for parse-don't-validate smells.
+   - Raw `HashMap`/`Vec` fields mutated from multiple modules.
+   - `clone()` used mainly to dodge lifetimes rather than to create a true snapshot.
+   - Runtime generation checks used where a borrow could prevent stale use at compile time.
+   - Public or crate-wide setters that can create impossible intermediate states.
+   - Tests reaching through storage internals instead of using narrow invariant-specific test hooks.
+
+4. Recommend the narrowest lifetime change that encodes the invariant.
+   - Convert owned cache fields to `&'a CanonicalIndex` when the view should not outlive the owner.
+   - Keep owned maps only for derived data not already stored canonically.
+   - Use `Transaction<'a>` or guard types borrowing `&'a mut Owner` to prevent observation of intermediate mutation.
+   - Keep generation/identity checks for detached handles, cross-owner inputs, serialization boundaries, or manually constructed test fixtures.
+
+5. Check mutation boundaries.
+   - Ensure mutators validate or parse before storing invalid state.
+   - Prefer relation-specific methods such as `insert_simplex`, `remove_isolated_vertex`, or `rebuild_from_storage` over exposing raw collection operations.
+   - Make fallible mutators return typed errors when an invariant would be violated.
+   - Verify rollback paths cannot leak partially mutated state through existing views.
+
+6. Validate performance claims carefully.
+   - Borrowing should remove avoidable clones or allocations, but do not assume it is faster without checking.
+   - Account for any added preflight checks on hot paths.
+   - For scientific or topology-heavy crates, prioritize correctness and invariant clarity before micro-optimizing.
+
+## Review Output
+
+Start with findings, ordered by correctness impact. For each finding include:
+
+- The canonical owner and the accidental duplicate or stale view risk.
+- The proposed borrowed-view or transaction-guard shape.
+- Whether runtime generation/provenance checks remain necessary.
+- Any API break and why it improves correctness, performance, or orthogonality.
+- Focused tests or compile-fail examples that would prove the lifetime invariant.
+
+If no change is needed, say whether the API is a true owned snapshot, detached handle, or rollback state and why borrowing would be worse.

--- a/agents/.agents/skills/rust-borrowed-view-audit/agents/openai.yaml
+++ b/agents/.agents/skills/rust-borrowed-view-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Borrowed View Audit"
+  short_description: "Audit Rust APIs for lifetime-bound views"
+  default_prompt: "Use $rust-borrowed-view-audit to review Rust snapshot and cache APIs for places where borrowed views should replace owned clones."

--- a/codex/.codex/config.toml
+++ b/codex/.codex/config.toml
@@ -11,56 +11,18 @@ or only report status.
 
 sandbox_mode = "workspace-write"
 
-notify = ["/Users/adam/.codex/computer-use/Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient", "turn-ended"]
-
 [sandbox_workspace_write]
 network_access = true
 writable_roots = [ "/Users/adam/.cache/codex/uv" ]
 
 [shell_environment_policy]
-set = { PATH = "/opt/homebrew/bin:/usr/local/bin:/Users/adam/.local/bin:/Users/adam/.cargo/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Codex.app/Contents/Resources", UV_CACHE_DIR = "/Users/adam/.cache/codex/uv" }
+set = { UV_CACHE_DIR = "/Users/adam/.cache/codex/uv" }
 
 [features]
 js_repl = false
-
-[mcp_servers.node_repl]
-args = []
-command = "/Applications/Codex.app/Contents/Resources/cua_node/bin/node_repl"
-startup_timeout_sec = 120
-
-[mcp_servers.node_repl.env]
-NODE_REPL_NATIVE_PIPE_CONNECT_TIMEOUT_MS = "1000"
-NODE_REPL_NODE_MODULE_DIRS = "/Applications/Codex.app/Contents/Resources/cua_node/lib/node_modules"
-NODE_REPL_NODE_PATH = "/Applications/Codex.app/Contents/Resources/cua_node/bin/node"
-NODE_REPL_TRUSTED_CODE_PATHS = "/Users/adam/.codex"
-CODEX_HOME = "/Users/adam/.codex"
-NODE_REPL_TRUSTED_BROWSER_CLIENT_SHA256S = "27dca86fd6b571c49414a4b78e46b57bcf683a46cd1319799c11fbb6cfae3110"
-BROWSER_USE_AVAILABLE_BACKENDS = "chrome,iab"
-NODE_REPL_INSTRUCTIONS_USE_CASE_BROWSER = "Control the in-app browser in conjunction with the Browser Plugin."
-NODE_REPL_INSTRUCTIONS_USE_CASE_CHROME = "Control the Chrome browser in conjunction with the Chrome Plugin. Prefer this method of controlling Chrome over alternatives (such as Computer Use) unless the user explicitly mentions an alternative."
-BROWSER_USE_CODEX_APP_BUILD_FLAVOR = "prod"
-BROWSER_USE_CODEX_APP_VERSION = "26.609.41114"
-CODEX_CLI_PATH = "/Applications/Codex.app/Contents/Resources/codex"
 
 [desktop]
 followUpQueueMode = "steer"
 
 [desktop.open-in-target-preferences]
 global = "zed"
-
-[desktop.open-in-target-preferences.perPath]
-"/Users/adam/projects/causal-triangulations" = "zed"
-
-[marketplaces.openai-bundled]
-last_updated = "2026-06-14T19:24:33Z"
-source_type = "local"
-source = "/Users/adam/.codex/.tmp/bundled-marketplaces/openai-bundled"
-
-[projects."/Users/adam/projects/causal-triangulations"]
-trust_level = "trusted"
-
-[projects."/Users/adam/projects/delaunay"]
-trust_level = "trusted"
-
-[plugins."browser@openai-bundled"]
-enabled = true

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -5,3 +5,9 @@
 # Lives in $HOME, never tracked by this repo.
 [include]
 	path = ~/.gitconfig.local
+[credential "https://github.com"]
+	helper =
+	helper = !/opt/homebrew/bin/gh auth git-credential
+[credential "https://gist.github.com"]
+	helper =
+	helper = !/opt/homebrew/bin/gh auth git-credential


### PR DESCRIPTION
- Add pinned CI checks for shell, Git, TOML, and YAML configuration.
- Configure CodeRabbit to review skills, workflows, and public dotfiles for secret exposure and workflow safety.
- Add the Rust borrowed-view audit skill for reviewing lifetime-bound Rust APIs.
- Trim Codex config to durable public defaults and remove local runtime state.
- Route GitHub and Gist credentials through the GitHub CLI helper.