### PR TITLE
Changed: Refine agent skill and stow workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,19 @@ Supported stow packages are `git`, `zsh`, and `agents`.
 # Preview changes before applying a package.
 just stow-check agents
 
-# Apply or re-apply one package after the dry-run check passes.
+# Apply one package and print the symlink operations performed.
 just stow-apply zsh
 
-# Apply all managed packages.
-just stow-all
+# Apply all managed packages and print their symlink operations.
+just stow-apply-all
 
-# Remove one package's symlinks.
+# Restow one package, refreshing existing links with explicit unlink/link output.
+just stow-restow agents
+
+# Restow all managed packages.
+just stow-restow-all
+
+# Remove one package's symlinks and print the removals.
 just stow-delete zsh
 
 # Adopt an existing live file into the repo (overwrites the package copy).
@@ -77,7 +83,7 @@ Use `--adopt` only when intentionally moving an existing `$HOME` file into dotfi
 
 The `just` stow recipes always pass both `-d "$PWD"` and `-t "$HOME"`. If running raw `stow`, pass both paths explicitly; otherwise stow targets the parent of the current directory, which can create links in the wrong place.
 
-For new package-owned files such as Codex skills, create the file under the package, run `just stow-check <package>`, then run `just stow-apply <package>` when the dry run looks right. Stow recipes do not stage, commit, or print source-control status.
+For new package-owned files such as Codex skills, create the file under the package, run `just stow-check <package>`, then run `just stow-apply <package>` when the dry run looks right. `stow-check` is the only simulation-mode recipe; `stow-apply` and `stow-apply-all` stow missing or new links, while `stow-restow` and `stow-restow-all` perform full unlink/link refreshes. Mutating recipes print the Stow link operations they perform. `just stow-all` remains as an alias for `just stow-apply-all`. Stow recipes do not stage, commit, or print source-control status.
 
 ## Brewfile workflow
 `Brewfile` is intentionally foundational: core CLI tools, developer casks, and apps expected on every machine.

--- a/agents/.agents/skills/academic-authorship-boundary/SKILL.md
+++ b/agents/.agents/skills/academic-authorship-boundary/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: academic-authorship-boundary
+description: Preserve human authorship for scholarly writing. Use when working on Adam's Praxis, theses, papers, manuscripts, publication drafts, academic sections, reviewer responses, or any request that involves text intended to appear under Adam's name. Also use when asked to outline, critique, review, proofread, cite-check, structure, or build academic writing while avoiding AI-authored prose.
+---
+
+# Academic Authorship Boundary
+
+Use this skill to protect Adam's authorship boundary for scholarly work. Academic prose that appears under Adam's name must be written by Adam.
+
+## Core Rule
+
+Do not generate substantive prose intended to appear in a Praxis, thesis, paper, manuscript, publication draft, reviewer response, or other academic work under Adam's name.
+
+## Allowed Help
+
+You may help with:
+
+- outlines, section plans, argument maps, and TODO scaffolds
+- review comments, critique, margin-note style feedback, and revision priorities
+- questions that help Adam decide what to write
+- citation audits, bibliography checks, DOI/link checks, and reference placement suggestions
+- LaTeX, Markdown, notebook, figure, build, PDF, and submission-tooling maintenance
+- author-facing TeX scaffolds, TODO macros, outline bullets, and generated-artifact plumbing
+- grammar, clarity, consistency, and structure review of prose Adam has already written
+
+## Disallowed Help
+
+Do not supply:
+
+- paragraphs, abstracts, introductions, conclusions, or section prose for Adam to paste into academic work
+- rewritten academic prose that replaces Adam's wording wholesale
+- reviewer-response text intended to be submitted as Adam's voice
+- claims of authorship provenance or AI-use compliance beyond what can be verified from repository/process facts
+
+## Response Pattern
+
+When asked to write academic prose, redirect to one of these forms:
+
+- an outline or bullet scaffold with clear `Author TODO` markers
+- a list of questions for Adam to answer in his own words
+- reviewer-style comments on Adam-authored text
+- a structural edit plan rather than replacement prose
+
+When Adam provides draft prose and asks for review, comment on it directly. Prefer specific critique, line-level concerns, missing evidence, unclear claims, citation gaps, and possible reorganizations. If proposing wording, keep it as a short illustrative alternative or comment, not a replacement section.
+
+## Repository Interactions
+
+If a repository has local paper-authorship guidance, follow it too. Keep paper drafts visibly marked as outlines or TODO scaffolds until Adam supplies the prose.
+
+Before editing repository paper sources such as `papers/*.tex`, read local agent and documentation guidance for paper ownership. Preserve or add explicit author-facing markers such as `Author TODO` scaffolds instead of filling in prose. It is fine to maintain build rules, source-date helpers, generated figures, bibliography plumbing, accessibility descriptions marked as author TODOs, and reviewer-copy artifact checks.
+
+Do not add formal AI-use or authorship-provenance disclosure text unless Adam explicitly asks for that specific venue/submission wording and supplies the factual basis.

--- a/agents/.agents/skills/academic-authorship-boundary/agents/openai.yaml
+++ b/agents/.agents/skills/academic-authorship-boundary/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Academic Authorship Boundary"
+  short_description: "Protects human-authored scholarly prose"
+  default_prompt: "Use $academic-authorship-boundary to help outline or review my academic writing without generating prose under my name."

--- a/agents/.agents/skills/changelog-commit-message/agents/openai.yaml
+++ b/agents/.agents/skills/changelog-commit-message/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Changelog Commit Message"
+  short_description: "Changelog-ready commit messages"
+  default_prompt: "Use $changelog-commit-message to write a changelog-ready commit message from my staged changes."

--- a/agents/.agents/skills/codecov-test-gaps/agents/openai.yaml
+++ b/agents/.agents/skills/codecov-test-gaps/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Codecov Test Gaps"
+  short_description: "Find meaningful coverage gaps"
+  default_prompt: "Use $codecov-test-gaps to inspect the latest coverage report and add meaningful missing tests."

--- a/agents/.agents/skills/crate-docs-update/SKILL.md
+++ b/agents/.agents/skills/crate-docs-update/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: crate-docs-update
-description: "Update the multi-file documentation suite for a scientific Rust crate, keeping README, REFERENCES, CITATION.cff, AGENTS, and docs/* consistent across changes. USE FOR: updating documentation after code/algorithm/release changes; syncing version metadata across Cargo.toml, CITATION.cff, README, and CHANGELOG; adding REFERENCES entries when new methods or papers are introduced; updating per-topic docs (api_design.md, invariants.md, scientific_basis.md, foliation.md, metropolis.md, moves.md, proposal_validation.md, BENCHMARKING.md, COVERAGE.md, PERFORMANCE.md, roadmap.md, KNOWN_ISSUES_*.md, TODO.md); adjusting AGENTS.md/CONTRIBUTING.md/CODE_OF_CONDUCT.md/SECURITY.md/RELEASING.md; preparing release-day doc edits. DO NOT USE FOR: writing commit messages (use changelog-commit-message); reviewing /// doc comments inside Rust source (use rust-api-docs); reviewing Cargo.toml/feature/MSRV/lints (use rust-cargo-hygiene); generating CHANGELOG.md content (delegate to git-cliff); making code changes; non-documentation chores."
+description: "Update documentation suites for scientific Rust crates, keeping README, REFERENCES, CITATION.cff, AGENTS, docs/*, and paper/process docs consistent. USE FOR: docs after code/algorithm/release changes; version metadata sync across Cargo.toml, CITATION.cff, README, and CHANGELOG; REFERENCES entries for new methods or papers; per-topic docs such as api_design.md, invariants.md, scientific_basis.md, validation.md, moves.md, proposal_validation.md, BENCHMARKING.md, COVERAGE.md, PERFORMANCE.md, roadmap.md, TODO.md; AGENTS/CONTRIBUTING/SECURITY/RELEASING updates; release-day doc edits. DO NOT USE FOR: commit messages (use changelog-commit-message); Rust /// docs (use rust-api-docs); Cargo/features/MSRV/lints (use rust-cargo-hygiene); generated CHANGELOG content (delegate to git-cliff); manuscript prose under Adam's name (use academic-authorship-boundary); code changes; non-documentation chores."
 ---
 
 # crate-docs-update
@@ -16,6 +16,7 @@ Use this skill to update existing documentation files, including:
 - **Top-level**: `README.md`, `REFERENCES.md`, `CITATION.cff`, `AGENTS.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`
 - **`docs/` topic files**: `api_design.md`, `invariants.md`, `numerical_robustness_guide.md`, `topology.md`, `validation.md`, `code_organization.md`, `scientific_basis.md`, `foliation.md`, `metropolis.md`, `moves.md`, `proposal_validation.md`, `roadmap.md`, `KNOWN_ISSUES_*.md`, `TODO.md`, `BENCHMARKING.md`, `COVERAGE.md`, `PERFORMANCE.md`, `ORIENTATION_SPEC.md`, etc.
 - **`docs/RELEASING.md`** when the release process itself changes
+- **Paper/process docs** such as `docs/dev/docs.md`, paper build workflows, and paper artifact guidance, while respecting the academic authorship boundary for manuscript prose.
 
 Do not hand-edit `CHANGELOG.md`. These crates use `git-cliff` (`cliff.toml`) to generate it from commit history. See [Changelog handling](#changelog-handling).
 
@@ -47,6 +48,8 @@ Use the staged or recent change as the source of truth and decide which docs are
 - **Process or policy changes** → `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `AGENTS.md`, `docs/RELEASING.md`
 
 If the relevant topic doc does not exist, prefer extending a related existing doc over creating a new file. Only add a new doc when the topic is genuinely new and persistent.
+
+If the change touches manuscript or publication material under `papers/`, use `academic-authorship-boundary` as the governing constraint. You may update paper build tooling, artifact freshness checks, bibliography wiring, outline/TODO scaffolds, and repository guidance, but do not write substantive paper prose for Adam.
 
 ### 3. Maintain cross-document consistency
 
@@ -80,6 +83,7 @@ These crates use `git-cliff` driven by `cliff.toml`. Do not hand-edit changelog 
 
 - never edit files marked auto-generated (e.g., `cargo-readme` output, `mdbook` build artifacts, generated API docs)
 - if a generated file looks wrong, fix the source instead
+- when a workflow checks generated paper/PDF/figure artifacts, document the source command and freshness check rather than patching generated outputs by hand
 
 ### 5. Per-repo convention sensitivity
 

--- a/agents/.agents/skills/crate-docs-update/agents/openai.yaml
+++ b/agents/.agents/skills/crate-docs-update/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Crate Docs Update"
+  short_description: "Sync scientific crate docs"
+  default_prompt: "Use $crate-docs-update to update this scientific Rust crate documentation after the current changes."

--- a/agents/.agents/skills/python-support-scripts/SKILL.md
+++ b/agents/.agents/skills/python-support-scripts/SKILL.md
@@ -17,6 +17,7 @@ Focus on newly added or modified Python that:
 - generates `CHANGELOG.md` or release notes
 - runs `cargo bench` / Criterion and aggregates JSON results
 - prepares release artifacts (tarballs, signed assets, docs uploads)
+- prepares reproducible paper, PDF, figure, or generated documentation artifacts
 - manipulates `Cargo.toml`, `Cargo.lock`, or workspace metadata
 - runs subprocess commands such as `cargo`, `gh`, `git`, or `rsync`
 - generates fixtures or diagnostic reports for the Rust crate
@@ -70,12 +71,14 @@ Check:
 - absolute paths and machine-specific values do not leak into committed output
 - random seeds, if any, are explicit
 - subprocess output is parsed deterministically (`--porcelain`, `--json`, `LC_ALL=C` when relevant)
+- dates used in committed artifacts come from explicit inputs and are parsed/formatted without relying on the process locale
 
 Flag:
 
 - `os.listdir`, `Path.glob`, or `set` iteration feeding committed output without sorting
 - timestamps in changelog entries that change between runs
 - locale-sensitive sorting or formatting on user-facing output
+- `datetime.strptime(..., "%B ...")` or similar locale-dependent parsing for English month names in CI/reproducible artifact paths; prefer ISO dates or an explicit month-name map plus UTC-aware datetimes
 
 ### 3. Error and edge handling
 

--- a/agents/.agents/skills/rust-invariant-performance/agents/openai.yaml
+++ b/agents/.agents/skills/rust-invariant-performance/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Invariant Performance"
+  short_description: "Optimize Rust without losing invariants"
+  default_prompt: "Use $rust-invariant-performance to review Rust performance while preserving invariants, typed errors, and validation boundaries."

--- a/agents/.agents/skills/rust-invariant-performance/references/delaunay.md
+++ b/agents/.agents/skills/rust-invariant-performance/references/delaunay.md
@@ -9,8 +9,9 @@ crate or closely related computational-geometry code.
   deterministic degeneracy handling.
 - Delaunay, PL-manifold, adjacency, Euler characteristic, ridge-link, and
   topology-guarantee invariants.
-- Validation layering: element/structure/topology checks must not be replaced by
-  Level-4 predicate work or skipped for speed.
+- Validation layering: Level 1 element validity, Level 2 combinatorial
+  consistency, and Level 3 intrinsic topology must not be replaced by Level 4
+  embedding checks, Level 5 geometric predicates, or skipped for speed.
 - Parse-don't-validate boundaries such as coordinate ranges, positive values,
   Hilbert bit depths, validated quantized batches, topology guarantees, and
   typed budgets.
@@ -26,6 +27,8 @@ crate or closely related computational-geometry code.
 - Hilbert ordering, quantization, deduplication, and construction preprocessing.
 - Topology validation and Delaunay validation, especially when run during repair
   or construction retries.
+- Spherical and toroidal backend validation where intrinsic dimension, ambient
+  embedding dimension, and predicate dimension can diverge.
 - Query and locate traversal, adjacency/ridge/facet iteration, and boundary
   extraction.
 - Benchmark fixture construction when it is inside measured closures.

--- a/agents/.agents/skills/rust-production-review/SKILL.md
+++ b/agents/.agents/skills/rust-production-review/SKILL.md
@@ -23,6 +23,11 @@ Focus on newly added or modified Rust code that affects:
 
 Use related focused Rust skills when the review narrows to a specialized concern, but keep this skill for broad production readiness and design review.
 
+## Project References
+
+- For `delaunay` or closely related computational-geometry work, read
+  [`references/delaunay.md`](references/delaunay.md) before reviewing.
+
 ### Scope Modes
 
 Default mode:

--- a/agents/.agents/skills/rust-production-review/agents/openai.yaml
+++ b/agents/.agents/skills/rust-production-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Production Review"
+  short_description: "Senior Rust production review"
+  default_prompt: "Use $rust-production-review to review changed Rust code for invariants, correctness, API stability, and maintainability."

--- a/agents/.agents/skills/rust-production-review/references/delaunay.md
+++ b/agents/.agents/skills/rust-production-review/references/delaunay.md
@@ -1,0 +1,31 @@
+# delaunay Production Review Notes
+
+Use this reference when applying `rust-production-review` to the `delaunay`
+crate or closely related computational-geometry code.
+
+## Validation Architecture
+
+- Preserve the validation hierarchy as separate responsibilities:
+  - Level 1: local object validity.
+  - Level 2: combinatorial consistency.
+  - Level 3: intrinsic PL topology.
+  - Level 4: embedding validity.
+  - Level 5: geometric predicates.
+- Geometry backends such as Euclidean, toroidal, and spherical support should
+  specialize embedding and predicate layers, not redefine intrinsic topology.
+- Delaunay or other geometric predicates must not substitute for lower-level
+  topology or embedding validation.
+- Keep intrinsic dimension and ambient dimension distinct. For example,
+  spherical `S^D` lives in `R^(D + 1)`, but the abstract simplex dimension
+  remains `D`.
+- Public fast-fail wrappers such as `is_valid_*` should delegate to canonical
+  `validate_*` implementations instead of duplicating logic that can drift.
+
+## Review Focus
+
+- Check that topology, embedding, and predicate errors preserve layer-specific
+  typed context for callers and tests.
+- Check new geometry backends against degenerate, malformed, duplicate, empty,
+  wrong-dimension, and wrong-radius inputs.
+- Check that helper extraction makes invariant-preserving steps clearer without
+  widening visibility or hiding failure context.

--- a/agents/.agents/skills/rust-test-quality/SKILL.md
+++ b/agents/.agents/skills/rust-test-quality/SKILL.md
@@ -46,6 +46,7 @@ A test suite is insufficient if it:
 Prefer:
 - unit tests for core logic
 - integration tests where behavior crosses modules
+- layer-specific tests for validation hierarchies, including negative cases that prove the expected error variant for malformed topology, invalid embedding, or failed geometric predicates
 
 ---
 
@@ -103,6 +104,7 @@ Evaluate whether tests:
 - assert meaningful outcomes (not just execution)
 - validate invariants and correctness
 - include negative / failure cases
+- exercise public fast-fail wrappers and the canonical validation functions they delegate to, so duplicate API surfaces cannot drift
 - avoid duplication without abstraction
 - are readable and maintainable
 

--- a/justfile
+++ b/justfile
@@ -114,10 +114,13 @@ stow-adopt package:
     package='{{package}}'
     case "$package" in git|zsh|agents) ;; *) echo "Unsupported stow package: $package" >&2; exit 2 ;; esac
     [ -d "$package" ] || { echo "Unknown stow package: $package" >&2; exit 2; }
-    stow -d "$PWD" -t "$HOME" --adopt -R "$package"
+    stow -d "$PWD" -t "$HOME" --adopt -v -R "$package"
     just stow-check "$package"
 
 stow-all:
+    just stow-apply-all
+
+stow-apply-all:
     #!/usr/bin/env bash
     set -euo pipefail
     for package in git zsh agents; do
@@ -128,8 +131,9 @@ stow-apply package:
     #!/usr/bin/env bash
     set -euo pipefail
     package='{{package}}'
-    just stow-check "$package"
-    stow -d "$PWD" -t "$HOME" -R "$package"
+    case "$package" in git|zsh|agents) ;; *) echo "Unsupported stow package: $package" >&2; exit 2 ;; esac
+    [ -d "$package" ] || { echo "Unknown stow package: $package" >&2; exit 2; }
+    stow -d "$PWD" -t "$HOME" -v -S "$package"
 
 stow-check package:
     #!/usr/bin/env bash
@@ -137,7 +141,22 @@ stow-check package:
     package='{{package}}'
     case "$package" in git|zsh|agents) ;; *) echo "Unsupported stow package: $package" >&2; exit 2 ;; esac
     [ -d "$package" ] || { echo "Unknown stow package: $package" >&2; exit 2; }
-    stow -d "$PWD" -t "$HOME" -n -v -R "$package"
+    stow -d "$PWD" -t "$HOME" -n -v -S "$package"
+
+stow-restow package:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    package='{{package}}'
+    case "$package" in git|zsh|agents) ;; *) echo "Unsupported stow package: $package" >&2; exit 2 ;; esac
+    [ -d "$package" ] || { echo "Unknown stow package: $package" >&2; exit 2; }
+    stow -d "$PWD" -t "$HOME" -v -R "$package"
+
+stow-restow-all:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    for package in git zsh agents; do
+        just stow-restow "$package"
+    done
 
 stow-delete package:
     #!/usr/bin/env bash
@@ -145,7 +164,7 @@ stow-delete package:
     package='{{package}}'
     case "$package" in git|zsh|agents) ;; *) echo "Unsupported stow package: $package" >&2; exit 2 ;; esac
     [ -d "$package" ] || { echo "Unknown stow package: $package" >&2; exit 2; }
-    stow -d "$PWD" -t "$HOME" -D "$package"
+    stow -d "$PWD" -t "$HOME" -v -D "$package"
 
 test-python: _ensure-uv
     uv run pytest


### PR DESCRIPTION
- Split normal stow application from explicit restow refresh commands.
- Add an academic authorship boundary skill with UI metadata.
- Add UI metadata for high-touch skills and capture recent paper, Delaunay, and reproducible tooling guidance.