### PR TITLE
Added: Review orchestration skills for code and tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ just check-skills
 - If `just` is unavailable, run the underlying validator directly:
 
 ```sh
-uv run --with PyYAML python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" <skill-dir>
+uv run python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" <skill-dir>
 ```
 
 - Use `uv run --with <package> ...` for one-off Python helper dependencies that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Repository Agent Instructions
+
+This repository is public dotfiles. Keep committed changes non-secret,
+machine-portable, and scoped to reproducible defaults.
+
+## Python And Skill Validation
+
+- Prefer `uv run` over bare `python3` for Python tooling in this repository.
+- Do not install packages into system or Homebrew Python just to run a repo
+  check.
+- For Codex skill validation, run:
+
+```sh
+uv run --with PyYAML python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" <skill-dir>
+```
+
+- Use `uv run --with <package> ...` for one-off Python helper dependencies that
+  are not part of this repo's locked environment.
+- If `uv` needs network access or cache writes outside the sandbox, request
+  approval instead of falling back to global Python package installation.
+- In tracked docs and instructions, prefer `$HOME`, `~`, or placeholders over
+  committed absolute paths such as `/Users/<name>/...`.
+
+## Dotfiles Workflow
+
+- Use `just` recipes as the primary command surface when they exist.
+- Do not mutate git state unless explicitly requested.
+- Do not edit local-only files such as `~/.codex/config.toml`,
+  `~/.zshrc.local`, `~/.gitconfig.local`, or `Brewfile.local` from this repo.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,14 @@ machine-portable, and scoped to reproducible defaults.
 - Prefer `uv run` over bare `python3` for Python tooling in this repository.
 - Do not install packages into system or Homebrew Python just to run a repo
   check.
-- For Codex skill validation, run:
+- For Codex skill validation, prefer the repository recipes:
+
+```sh
+just skill-check agents/.agents/skills/<skill-id>
+just check-skills
+```
+
+- If `just` is unavailable, run the underlying validator directly:
 
 ```sh
 uv run --with PyYAML python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" <skill-dir>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ just check-skills
 - If `just` is unavailable, run the underlying validator directly:
 
 ```sh
-uv run python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" <skill-dir>
+uv run python scripts/skill_validate.py <skill-dir>
 ```
 
 - Use `uv run --with <package> ...` for one-off Python helper dependencies that

--- a/README.md
+++ b/README.md
@@ -155,16 +155,18 @@ Jupyter kernels:
 ```toml
 [sandbox_workspace_write]
 network_access = true
-writable_roots = ["/Users/adam/.cache/codex/uv"]
+writable_roots = ["/Users/<username>/.cache/codex/uv"]
 
 [shell_environment_policy]
-set = { UV_CACHE_DIR = "/Users/adam/.cache/codex/uv" }
+set = { UV_CACHE_DIR = "/Users/<username>/.cache/codex/uv" }
 ```
 
 This lets Rust/Python workflows use `uv run`, `uv lock`, and notebook execution
 without giving Codex write access to all of `~/.cache` or disabling sandboxing.
 The network exception is intentionally attached to `workspace-write`; it is
 needed for local kernel sockets such as Jupyter's loopback ports.
+Replace `/Users/<username>` with the absolute home path on the local machine;
+keep the resulting machine-specific `~/.codex/config.toml` out of this repo.
 
 Keep secrets and mutable runtime state out of this public repo. Do not commit
 `~/.codex/auth.json`, logs, caches, sqlite state, marketplace cache state,
@@ -176,6 +178,8 @@ Local override files are not tracked and should not be committed.
 
 ### `~/.zshrc.local`
 Use for machine-specific shell paths, aliases, and experiments. It is sourced last by `zsh/.zshrc`.
+Keep host-specific SSH aliases and work/institution endpoints here rather than
+in the tracked `zsh/.zshrc`.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -226,9 +226,12 @@ To add a skill:
 3. validate and re-stow the package:
 
 ```sh
+just skill-check agents/.agents/skills/<skill-id>
 just stow-check agents
 just stow-apply agents
 ```
+
+Run `just check-skills` to validate every skill in `agents/.agents/skills/`.
 
 Review the changed skill files separately before including them in a commit.
 

--- a/agents/.agents/skills/project-tooling-review/SKILL.md
+++ b/agents/.agents/skills/project-tooling-review/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: project-tooling-review
+description: "Review and fix repository tooling surfaces that define how maintainers run, validate, and update a project. Use for justfile recipe design, GitHub Actions workflows, CI command drift, tool-version and installer drift, Brewfile and uv/cargo/rustup tooling configuration, lint/format/type-check command surfaces, release/support scripts wiring, docs that describe project commands, and cross-language validation recipes. Use when the user asks to review project tooling, just recipes, CI workflows, GitHub Actions, tool versions, command consistency, or repository workflow ergonomics. Do not use for Rust or Python source review except where tooling invokes those validators; use the language orchestrators for code behavior. Do not use for requests to commit, stage, push, tag, or otherwise mutate git state."
+---
+
+# project-tooling-review
+
+Review the project command layer: the recipes, workflows, version pins, and docs that let maintainers run the right checks without remembering every underlying tool.
+
+## Ground Rules
+
+- Do not perform git state mutations. Do not stage, commit, push, tag, checkout, reset, or stash unless the user explicitly asks in the current turn.
+- Do not upgrade, install, uninstall, or mutate tool versions unless the user explicitly asks. Review and propose or apply file edits only within the requested scope.
+- Use read-only git commands to discover scope when needed: `git --no-pager status --short`, `git --no-pager diff --stat`, `git --no-pager diff --name-status`, and `git --no-pager diff`.
+- Respect repository-local agent instructions before editing. If the repository documents development commands, read that guidance before changing recipes or workflows.
+- Prefer changed-file review by default. Use whole-repo baseline mode only when the user explicitly asks for "repo", "whole repo", "entire repo", "baseline audit", or equivalent.
+- When checking whether a tool is "latest" or current, verify against live authoritative sources or local package-manager metadata. Do not rely on model memory for current versions.
+
+## Scope Routing
+
+After identifying changed files, load only the references that apply:
+
+- [`references/justfile.md`](references/justfile.md) for `justfile`, command recipes, local validator tiers, recipe naming, and docs that describe `just` commands.
+- [`references/github-actions.md`](references/github-actions.md) for `.github/workflows/**`, Actions permissions/triggers/caches/matrices, CI use of `just`, and workflow validation.
+- [`references/tool-versions.md`](references/tool-versions.md) for `Brewfile`, `uv`, `cargo install`, `rustup`, lockfiles, action versions, language toolchains, and version drift.
+
+If multiple surfaces changed, review them in this order:
+
+1. Tool versions and installers, so commands use the intended tools.
+2. `justfile` recipes and local command contracts.
+3. GitHub Actions and remote CI wiring.
+4. Docs and handoff summaries that describe the command surface.
+
+## Review Goals
+
+### 1. Command Surface Coherence
+
+The repository should expose a small, memorable command layer. Prefer canonical `just` recipes such as `check`, `fix`, `ci`, `test-*`, `lint-*`, `coverage`, `docs`, and release/performance recipes over duplicated command strings scattered through docs and workflows.
+
+Flag drift between:
+
+- `justfile`
+- `.github/workflows/**`
+- `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, and `docs/**`
+- package/tool config files
+- release or support scripts
+
+### 2. Safety And Failure Behavior
+
+Tooling should fail loudly and safely.
+
+Check:
+
+- destructive recipes require explicit arguments and clear names
+- shell snippets do not swallow failures
+- commands have stable working directories and path assumptions
+- CI logs preserve enough context to diagnose failures
+- secrets, tokens, local paths, and private data are not printed
+
+### 3. Validation Tiers
+
+Keep fast local checks, full CI, slow/performance checks, release checks, and fixers distinct. Do not make every local workflow run the slowest path unless the repository explicitly wants that.
+
+### 4. Version And Update Discipline
+
+Check that tool versions are intentional, documented where needed, and consistent across local installers, lockfiles, workflows, and docs. When latest-version claims matter, verify them live before recommending changes.
+
+### 5. Cross-Language Coordination
+
+When tooling changes alter Rust or Python validation behavior, identify the affected language surface and call out whether `rust-review-orchestrator` or `python-review-orchestrator` should also run. Do not duplicate their source-code review inside this skill.
+
+## Fix Loop
+
+For each applicable tooling surface:
+
+1. Read the relevant reference file.
+2. Inspect changed files and nearby command owners.
+3. Implement minimal fixes for real tooling drift, safety, or validation issues.
+4. Run the focused validator for the surface when available.
+5. If validation fails, fix and rerun the same validator before moving on.
+6. Record changed files and commands for the final summary.
+
+If a validator needs network, installation, or other approval, use the strongest read-only/local check available and document the remaining verification.
+
+## Final Summary
+
+End with a concise summary that helps the maintainer review unstaged changes by file. Include:
+
+- each file changed and why
+- tooling surfaces reviewed
+- validators run and their results
+- version checks performed and whether they were live or local-only
+- language orchestrators recommended or run, if any
+- anything intentionally deferred or not run
+- confirmation that no git state mutations were performed, if true
+
+Lead with unresolved tooling risks if any remain.

--- a/agents/.agents/skills/project-tooling-review/SKILL.md
+++ b/agents/.agents/skills/project-tooling-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-tooling-review
-description: "Review and fix repository tooling surfaces that define how maintainers run, validate, and update a project. Use for justfile recipe design, GitHub Actions workflows, CI command drift, tool-version and installer drift, Brewfile and uv/cargo/rustup tooling configuration, lint/format/type-check command surfaces, release/support scripts wiring, docs that describe project commands, and cross-language validation recipes. Use when the user asks to review project tooling, just recipes, CI workflows, GitHub Actions, tool versions, command consistency, or repository workflow ergonomics. Do not use for Rust or Python source review except where tooling invokes those validators; use the language orchestrators for code behavior. Do not use for requests to commit, stage, push, tag, or otherwise mutate git state."
+description: "Review and fix repository tooling surfaces that define how maintainers run, validate, and update a project. Use for justfile recipe design, GitHub Actions workflows, CI command drift, tool-version and installer drift, uv tool and cargo-install managed CLI updates, Brewfile and uv/cargo/rustup tooling configuration, lint/format/type-check command surfaces, release/support scripts wiring, docs that describe project commands, and cross-language validation recipes. Use when the user asks to review project tooling, just recipes, CI workflows, GitHub Actions, tool versions, command consistency, or repository workflow ergonomics. Do not use for Rust or Python source review except where tooling invokes those validators; use the language orchestrators for code behavior. Do not use for requests to commit, stage, push, tag, or otherwise mutate git state."
 ---
 
 # project-tooling-review
@@ -10,11 +10,13 @@ Review the project command layer: the recipes, workflows, version pins, and docs
 ## Ground Rules
 
 - Do not perform git state mutations. Do not stage, commit, push, tag, checkout, reset, or stash unless the user explicitly asks in the current turn.
-- Do not upgrade, install, uninstall, or mutate tool versions unless the user explicitly asks. Review and propose or apply file edits only within the requested scope.
+- Do not install or uninstall unrelated tools unless the user explicitly asks. When the requested scope includes tool-version currentness, update drift, or "latest" tooling review, update stale tools through the repository's existing manager and reconcile tracked pins.
 - Use read-only git commands to discover scope when needed: `git --no-pager status --short`, `git --no-pager diff --stat`, `git --no-pager diff --name-status`, and `git --no-pager diff`.
 - Respect repository-local agent instructions before editing. If the repository documents development commands, read that guidance before changing recipes or workflows.
 - Prefer changed-file review by default. Use whole-repo baseline mode only when the user explicitly asks for "repo", "whole repo", "entire repo", "baseline audit", or equivalent.
+- When invoked by `repo-review` with a branch-scope file list or diff, honor that provided scope instead of rediscovering a narrower staged or worktree-only scope.
 - When checking whether a tool is "latest" or current, verify against live authoritative sources or local package-manager metadata. Do not rely on model memory for current versions.
+- For installed-tool drift, first record the resolved executable, installed version, and owning manager before comparing repo pins, docs, workflows, or remote latest metadata. A freshly upgraded local tool is evidence that must not be skipped just because no version file changed.
 
 ## Scope Routing
 
@@ -65,6 +67,8 @@ Keep fast local checks, full CI, slow/performance checks, release checks, and fi
 
 Check that tool versions are intentional, documented where needed, and consistent across local installers, lockfiles, workflows, and docs. When latest-version claims matter, verify them live before recommending changes.
 
+Start with the local installed version for tools that are invoked directly from the command surface, especially `uv`, `uv tool` managed CLIs, `cargo install` managed binaries, `rustup`, and Homebrew-managed CLIs. Then compare that local state against repository pins and authoritative latest-version sources. If a managed tool is stale and version updates are in scope, update it first, then update any matching repository pins, `justfile` install recipes, bootstrap scripts, docs, and GitHub Actions workflow versions.
+
 ### 5. Cross-Language Coordination
 
 When tooling changes alter Rust or Python validation behavior, identify the affected language surface and call out whether `rust-review-orchestrator` or `python-review-orchestrator` should also run. Do not duplicate their source-code review inside this skill.
@@ -90,6 +94,7 @@ End with a concise summary that helps the maintainer review unstaged changes by 
 - tooling surfaces reviewed
 - validators run and their results
 - version checks performed and whether they were live or local-only
+- managed tool updates performed, before/after versions, and `justfile` or GitHub Actions pins updated
 - language orchestrators recommended or run, if any
 - anything intentionally deferred or not run
 - confirmation that no git state mutations were performed, if true

--- a/agents/.agents/skills/project-tooling-review/SKILL.md
+++ b/agents/.agents/skills/project-tooling-review/SKILL.md
@@ -18,6 +18,19 @@ Review the project command layer: the recipes, workflows, version pins, and docs
 - When checking whether a tool is "latest" or current, verify against live authoritative sources or local package-manager metadata. Do not rely on model memory for current versions.
 - For installed-tool drift, first record the resolved executable, installed version, and owning manager before comparing repo pins, docs, workflows, or remote latest metadata. A freshly upgraded local tool is evidence that must not be skipped just because no version file changed.
 
+## Review Trace
+
+When invoked by `repo-review`, begin with a handoff receipt that names:
+
+- the parent branch scope and tooling-owned file list or file count handed off
+- selected tooling surfaces and why they apply
+- skipped tooling surfaces when a maintainer might reasonably expect them
+- reference files that will be loaded
+
+After loading each reference file, keep its name in the running trace for the final summary. This trace is required evidence that the tooling pass reviewed the intended command, workflow, or version surfaces rather than only describing them.
+
+When invoked by `repo-review`, provide table-ready evidence for the parent `Review Evidence` table: selected tooling surfaces, reference files loaded, validators run, version checks performed, and any skipped surfaces that might otherwise look missing.
+
 ## Scope Routing
 
 After identifying changed files, load only the references that apply:
@@ -92,6 +105,8 @@ End with a concise summary that helps the maintainer review unstaged changes by 
 
 - each file changed and why
 - tooling surfaces reviewed
+- reference files actually loaded
+- table-ready evidence for `repo-review` when invoked by the meta-orchestrator
 - validators run and their results
 - version checks performed and whether they were live or local-only
 - managed tool updates performed, before/after versions, and `justfile` or GitHub Actions pins updated

--- a/agents/.agents/skills/project-tooling-review/agents/openai.yaml
+++ b/agents/.agents/skills/project-tooling-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Project Tooling Review"
+  short_description: "Review just, CI, and tool versions"
+  default_prompt: "Use $project-tooling-review to review and fix project tooling, just recipes, CI workflows, and tool-version drift."

--- a/agents/.agents/skills/project-tooling-review/references/github-actions.md
+++ b/agents/.agents/skills/project-tooling-review/references/github-actions.md
@@ -20,6 +20,22 @@ Use this reference for `.github/workflows/**`, reusable workflow calls, Actions-
 - Prefer commit SHA pins for high-security/release/signing workflows when that policy exists, and document the update path.
 - Keep action versions consistent across workflows unless a workflow intentionally needs a different major version.
 
+## Managed Tool Version Propagation
+
+When `project-tooling-review` updates a tool managed by `uv tool` or `cargo install`, check whether GitHub Actions installs or invokes that tool. Update workflow pins in the same pass when the workflow depends on the updated version.
+
+Check for:
+
+- workflow `env` pins such as `UV_VERSION`, `JUST_VERSION`, `ZIZMOR_VERSION`, or other `<TOOL>_VERSION` values
+- setup action inputs such as `version: ${{ env.UV_VERSION }}` or literal version strings
+- cargo-install cache actions with `tool: name@version`
+- inline `cargo install --version`, `uv tool install name@version`, `pipx install name==version`, or equivalent install commands
+- comments next to pinned tool versions when they are used as human-readable version markers
+
+Keep the action pin and managed tool pin separate. For example, updating `zizmor` should update `ZIZMOR_VERSION` or `tool: zizmor@...`; it should not update `taiki-e/cache-cargo-install-action@...` unless that action itself is stale. Updating `uv` should update the setup action's requested `uv` version; it should not update `astral-sh/setup-uv@...` unless the setup action itself is stale.
+
+If the workflow reads the version from a single env var or bootstrap script constant, update that source of truth rather than duplicating literal versions throughout the workflow. Keep local bootstrap pins, workflow pins, and command docs synchronized.
+
 ## Drift Checks
 
 Compare workflows against:
@@ -27,6 +43,7 @@ Compare workflows against:
 - `justfile` recipe names and arguments
 - `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, and `docs/dev/**`
 - `Brewfile`, `pyproject.toml`, `uv.lock`, `Cargo.toml`, `rust-toolchain.toml`, and other toolchain files
+- `uv tool` and `cargo install` managed CLI inventories and updated local versions
 - branch protection or required check naming when available
 
 Flag workflows that run stale recipes, bypass canonical local checks, silently skip failures, or publish artifacts without matching release docs.
@@ -41,4 +58,3 @@ Use repository guidance first. Otherwise prefer:
 - A targeted dry run with `act` only when the repository already supports it and local secrets are not required.
 
 Do not trigger remote workflow runs, publish releases, upload artifacts, or mutate repository settings unless the user explicitly asks.
-

--- a/agents/.agents/skills/project-tooling-review/references/github-actions.md
+++ b/agents/.agents/skills/project-tooling-review/references/github-actions.md
@@ -1,0 +1,44 @@
+# GitHub Actions Review
+
+Use this reference for `.github/workflows/**`, reusable workflow calls, Actions-related docs, and CI command wiring.
+
+## Review Focus
+
+- Workflows should call canonical `just` recipes when the repository standardizes on `just`; avoid duplicating long local command strings in YAML.
+- Workflow names, job names, and required status checks should remain stable unless the change intentionally updates branch protection or release policy.
+- Triggers should match intent: `pull_request` for PR validation, `push` for protected branches or release branches, `workflow_dispatch` for manual runs, and scheduled runs only when maintenance value justifies noise.
+- Permissions should be least-privilege. Prefer top-level `permissions: contents: read` and elevate only specific jobs that need writes, packages, pages, OIDC, or checks.
+- Concurrency should cancel redundant PR runs when safe, but not cancel release/publish jobs that must complete.
+- Matrix strategy should cover declared supported versions and platforms without exploding cost accidentally.
+- Caches should key on lockfiles and toolchain files, not only broad branch names. Cache restore should not hide dependency drift.
+- Artifacts should have clear names, bounded retention, and no secrets or oversized generated clutter.
+
+## Version And Pinning Checks
+
+- Verify action versions against live releases when the user asks for currentness or when changing versions. Do not rely on model memory for latest action versions.
+- Prefer major-version pins such as `actions/checkout@v4` for routine maintenance unless the repository has a stricter supply-chain policy.
+- Prefer commit SHA pins for high-security/release/signing workflows when that policy exists, and document the update path.
+- Keep action versions consistent across workflows unless a workflow intentionally needs a different major version.
+
+## Drift Checks
+
+Compare workflows against:
+
+- `justfile` recipe names and arguments
+- `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, and `docs/dev/**`
+- `Brewfile`, `pyproject.toml`, `uv.lock`, `Cargo.toml`, `rust-toolchain.toml`, and other toolchain files
+- branch protection or required check naming when available
+
+Flag workflows that run stale recipes, bypass canonical local checks, silently skip failures, or publish artifacts without matching release docs.
+
+## Validators
+
+Use repository guidance first. Otherwise prefer:
+
+- `actionlint` or `just action-lint` when available.
+- YAML linting when actionlint is unavailable.
+- `gh workflow view` or `gh api` for live workflow metadata only when needed and available.
+- A targeted dry run with `act` only when the repository already supports it and local secrets are not required.
+
+Do not trigger remote workflow runs, publish releases, upload artifacts, or mutate repository settings unless the user explicitly asks.
+

--- a/agents/.agents/skills/project-tooling-review/references/justfile.md
+++ b/agents/.agents/skills/project-tooling-review/references/justfile.md
@@ -1,0 +1,44 @@
+# justfile Review
+
+Use this reference for `justfile` changes, command-surface docs, and recipes that define how maintainers run local workflows.
+
+## Review Focus
+
+- Prefer a small command vocabulary over many one-off recipes. Common tiers are `check`, `check-fast`, `fix`, `ci`, `test-*`, `lint-*`, `coverage`, `docs`, `bench-*`, `release-*`, and project-specific smoke checks.
+- Keep `just` as the command memory layer. Workflows and docs should call recipes instead of duplicating long `cargo`, `uv`, `taplo`, `actionlint`, `typos`, or notebook commands.
+- Recipe names should describe maintainer intent, not the implementation tool, unless the recipe is a direct tool wrapper such as `action-lint` or `toml-fmt-check`.
+- Separate fixers from checks. A recipe named `check` or `ci` should not mutate tracked files; a recipe named `fix` should make mutations explicit.
+- Separate fast local checks from full CI and slow/performance/release checks.
+- Preserve recipe composability. Prefer recipes that call other recipes over copy-pasted command sequences when the same workflow appears in multiple places.
+
+## Safety Checks
+
+- Destructive recipes require explicit arguments and should not hide behind friendly names.
+- Avoid broad deletes. If cleanup is necessary, scope it to known build/output directories and quote paths.
+- Recipes that rely on shell features should use a clear shell setting or script block according to local convention.
+- Commands should fail on the first real failure. Watch for `|| true`, ignored exit codes, pipelines without failure handling, and swallowed subprocess errors.
+- Recipes should not rely on the user's current directory when the repository root matters.
+- Secrets and tokens should not appear in command echo, logs, or generated files.
+
+## Drift Checks
+
+Compare `justfile` against:
+
+- `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, and `docs/dev/**`
+- `.github/workflows/**`
+- language-specific config such as `pyproject.toml`, `Cargo.toml`, `rust-toolchain.toml`, and lockfiles
+- scripts that are invoked by recipes
+
+Flag docs or workflows that mention deleted/renamed recipes, skip new required recipes, or describe different command arguments than the recipe actually accepts.
+
+## Validators
+
+Use repository guidance first. Otherwise prefer:
+
+- `just --list` or `just --summary` to confirm recipes parse and are discoverable.
+- `just --fmt --check` when the installed `just` supports it.
+- `just --dry-run <recipe>` for safe recipe expansion checks when arguments are known.
+- The narrow changed recipe's check command when it is safe and local.
+
+Do not run destructive, publishing, release, or update recipes unless the user explicitly asks.
+

--- a/agents/.agents/skills/project-tooling-review/references/justfile.md
+++ b/agents/.agents/skills/project-tooling-review/references/justfile.md
@@ -11,6 +11,19 @@ Use this reference for `justfile` changes, command-surface docs, and recipes tha
 - Separate fast local checks from full CI and slow/performance/release checks.
 - Preserve recipe composability. Prefer recipes that call other recipes over copy-pasted command sequences when the same workflow appears in multiple places.
 
+## Tool Install Recipes
+
+If `justfile` installs, upgrades, checks, or asserts versions for tools managed by `uv tool`, `cargo install`, Homebrew, or another manager, keep those recipes synchronized with the updated managed-tool versions.
+
+Check for:
+
+- recipe variables such as `<tool>_version` or `<tool>-version`
+- inline install specs such as `cargo install --version`, `uv tool install name@version`, `brew install`, `pipx install name==version`, or setup helper arguments
+- ensure/check recipes that compare `tool --version` output against a pinned value
+- recipes that call bootstrap scripts or workflows with version arguments
+
+When `project-tooling-review` updates a managed tool, update matching `justfile` pins in the same pass before validating workflows. The local command surface should install and assert the same version that GitHub Actions and bootstrap scripts use.
+
 ## Safety Checks
 
 - Destructive recipes require explicit arguments and should not hide behind friendly names.
@@ -27,6 +40,7 @@ Compare `justfile` against:
 - `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, and `docs/dev/**`
 - `.github/workflows/**`
 - language-specific config such as `pyproject.toml`, `Cargo.toml`, `rust-toolchain.toml`, and lockfiles
+- managed tool inventories from `uv tool list`, `cargo install --list`, and `cargo install-update -l`
 - scripts that are invoked by recipes
 
 Flag docs or workflows that mention deleted/renamed recipes, skip new required recipes, or describe different command arguments than the recipe actually accepts.
@@ -41,4 +55,3 @@ Use repository guidance first. Otherwise prefer:
 - The narrow changed recipe's check command when it is safe and local.
 
 Do not run destructive, publishing, release, or update recipes unless the user explicitly asks.
-

--- a/agents/.agents/skills/project-tooling-review/references/tool-versions.md
+++ b/agents/.agents/skills/project-tooling-review/references/tool-versions.md
@@ -5,7 +5,7 @@ Use this reference for tool-version drift across local installers, lockfiles, Gi
 ## Ground Rules
 
 - Do not claim a tool is latest from memory. Verify currentness through live authoritative sources or local package-manager metadata.
-- Do not install, upgrade, uninstall, or run update commands unless the user explicitly asks.
+- Do not install or uninstall unrelated tools unless the user explicitly asks. When the requested scope includes tool-version currentness, update drift, or "latest" tooling review, update stale tools through the repository's existing manager.
 - Keep "currentness" separate from "consistency." A repo can be internally consistent while not latest, and that is often acceptable.
 - Prefer the repository's existing tool manager. Do not introduce a new manager just to solve one pin.
 
@@ -13,10 +13,53 @@ Use this reference for tool-version drift across local installers, lockfiles, Gi
 
 - `Brewfile`, `.Brewfile`, install scripts, and stow/bootstrap docs.
 - `pyproject.toml`, `uv.lock`, `requirements*.txt`, `.python-version`, `tox.ini`, `noxfile.py`, and Python tool config.
+- `uv tool` managed CLI tools, their install specs, docs, and workflow invocations.
 - `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, `.cargo/**`, cargo install recipes, and Rust tool docs.
+- `cargo install` managed binaries, `cargo install-update` output, bootstrap pins, and workflow install specs.
 - `.github/workflows/**` action versions and setup steps.
 - `justfile` recipes that install, update, check, or invoke tools.
 - `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/dev/**`, and release docs that mention tool versions or commands.
+
+## Local Tool Inventory
+
+Before comparing a tool to repo pins or remote latest metadata, inspect the local tool that maintainers actually run:
+
+- Resolve the executable with `command -v <tool>` or the repository's documented absolute path.
+- Capture the installed version with `<tool> --version` or the tool's documented version command.
+- Identify the owning manager when possible: Homebrew, `uv tool`, `cargo install`, `rustup`, system package manager, or standalone installer.
+- Compare the installed version against docs, lockfiles, workflows, installer manifests, and update recipes.
+- If a tool was just installed or upgraded locally, treat that local version as a currentness signal to reconcile rather than ignoring it because the changed files did not mention the tool.
+
+For `uv` itself, always check `command -v uv` and `uv --version` first. If it is Homebrew-managed, also use Homebrew metadata such as `brew list --versions uv`, `brew info uv`, or Homebrew JSON metadata when available. Use `uv tool list` for tools installed by `uv`, not as the source of truth for the `uv` executable's own version.
+
+For tools managed by `uv tool`, run `uv tool list` before updating. When version updates are in scope, run `uv tool upgrade --all` or `uv tool upgrade <name>` for targeted review, then run `uv tool list` again and record before/after versions. If a `uv tool` command needs network or cache access, request approval rather than substituting a global Python install.
+
+For tools managed by `cargo install`, run `cargo install --list` and `cargo install-update -l` before updating. When version updates are in scope, run `cargo install-update --all` or `cargo install-update <package>` for targeted review, preserving repository-required flags such as `--locked` when applicable. Run `cargo install --list` or `<tool> --version` after updating and record before/after versions.
+
+## Version Source Of Truth
+
+For managed CLI tool updates, reconcile versions in this order:
+
+1. Owning manager state after update: installed version and manager metadata from `uv tool list`, `cargo install --list`, `<tool> --version`, Homebrew metadata, or the relevant manager.
+2. Local command source of truth: `justfile` variables or install specs, bootstrap constants in `bin/**`, and repository installer scripts.
+3. CI pins: `.github/workflows/**` environment variables, action inputs, inline install commands, and cache-install `tool: name@version` values.
+4. Documentation: `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/**`, and release notes that mention the tool version or update command.
+
+Avoid creating duplicate independent pins. If one tracked file can read or call the repository's source of truth, prefer that over repeating literal versions. Keep project dependency lockfiles separate from managed CLI pins unless the user explicitly asks for dependency updates.
+
+## Managed Tool Update Flow
+
+Use this flow for `uv tool` and `cargo install` managed CLIs:
+
+1. Inventory installed tools, versions, owning manager, and command paths.
+2. Compare against authoritative latest metadata from the manager, package index, or registry.
+3. Update stale tools with the owning manager when version updates are in scope.
+4. Capture the new installed versions and note tools that were already current.
+5. Search tracked files for each updated tool name and old version, including `justfile`, `.github/workflows/**`, `bin/**`, `README.md`, `AGENTS.md`, `docs/**`, `pyproject.toml`, and lockfiles.
+6. Update repository pins that install or assert the tool version: `*_VERSION` environment variables, `cargo install --version`, `uv tool install <tool>@<version>`, action inputs, cache-install `tool: name@version` values, bootstrap constants, and docs.
+7. If `justfile` installs, upgrades, checks, or asserts the updated tool, update the recipe version, recipe variable, or install spec in the same change. The command memory layer should install the same updated version the manager now reports.
+8. If a GitHub Actions workflow uses the updated tool, update the workflow's pinned tool version in the same change. Do not confuse the workflow action version or SHA with the managed tool version; update action pins only when the action itself is stale.
+9. Run focused validators for the touched tooling surface.
 
 ## Consistency Checks
 
@@ -28,13 +71,14 @@ Use this reference for tool-version drift across local installers, lockfiles, Gi
 
 ## Currentness Checks
 
-Use the source appropriate to the tool:
+Use the source appropriate to the tool for read-only currentness checks:
 
 - Homebrew tools: `brew info`, `brew outdated`, or Homebrew JSON metadata when available.
-- `uv`: official releases, package-manager metadata, or the installed `uv --version` plus the manager that installed it.
-- Python packages: `uv lock --upgrade-package <name>` preview workflows, `uv tree`, package index metadata, or repository-approved commands.
+- `uv`: installed `uv --version` plus the manager that installed it, then official releases or package-manager metadata for latest-version claims.
+- `uv tool` managed tools: `uv tool list` and package index metadata when a non-mutating latest check is required; use the managed update flow above when version updates are in scope.
+- Python packages: `uv lock --check`, `uv tree`, package index metadata, or repository-approved read-only commands. Do not mutate project dependency lockfiles during managed CLI update review unless the user explicitly asks for dependency updates.
 - Rust toolchain: `rustup show`, `rustup check`, `rust-toolchain.toml`, and official channel metadata.
-- Cargo-installed tools: `cargo install --list`, `cargo search <crate> --limit 1`, `cargo install-update -l` when installed, or crates.io metadata.
+- Cargo-installed tools: `cargo install --list`, `cargo install-update -l`, `cargo search <crate> --limit 1`, or crates.io metadata; use the managed update flow above when version updates are in scope.
 - GitHub Actions: action release pages, tags, GitHub API, or Dependabot/Renovate metadata if configured.
 
 If network access or package-manager metadata is unavailable, report the check as local-only and name what remains unverified.
@@ -52,9 +96,9 @@ If network access or package-manager metadata is unavailable, report the check a
 Use repository guidance first. Otherwise prefer read-only checks:
 
 - `brew bundle check` for Brewfile satisfaction when available.
-- `uv lock --check`, `uv tree`, or repository `uv` recipes for Python environments.
-- `cargo tree`, `cargo metadata`, `cargo install --list`, or repository cargo-tool recipes for Rust tooling.
+- `uv lock --check`, `uv tree`, `uv tool list`, or repository `uv` recipes for Python environments and `uv tool` managed CLIs.
+- `cargo tree`, `cargo metadata`, `cargo install --list`, `cargo install-update -l`, or repository cargo-tool recipes for Rust tooling.
 - `rustup show` and `rustup check` for Rust toolchain status.
 - `just --summary` plus relevant check recipes for command-surface consistency.
 
-Do not run update/install recipes, `brew upgrade`, `uv lock --upgrade`, `cargo update`, or `rustup update` unless the user explicitly asks.
+Do not run broad ecosystem updates such as `brew upgrade`, `uv lock --upgrade`, `cargo update`, or `rustup update` unless the user explicitly asks. `uv tool upgrade` and `cargo install-update` are in scope when reviewing managed CLI version drift.

--- a/agents/.agents/skills/project-tooling-review/references/tool-versions.md
+++ b/agents/.agents/skills/project-tooling-review/references/tool-versions.md
@@ -1,0 +1,60 @@
+# Tool Version Review
+
+Use this reference for tool-version drift across local installers, lockfiles, GitHub Actions, and docs.
+
+## Ground Rules
+
+- Do not claim a tool is latest from memory. Verify currentness through live authoritative sources or local package-manager metadata.
+- Do not install, upgrade, uninstall, or run update commands unless the user explicitly asks.
+- Keep "currentness" separate from "consistency." A repo can be internally consistent while not latest, and that is often acceptable.
+- Prefer the repository's existing tool manager. Do not introduce a new manager just to solve one pin.
+
+## Surfaces To Inspect
+
+- `Brewfile`, `.Brewfile`, install scripts, and stow/bootstrap docs.
+- `pyproject.toml`, `uv.lock`, `requirements*.txt`, `.python-version`, `tox.ini`, `noxfile.py`, and Python tool config.
+- `Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, `.cargo/**`, cargo install recipes, and Rust tool docs.
+- `.github/workflows/**` action versions and setup steps.
+- `justfile` recipes that install, update, check, or invoke tools.
+- `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/dev/**`, and release docs that mention tool versions or commands.
+
+## Consistency Checks
+
+- Local and CI tool versions should agree when reproducibility matters.
+- Docs should not tell maintainers to install a different version than workflows or lockfiles use.
+- Recipes should invoke tools through the intended manager (`uv run`, `cargo`, Homebrew path, project-local script) rather than relying on accidental PATH order.
+- Lockfiles should be updated when dependency declarations change.
+- Version pins should have an update path, especially for Actions, cargo-installed binaries, and tools not covered by a lockfile.
+
+## Currentness Checks
+
+Use the source appropriate to the tool:
+
+- Homebrew tools: `brew info`, `brew outdated`, or Homebrew JSON metadata when available.
+- `uv`: official releases, package-manager metadata, or the installed `uv --version` plus the manager that installed it.
+- Python packages: `uv lock --upgrade-package <name>` preview workflows, `uv tree`, package index metadata, or repository-approved commands.
+- Rust toolchain: `rustup show`, `rustup check`, `rust-toolchain.toml`, and official channel metadata.
+- Cargo-installed tools: `cargo install --list`, `cargo search <crate> --limit 1`, `cargo install-update -l` when installed, or crates.io metadata.
+- GitHub Actions: action release pages, tags, GitHub API, or Dependabot/Renovate metadata if configured.
+
+If network access or package-manager metadata is unavailable, report the check as local-only and name what remains unverified.
+
+## Pinning Guidance
+
+- Pin when reproducibility, CI stability, or supply-chain policy matters.
+- Allow floating major versions when routine maintenance and upstream security patches are preferred.
+- Avoid exact pins in docs if the true source of record is a lockfile or installer manifest.
+- Keep generated lockfiles machine-readable and avoid hand-editing them unless the repository explicitly permits it.
+- Treat version bumps as behavior changes when they alter formatter output, lints, generated docs, benchmark output, or CI behavior.
+
+## Validators
+
+Use repository guidance first. Otherwise prefer read-only checks:
+
+- `brew bundle check` for Brewfile satisfaction when available.
+- `uv lock --check`, `uv tree`, or repository `uv` recipes for Python environments.
+- `cargo tree`, `cargo metadata`, `cargo install --list`, or repository cargo-tool recipes for Rust tooling.
+- `rustup show` and `rustup check` for Rust toolchain status.
+- `just --summary` plus relevant check recipes for command-surface consistency.
+
+Do not run update/install recipes, `brew upgrade`, `uv lock --upgrade`, `cargo update`, or `rustup update` unless the user explicitly asks.

--- a/agents/.agents/skills/python-review-orchestrator/SKILL.md
+++ b/agents/.agents/skills/python-review-orchestrator/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: python-review-orchestrator
+description: "Coordinate a structured Python code-review-and-fix workflow by loading named Python skills in sequence, grouping them by notebook, boundary, scientific, support-tooling, validation, and synthesis concerns, applying fixes pass by pass, and choosing focused validators from changed files. Use when the user asks for a Python review suite, repo-wide Python review, whole-repo baseline audit, staged/changed Python review, notebook-and-script cleanup, or 'fix all' across multiple Python review skills. Also use when the user wants focused Python skills applied in order with fixes and validation before moving to the next skill. Do not use when there is no Python code, notebook, pytest, Python config, data fixture, or Python workflow impact; for single-purpose reviews that name only one focused Python skill; or for requests to commit, stage, push, tag, or otherwise mutate git state."
+---
+
+# python-review-orchestrator
+
+Coordinate focused Python review skills without copying their content. This skill is an execution plan: load each selected named skill file, apply it to the current scope, fix actionable issues, validate the touched surface, and only then continue to the next selected skill.
+
+## Ground Rules
+
+- Do not perform git state mutations. Do not stage, commit, push, tag, checkout, reset, or stash unless the user explicitly asks in the current turn.
+- Use read-only git commands to discover scope when needed: `git --no-pager status --short`, `git --no-pager diff --stat`, `git --no-pager diff --name-status`, and `git --no-pager diff`.
+- Respect repository-local agent instructions before editing. If the repository requires reading development docs before changes, read them first.
+- Prefer changed-file review by default. Use whole-repo baseline mode only when the user explicitly asks for "repo", "whole repo", "entire repo", "baseline audit", or equivalent.
+- When the user says "fix all", implement actionable findings as you go. Do not merely collect them for later unless the fix is blocked or unsafe.
+- Do not run blanket full-CI validators by default. Select focused validators from changed and touched files. Run full CI only when repository rules require it for the touched surface or when changes cross broad Python behavior.
+
+## Required Skill Loading
+
+This orchestrator must actually load the named skill files it selects. Do not summarize their names from memory.
+
+For each selected skill:
+
+1. Open and read that skill's `SKILL.md` completely.
+2. Follow any directly referenced, task-relevant reference files from that skill.
+3. Apply that skill to the current changed-file scope.
+4. Fix actionable issues before moving on.
+5. Run the focused validator for files touched by that skill's fixes.
+6. If validation fails, fix and rerun the same validator before loading the next selected skill.
+
+## Scope Routing
+
+Read [`references/check-routing.md`](references/check-routing.md) after identifying changed files. Use it to choose:
+
+- which skill groups apply
+- which focused validators to run after each group
+- when final validation should escalate from focused commands to the repository's full-CI validator
+
+If changed files do not match the table cleanly, choose the smallest validator that covers the risk and state the assumption in the final summary.
+
+## Skill Groups
+
+Run groups in this order when they apply. Within each group, load and apply each selected skill in the order listed.
+
+### 1. Notebook/Reproducibility Pass
+
+Use when `.ipynb` files, notebook execution helpers, notebook dependency groups, rendered outputs, or notebook CI paths changed.
+
+- `jupyter-notebook-review`
+
+This skill is the notebook front door. After it runs, select additional Python skills below when notebook code contains substantial reusable, scientific, CLI, support-tooling, or test behavior.
+
+### 2. Boundary/Application Pass
+
+Use for CLI/application behavior, parsers, file I/O, stdout/stderr contracts, privacy-sensitive output, date/time handling, config loading, raw data boundaries, typed models, or invalid-state prevention.
+
+- `python-cli-review`
+- `python-parse-dont-validate` when raw dicts, config, environment variables, subprocess output, JSON/CSV/TOML/YAML, paths, optionals, or primitive values carry invariants
+
+### 3. Scientific/Data Pass
+
+Use for numerical, geometric, statistical, dataframe, fixture-generation, scientific reproducibility, Rust-interoperability, NumPy/SciPy, or Hypothesis-over-numerical-input changes.
+
+- `python-scientific-review`
+
+### 4. Support Tooling Pass
+
+Use for changelog generators, release helpers, benchmark runners, CI scripts, fixture utilities, diagnostic CLIs, subprocess wrappers around `cargo`/`git`/`gh`, generated artifact preparation, or Rust-crate development tooling.
+
+- `python-support-scripts`
+
+### 5. Validation/Test Pass
+
+Use for tests, fixtures, coverage gaps, pytest ergonomics, CLI output capture, malformed-input coverage, notebook checker tests, and error-path behavior.
+
+- `python-test-quality`
+
+### 6. Final Synthesis Pass
+
+Use this pass after all selected skills and validators have run.
+
+This pass reconciles findings from earlier groups, removes duplicates, checks severity, and decides whether remaining issues are blockers, follow-ups, or acceptable residual risk. Do not load an extra broad Python skill unless one of the focused skills above actually applies to the remaining issue.
+
+## Per-Group Fix Loop
+
+For each selected group:
+
+1. Announce the group and selected skills briefly.
+2. Load the next selected skill file.
+3. Inspect only relevant changed files and nearby boundary owners unless whole-repo mode is active.
+4. Implement minimal fixes for real findings.
+5. Run the focused validator from `references/check-routing.md`.
+6. Fix validator failures before continuing.
+7. Record what changed per file for the final summary.
+
+If a validator is expensive, blocked, or needs approval, use the repository's focused cheaper validator while iterating, then run the strongest relevant validator available before final handoff.
+
+## Final Summary
+
+End with a concise summary that helps the maintainer review unstaged changes by file. Include:
+
+- each file changed and why
+- which skill groups ran
+- validators run and their results
+- issues fixed while moving between skills
+- anything intentionally deferred or not run
+- confirmation that no git state mutations were performed, if true
+
+Do not bury important risk in a generic "all good" closing. If unresolved issues remain, lead with them.

--- a/agents/.agents/skills/python-review-orchestrator/SKILL.md
+++ b/agents/.agents/skills/python-review-orchestrator/SKILL.md
@@ -17,6 +17,19 @@ Coordinate focused Python review skills without copying their content. This skil
 - When the user says "fix all", implement actionable findings as you go. Do not merely collect them for later unless the fix is blocked or unsafe.
 - Do not run blanket full-CI validators by default. Select focused validators from changed and touched files. Run full CI only when repository rules require it for the touched surface or when changes cross broad Python behavior.
 
+## Review Trace
+
+When invoked by `repo-review`, begin with a handoff receipt that names:
+
+- the parent branch scope and Python-owned file list or file count handed off
+- selected Python skill groups and why they apply
+- skipped Python skill groups when a maintainer might reasonably expect them
+- routing reference files that will be loaded
+
+For every selected group, announce the group and focused skills before loading the first skill. After loading each focused skill or reference file, keep its name in the running trace for the final summary. This trace is required evidence that the orchestrator ran the selected Python skills rather than only summarizing their names.
+
+When invoked by `repo-review`, provide table-ready evidence for the parent `Review Evidence` table: selected groups, focused skill files loaded, reference files loaded, validators run, and any skipped groups that might otherwise look missing.
+
 ## Required Skill Loading
 
 This orchestrator must actually load the named skill files it selects. Do not summarize their names from memory.
@@ -103,6 +116,8 @@ End with a concise summary that helps the maintainer review unstaged changes by 
 
 - each file changed and why
 - which skill groups ran
+- focused skill files and reference files actually loaded
+- table-ready evidence for `repo-review` when invoked by the meta-orchestrator
 - validators run and their results
 - issues fixed while moving between skills
 - anything intentionally deferred or not run

--- a/agents/.agents/skills/python-review-orchestrator/SKILL.md
+++ b/agents/.agents/skills/python-review-orchestrator/SKILL.md
@@ -13,6 +13,7 @@ Coordinate focused Python review skills without copying their content. This skil
 - Use read-only git commands to discover scope when needed: `git --no-pager status --short`, `git --no-pager diff --stat`, `git --no-pager diff --name-status`, and `git --no-pager diff`.
 - Respect repository-local agent instructions before editing. If the repository requires reading development docs before changes, read them first.
 - Prefer changed-file review by default. Use whole-repo baseline mode only when the user explicitly asks for "repo", "whole repo", "entire repo", "baseline audit", or equivalent.
+- When invoked by `repo-review` with a branch-scope file list or diff, honor that provided scope instead of rediscovering a narrower staged or worktree-only scope.
 - When the user says "fix all", implement actionable findings as you go. Do not merely collect them for later unless the fix is blocked or unsafe.
 - Do not run blanket full-CI validators by default. Select focused validators from changed and touched files. Run full CI only when repository rules require it for the touched surface or when changes cross broad Python behavior.
 

--- a/agents/.agents/skills/python-review-orchestrator/agents/openai.yaml
+++ b/agents/.agents/skills/python-review-orchestrator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Python Review Orchestrator"
+  short_description: "Coordinate focused Python review passes"
+  default_prompt: "Use $python-review-orchestrator to review and fix changed Python code pass by pass, then run focused validators."

--- a/agents/.agents/skills/python-review-orchestrator/references/check-routing.md
+++ b/agents/.agents/skills/python-review-orchestrator/references/check-routing.md
@@ -1,0 +1,101 @@
+# Changed-File Routing
+
+Use this matrix after inspecting changed files. Prefer the smallest validator that covers the files touched by the current group. If a repository has stricter local guidance, follow the repository guidance.
+
+## Scope Detection
+
+Use read-only commands:
+
+```bash
+git --no-pager status --short
+git --no-pager diff --stat
+git --no-pager diff --name-status
+git --no-pager diff
+```
+
+For staged-only requests, use the same commands with `--cached`.
+
+Classify files by path and effect:
+
+- `*.py`, `src/**/*.py`, `scripts/**/*.py`, `tools/**/*.py`: Python implementation, CLI, support tooling, or scientific code.
+- `tests/**/*.py`, `test_*.py`, `*_test.py`, `conftest.py`: pytest surface, fixtures, and test helpers.
+- `notebooks/**/*.ipynb`, `*.ipynb`: notebook source, outputs, and execution hygiene.
+- `pyproject.toml`, `uv.lock`, `requirements*.txt`, `setup.cfg`, `tox.ini`, `noxfile.py`, `mypy.ini`, `.python-version`, `.ruff.toml`, `ruff.toml`, `ty.toml`, `pyrightconfig.json`: Python packaging, dependency, lint, format, and type-check surface.
+- `data/**`, `fixtures/**`, `tests/fixtures/**`, `examples/**`: fixtures, examples, generated reference data, and interoperability artifacts.
+- `justfile`, `.github/workflows/**`, config files: tooling or CI surface.
+- `README.md`, `docs/**`, notebook markdown, and CLI examples: documentation surface.
+
+## Skill Group Selection
+
+| Changed surface | Select these groups |
+|---|---|
+| `.ipynb` notebooks, notebook execution helpers, notebook dependency groups, committed outputs | Notebook/Reproducibility, then any domain group implied by code cells, Validation/Test |
+| CLI entry points, argparse/Click/Typer, stdout/stderr, local file import/export, date/time parsing, privacy-sensitive output | Boundary/Application, Validation/Test |
+| JSON/CSV/TOML/YAML/env/subprocess parsing, dataclasses/attrs/Pydantic models, raw dicts or primitives with invariants | Boundary/Application with `python-parse-dont-validate`, Validation/Test |
+| Numerical, geometric, statistical, scientific, dataframe, NumPy/SciPy, Hypothesis-over-numeric, or Rust-interoperability code | Scientific/Data, Boundary/Application when raw inputs carry invariants, Validation/Test |
+| Changelog/release/CI/benchmark/fixture/diagnostic scripts, generated artifact preparation, subprocess wrappers around `cargo`/`git`/`gh` | Support Tooling, Boundary/Application when CLI behavior matters, Validation/Test |
+| Tests/fixtures only | Validation/Test, plus domain group only if tests encode scientific, CLI, parser, or support-tool behavior that can hide a production bug |
+| Python packaging, lint, format, type-check, or dependency config | Validation/Test, plus affected domain group if config changes behavior |
+| Docs-only Python examples or notebook prose | Relevant domain group only if examples are executable or user-facing behavior changed; otherwise docs validators |
+| Workflow/config only | No Python skill group unless Python behavior, validators, notebooks, or generated artifacts changed; run config validators |
+
+## Focused Validators
+
+Use the repository's documented commands when available. If no local guidance exists, use the generic fallbacks in this table.
+
+| Files touched | Validator |
+|---|---|
+| Python library/application source | documented focused Python check; fallback `python -m compileall <changed paths>` plus targeted `pytest` when tests exist |
+| CLI entry points or user-facing command output | documented CLI tests; fallback targeted `pytest`, plus `python -m <module> --help` or the local command's `--help` when discoverable |
+| Parser/config/model changes | targeted parser/model tests; fallback targeted `pytest` plus the repository type checker if configured |
+| Scientific/numerical/dataframe code | targeted scientific tests, property tests, or fixture checks; run benchmark/allocation checks only when making performance claims |
+| Support scripts and dev tooling | targeted pytest/golden tests; run `--help` smoke checks for changed CLIs when safe |
+| Tests only | `pytest <changed test files>` or the repository's narrow test recipe |
+| Notebooks | repository notebook lint/execute recipe; fallback notebook JSON parse and lightweight lint, execute only when dependencies and runtime are reasonable |
+| Python package/dependency config | repository lock/check recipe; fallback `python -m compileall` and configured lint/type/test commands when available |
+| Type annotations or invariant-carrying models | configured type checker (`mypy`, `pyright`, `basedpyright`, `ty`, or local recipe) plus targeted tests |
+| Markdown/docs/examples | docs, markdown, link, or example validators from the repository |
+| GitHub workflows/YAML/config | documented config validators, `actionlint`, or YAML checks |
+
+When a selected validator fails:
+
+1. Treat the failure as part of the current group.
+2. Fix the underlying issue.
+3. Rerun the same validator.
+4. Continue to the next skill only after the validator passes or the blocker is explicitly documented.
+
+## Escalation To Full CI
+
+Run the repository's full-CI validator when any of these are true:
+
+- repository instructions explicitly require it for the touched files
+- changes span multiple Python layers and no smaller validator covers the combined risk
+- public CLI behavior and parser/model invariants changed together
+- scientific/reproducibility behavior changed in a way that could affect broad results
+- notebook execution, support scripts, and package config changed together
+- final synthesis finds cross-cutting risk not covered by focused validators
+
+Do not run full CI merely because the workflow is ending. Use focused validators for docs-only, config-only, tests-only, examples-only, fixture-only, notebook-only, or support-script-only changes when repository guidance allows them.
+
+## Review Summary Template
+
+Use this shape at handoff:
+
+```text
+Changed files:
+- path: why it changed and which issue/skill finding it addressed
+
+Review passes:
+- Notebook/Reproducibility: skills run and notable outcomes
+- Boundary/Application: skills run and notable outcomes
+- Scientific/Data: skills run and notable outcomes
+- Support Tooling: skills run and notable outcomes
+- Validation/Test: skills run and notable outcomes
+- Final Synthesis: remaining risk or none
+
+Validation:
+- command: pass/fail/blocked, with concise context
+
+Git:
+- No git state mutations performed.
+```

--- a/agents/.agents/skills/repo-review/SKILL.md
+++ b/agents/.agents/skills/repo-review/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: repo-review
+description: "Coordinate a repo-level review-and-fix workflow by routing changed files to rust-review-orchestrator, python-review-orchestrator, and project-tooling-review as needed, then synthesizing cross-surface validation. Use when the user asks for staged, changed, PR, branch, repo-wide, or mixed Rust/Python/tooling review; repository review suites; or fix-all work across code and tooling. Do not use for single-surface requests that clearly name only Rust, Python, notebooks, Justfile, GitHub Actions, or tool-version review; use the focused orchestrator directly. Do not use for commit, stage, push, tag, checkout, reset, stash, or other git-state mutations."
+---
+
+# repo-review
+
+Route mixed repository review work to the focused orchestrators. This skill decides which review surfaces apply, loads the selected orchestrator skills, lets each one run its own fix loop, and then reconciles cross-surface validation.
+
+## Ground Rules
+
+- Do not perform git state mutations. Do not stage, commit, push, tag, checkout, reset, or stash unless the user explicitly asks in the current turn.
+- Prefer changed-file review by default. Use whole-repo baseline mode only when the user explicitly asks for "repo", "whole repo", "entire repo", "baseline audit", or equivalent.
+- When the user says "staged", inspect staged files with read-only git commands such as `git --no-pager diff --cached --name-status` and `git --no-pager diff --cached`.
+- If the request clearly targets one surface, use the focused orchestrator directly instead of this meta-skill.
+- When the user asks to fix issues, implement actionable findings as each selected orchestrator discovers them. Do not merely collect findings unless the fix is blocked or unsafe.
+- Keep this skill thin. Do not duplicate the detailed review rules from Rust, Python, or tooling skills; load those skills and follow them.
+
+## Required Skill Loading
+
+This meta-orchestrator must actually load every selected orchestrator's `SKILL.md` completely before applying it.
+
+After identifying scope:
+
+1. Read [`references/check-routing.md`](references/check-routing.md).
+2. Select the smallest set of orchestrators that covers the changed surfaces:
+   - `project-tooling-review`
+   - `rust-review-orchestrator`
+   - `python-review-orchestrator`
+3. For each selected orchestrator, open and read its `SKILL.md` completely.
+4. Follow that orchestrator's directly referenced files when they apply.
+5. Let the orchestrator run its own pass order, fix loop, and focused validation before moving to the next selected orchestrator.
+6. Record validators, changes, unresolved risks, and any cross-surface handoffs for the final summary.
+
+## Review Order
+
+Use this order unless the changed files make a different order clearly safer:
+
+1. Run `project-tooling-review` first when tool versions, `justfile`, workflows, or command docs changed enough to affect which validators should run.
+2. Run `rust-review-orchestrator` when Rust source, tests, examples, benches, Cargo metadata, Rust docs, or Rust-facing workflows changed.
+3. Run `python-review-orchestrator` when Python source, notebooks, pytest fixtures, Python config, lockfiles, or Python-facing workflows changed.
+4. Revisit tooling only when language fixes require recipe, workflow, lockfile, or command-doc updates.
+5. Synthesize final validation across all surfaces, preferring the strongest focused validator already justified by the touched files.
+
+## Cross-Surface Handling
+
+Treat build and validation files as shared ownership:
+
+- `Cargo.toml`, `Cargo.lock`, `pyproject.toml`, `uv.lock`, and toolchain files can require both language and tooling review.
+- `justfile` and `.github/workflows/**` belong to project tooling, but route to Rust or Python too when they change the language checks that run.
+- `README.md`, `AGENTS.md`, `CONTRIBUTING.md`, and `docs/**` belong to project tooling when they describe commands, CI, tool versions, or maintainer workflow. Route to language orchestrators when they document public API, examples, notebooks, or behavior.
+- Generated files, fixtures, benchmarks, and support scripts should be reviewed by the language orchestrator that owns their behavior plus project tooling when command wiring changed.
+
+## Final Summary
+
+End with a concise summary that helps the maintainer review unstaged changes by surface. Include:
+
+- orchestrators selected and why
+- files changed and what was fixed
+- validators run and their results
+- cross-surface risks resolved or deferred
+- anything intentionally not run
+- confirmation that no git state mutations were performed, if true
+
+Lead with unresolved blockers if any remain.

--- a/agents/.agents/skills/repo-review/SKILL.md
+++ b/agents/.agents/skills/repo-review/SKILL.md
@@ -16,6 +16,24 @@ Route mixed repository review work to the focused orchestrators. This skill esta
 - When the user asks to fix issues, implement actionable findings as each selected orchestrator discovers them. Do not merely collect findings unless the fix is blocked or unsafe.
 - Keep this skill thin. Do not duplicate the detailed review rules from Rust, Python, or tooling skills; load those skills and follow them.
 
+## Review Trace
+
+Make orchestration visible while working. Before running focused orchestrators, emit a compact dispatch note with:
+
+- scope: branch, base, whether staged/unstaged/untracked work is included, and either the file count or file list when small
+- selected orchestrators, each with one reason tied to changed files
+- skipped orchestrators, each with one reason
+- planned run order
+
+Before each selected orchestrator starts, emit a handoff note naming the orchestrator and the branch-scope files or diff slice being handed to it. After each orchestrator finishes, record the focused skill groups, skill files, reference files, fixes, and validators it actually used. Treat this trace as the user's audit trail that the child skill was really run, not as optional narration.
+
+The final summary must include a Markdown table headed `Review Evidence` with these columns:
+
+| Orchestrator | Status | Why selected or skipped | Scope handed off | Skills/references actually loaded | Validators |
+| --- | --- | --- | --- | --- | --- |
+
+Include one row for each of `project-tooling-review`, `rust-review-orchestrator`, and `python-review-orchestrator`. Use `selected`, `skipped`, or `blocked` in the Status column. For selected orchestrators, do not leave the skills/references cell blank; name the loaded files, or write `none loaded` only with a reason.
+
 ## Required Skill Loading
 
 This meta-orchestrator must actually load every selected orchestrator's `SKILL.md` completely before applying it.
@@ -27,11 +45,12 @@ After establishing branch scope:
    - `project-tooling-review`
    - `rust-review-orchestrator`
    - `python-review-orchestrator`
-3. For each selected orchestrator, open and read its `SKILL.md` completely.
-4. Follow that orchestrator's directly referenced files when they apply.
-5. Give the orchestrator the established branch file list and diff as its scope. This branch-scope handoff overrides a focused orchestrator's changed-file default for the current meta-review.
-6. Let the orchestrator run its own pass order, fix loop, and focused validation before moving to the next selected orchestrator.
-7. Record validators, changes, unresolved risks, and any cross-surface handoffs for the final summary.
+3. Emit the review dispatch note from [Review Trace](#review-trace), including selected and skipped orchestrators.
+4. For each selected orchestrator, open and read its `SKILL.md` completely.
+5. Follow that orchestrator's directly referenced files when they apply.
+6. Give the orchestrator the established branch file list and diff as its scope. This branch-scope handoff overrides a focused orchestrator's changed-file default for the current meta-review.
+7. Let the orchestrator run its own pass order, fix loop, and focused validation before moving to the next selected orchestrator.
+8. Record validators, changes, unresolved risks, and any cross-surface handoffs for the final summary.
 
 ## Review Order
 
@@ -56,7 +75,9 @@ Treat build and validation files as shared ownership:
 
 End with a concise summary that helps the maintainer review unstaged changes by surface. Include:
 
-- orchestrators selected and why
+- the `Review Evidence` table described above
+- orchestrators selected and skipped, with reasons
+- focused skill groups, skill files, and reference files actually loaded by each selected orchestrator
 - files changed and what was fixed
 - validators run and their results
 - cross-surface risks resolved or deferred

--- a/agents/.agents/skills/repo-review/SKILL.md
+++ b/agents/.agents/skills/repo-review/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: repo-review
-description: "Coordinate a repo-level review-and-fix workflow by routing changed files to rust-review-orchestrator, python-review-orchestrator, and project-tooling-review as needed, then synthesizing cross-surface validation. Use when the user asks for staged, changed, PR, branch, repo-wide, or mixed Rust/Python/tooling review; repository review suites; or fix-all work across code and tooling. Do not use for single-surface requests that clearly name only Rust, Python, notebooks, Justfile, GitHub Actions, or tool-version review; use the focused orchestrator directly. Do not use for commit, stage, push, tag, checkout, reset, stash, or other git-state mutations."
+description: "Coordinate a branch-scoped repo review-and-fix workflow by routing current-branch changes to rust-review-orchestrator, python-review-orchestrator, and project-tooling-review as needed, then synthesizing cross-surface validation. Use when the user asks for branch, PR, repo-wide, staged, changed, or mixed Rust/Python/tooling review; repository review suites; or fix-all work across code and tooling. Do not use for single-surface requests that clearly name only Rust, Python, notebooks, Justfile, GitHub Actions, or tool-version review; use the focused orchestrator directly. Do not use for commit, stage, push, tag, checkout, reset, stash, or other git-state mutations."
 ---
 
 # repo-review
 
-Route mixed repository review work to the focused orchestrators. This skill decides which review surfaces apply, loads the selected orchestrator skills, lets each one run its own fix loop, and then reconciles cross-surface validation.
+Route mixed repository review work to the focused orchestrators. This skill establishes the current branch as the review scope, decides which review surfaces apply, loads the selected orchestrator skills, lets each one run its own fix loop, and then reconciles cross-surface validation.
 
 ## Ground Rules
 
 - Do not perform git state mutations. Do not stage, commit, push, tag, checkout, reset, or stash unless the user explicitly asks in the current turn.
-- Prefer changed-file review by default. Use whole-repo baseline mode only when the user explicitly asks for "repo", "whole repo", "entire repo", "baseline audit", or equivalent.
-- When the user says "staged", inspect staged files with read-only git commands such as `git --no-pager diff --cached --name-status` and `git --no-pager diff --cached`.
+- Prefer branch review by default: compare the current branch to its PR/default-branch base, and include staged, unstaged, and untracked work on top of that branch.
+- Use staged-only, changed-file-only, or whole-repo baseline scope only when the user explicitly asks for that narrower or broader scope.
 - If the request clearly targets one surface, use the focused orchestrator directly instead of this meta-skill.
 - When the user asks to fix issues, implement actionable findings as each selected orchestrator discovers them. Do not merely collect findings unless the fix is blocked or unsafe.
 - Keep this skill thin. Do not duplicate the detailed review rules from Rust, Python, or tooling skills; load those skills and follow them.
@@ -20,7 +20,7 @@ Route mixed repository review work to the focused orchestrators. This skill deci
 
 This meta-orchestrator must actually load every selected orchestrator's `SKILL.md` completely before applying it.
 
-After identifying scope:
+After establishing branch scope:
 
 1. Read [`references/check-routing.md`](references/check-routing.md).
 2. Select the smallest set of orchestrators that covers the changed surfaces:
@@ -29,8 +29,9 @@ After identifying scope:
    - `python-review-orchestrator`
 3. For each selected orchestrator, open and read its `SKILL.md` completely.
 4. Follow that orchestrator's directly referenced files when they apply.
-5. Let the orchestrator run its own pass order, fix loop, and focused validation before moving to the next selected orchestrator.
-6. Record validators, changes, unresolved risks, and any cross-surface handoffs for the final summary.
+5. Give the orchestrator the established branch file list and diff as its scope. This branch-scope handoff overrides a focused orchestrator's changed-file default for the current meta-review.
+6. Let the orchestrator run its own pass order, fix loop, and focused validation before moving to the next selected orchestrator.
+7. Record validators, changes, unresolved risks, and any cross-surface handoffs for the final summary.
 
 ## Review Order
 

--- a/agents/.agents/skills/repo-review/agents/openai.yaml
+++ b/agents/.agents/skills/repo-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Repo Review"
+  short_description: "Route repo-wide review passes"
+  default_prompt: "Use $repo-review to review and fix changed Rust, Python, and tooling surfaces with the focused orchestrators."

--- a/agents/.agents/skills/repo-review/references/check-routing.md
+++ b/agents/.agents/skills/repo-review/references/check-routing.md
@@ -4,13 +4,20 @@ Use this reference after reading the requested scope and before selecting focuse
 
 ## Scope Discovery
 
-Choose read-only discovery commands that match the request:
+Default to branch scope. The normal workflow is to make a branch, review the whole branch, and include any staged, unstaged, or untracked work still sitting on top of it.
 
-- Staged review: `git --no-pager diff --cached --name-status` and `git --no-pager diff --cached`.
-- Changed worktree review: `git --no-pager status --short`, `git --no-pager diff --name-status`, and `git --no-pager diff`.
-- Branch or PR-style review: inspect the branch diff against the appropriate base without mutating git state.
+Use read-only discovery commands:
 
-If scope is ambiguous, prefer the current changed files over a whole-repo baseline.
+- Identify the branch: `git --no-pager branch --show-current`.
+- Use an explicit user-provided or PR-provided base when available.
+- Otherwise infer the default-branch base from `origin/HEAD`, `origin/main`, `origin/master`, `main`, or `master`, in that order when present.
+- Do not use the branch's same-name tracking upstream as the review base; that narrows a pushed feature branch to only unpushed local changes.
+- Find the merge base: `git --no-pager merge-base HEAD <base>`.
+- Inspect committed branch changes: `git --no-pager diff --name-status <merge-base>...HEAD` and `git --no-pager diff <merge-base>...HEAD`.
+- Inspect the full local branch state, including staged and unstaged work: `git --no-pager diff --name-status <merge-base>` and `git --no-pager diff <merge-base>`.
+- Include untracked files with `git --no-pager status --short` and `git ls-files --others --exclude-standard`.
+
+Use staged-only, changed-worktree-only, or whole-repo baseline scope only when the user explicitly asks for that scope. If the branch base cannot be inferred, report the ambiguity and fall back to the current changed files only after making that limitation visible.
 
 ## Surface Matrix
 
@@ -56,6 +63,8 @@ Use the smallest order that preserves validation integrity:
 3. Python next when Python-owned behavior, notebooks, or Python config changed.
 4. Project tooling again only when the language passes changed commands, workflow files, lockfiles, or docs.
 5. Final synthesis after all selected validators pass or known blockers are documented.
+
+Pass the same branch-scope file list and diff to every selected orchestrator. Do not let a focused orchestrator silently re-scope the review to only staged or unstaged changes unless the user requested that narrower scope.
 
 ## Validation Choice
 

--- a/agents/.agents/skills/repo-review/references/check-routing.md
+++ b/agents/.agents/skills/repo-review/references/check-routing.md
@@ -1,0 +1,70 @@
+# Check Routing
+
+Use this reference after reading the requested scope and before selecting focused orchestrators.
+
+## Scope Discovery
+
+Choose read-only discovery commands that match the request:
+
+- Staged review: `git --no-pager diff --cached --name-status` and `git --no-pager diff --cached`.
+- Changed worktree review: `git --no-pager status --short`, `git --no-pager diff --name-status`, and `git --no-pager diff`.
+- Branch or PR-style review: inspect the branch diff against the appropriate base without mutating git state.
+
+If scope is ambiguous, prefer the current changed files over a whole-repo baseline.
+
+## Surface Matrix
+
+Select `rust-review-orchestrator` for:
+
+- `src/**/*.rs`, `tests/**/*.rs`, `benches/**/*.rs`, `examples/**/*.rs`
+- Rust doctests, examples, public API docs, `README` Rust examples, or crate docs
+- `Cargo.toml`, `Cargo.lock`, `.cargo/**`, `rust-toolchain*`, `clippy.toml`, `rustfmt.toml`
+- workflows or recipes that change Rust validation, feature flags, benchmarks, releases, or coverage
+
+Select `python-review-orchestrator` for:
+
+- `*.py`, `scripts/**/*.py`, `tests/**/*.py`, Python packages, Python fixtures, and generated Python utilities
+- `.ipynb`, notebook runners, notebook dependency groups, and rendered notebook workflows
+- `pyproject.toml`, `uv.lock`, requirement files, pytest/ruff/mypy/pyright/coverage configuration
+- workflows or recipes that change Python validation, release helpers, notebooks, or coverage
+
+Select `project-tooling-review` for:
+
+- `justfile`, `Makefile`, shell command wrappers, and local validator tiers
+- `.github/workflows/**`, action versions, CI permissions, caches, matrices, and status-check wiring
+- `Brewfile`, tool installer docs, `uv tool`, `cargo install`, `rustup`, language toolchain pins, and update workflows
+- `AGENTS.md`, `README.md`, `CONTRIBUTING.md`, `docs/**`, or changelog text that describes command surfaces, CI, tools, or maintainer workflow
+- semgrep, actionlint, zizmor, markdown, YAML, TOML, and release configuration
+
+## Shared Files
+
+Route shared files to all affected owners:
+
+- `Cargo.toml` with dependency, feature, lint, or MSRV changes: Rust plus project tooling.
+- `pyproject.toml` with dependency groups, entry points, lint config, or project scripts: Python plus project tooling.
+- `uv.lock` or `Cargo.lock`: language review for dependency impact and tooling review for version/update discipline.
+- `justfile`: project tooling first; add Rust or Python when recipe semantics change which language checks run.
+- `.github/workflows/**`: project tooling first; add Rust or Python when matrices, toolchains, or validation coverage change.
+- Docs with commands and examples: project tooling for command truth, language orchestrators for API or behavior truth.
+
+## Ordering
+
+Use the smallest order that preserves validation integrity:
+
+1. Project tooling first when tool versions, recipes, workflows, or command docs may affect validators.
+2. Rust next when Rust-owned behavior or crate metadata changed.
+3. Python next when Python-owned behavior, notebooks, or Python config changed.
+4. Project tooling again only when the language passes changed commands, workflow files, lockfiles, or docs.
+5. Final synthesis after all selected validators pass or known blockers are documented.
+
+## Validation Choice
+
+Let each selected orchestrator choose focused validators from its own routing guidance. At the meta level, check whether the combined change needs stronger validation:
+
+- If only one surface changed, keep that surface's focused validator.
+- If language code and command wiring changed together, run the focused language validator and the focused tooling validator.
+- If workflows changed, prefer local structural validation such as YAML parsing, `actionlint`, `zizmor`, or repository recipes when available.
+- If lockfiles, toolchain pins, or latest-version claims changed, verify with live authoritative sources or local package-manager metadata before declaring them current.
+- Escalate to full CI only when cross-surface changes make focused validators insufficient or repository instructions require it.
+
+If a validator needs network access, installation, or approval, run the strongest local read-only substitute and report the gap.

--- a/agents/.agents/skills/rust-invariant-performance/SKILL.md
+++ b/agents/.agents/skills/rust-invariant-performance/SKILL.md
@@ -266,6 +266,44 @@ Use these when they fit the codebase:
 - make cache invalidation explicit before adding caches
 - add or update benchmarks before claiming a win
 
+## Command Taxonomy
+
+When a repo provides standardized benchmark recipes, distinguish routine
+correctness validation, performance evidence, release evidence, and docs
+promotion. Do not recommend expensive release-comparison commands as a default
+pre-commit step.
+
+Prefer this order:
+
+- Run the repo's normal correctness gate before committing or handing off work.
+  In many Rust crates this is `just ci`, but defer to the repo's own
+  development docs.
+- For performance-sensitive code, run the smallest representative benchmark or
+  smoke proxy before and after the change.
+- For PR-ready performance work, run the repo's local regression guard when one
+  exists.
+- For release prep, run the curated release-signal suite and release-comparison
+  report commands.
+- For already-published releases, compare stored release benchmark artifacts
+  instead of rerunning old code locally when the repo supports that workflow.
+
+Common command roles:
+
+- Correctness gate: compile, lint, test, doc, example, and benchmark-harness
+  validation. This should be the routine pre-commit check.
+- Focused benchmark: targeted Criterion or domain-specific benchmark for the
+  hot path under review.
+- Smoke proxy: broad but relatively cheap wall-clock or allocation proxy used
+  before pushing performance-sensitive changes.
+- Regression guard: local branch-vs-baseline comparison used for PR-ready
+  performance evidence.
+- Release-signal suite: curated benchmark set for release-to-release evidence,
+  usually slower and not a routine commit gate.
+- Release artifact comparison: compares benchmark data already attached to
+  published releases.
+- Release docs promotion: updates curated performance documentation and archives
+  the previous report; this is a release-maintenance task, not an audit default.
+
 ## Output Format
 
 ### Scope

--- a/agents/.agents/skills/rust-invariant-performance/SKILL.md
+++ b/agents/.agents/skills/rust-invariant-performance/SKILL.md
@@ -273,6 +273,12 @@ correctness validation, performance evidence, release evidence, and docs
 promotion. Do not recommend expensive release-comparison commands as a default
 pre-commit step.
 
+When a repository provides `benches/README.md`, read it before running or
+recommending benchmark commands. Use its final or PR-ready checks for
+benchmark-affecting or performance-sensitive changes, but do not promote
+expensive benchmark suites into routine correctness gates unless the repository
+explicitly says to.
+
 Prefer this order:
 
 - Run the repo's normal correctness gate before committing or handing off work.

--- a/agents/.agents/skills/rust-invariant-performance/references/delaunay.md
+++ b/agents/.agents/skills/rust-invariant-performance/references/delaunay.md
@@ -69,6 +69,30 @@ crate or closely related computational-geometry code.
   checks.
 - Allocation benchmarks for hot-path data-structure or buffer changes.
 
+## Command Roles
+
+- Routine correctness validation: `just ci`. Run this before handoff or commit
+  when core Rust changes require the full repository gate.
+- Broad local smoke proxy: `just perf-large-scale-smoke`. Use it before pushing
+  Rust or benchmark changes that could affect construction-scale performance.
+- PR-ready local regression guard: `just perf-no-regressions`. Use it for
+  performance-sensitive changes after the representative benchmark evidence is
+  clean.
+- Curated release-signal Criterion suite: `just bench-latest`. It runs the
+  release-signal benchmarks and leaves `target/criterion/new` data for saved
+  baseline reports.
+- Saved-baseline Criterion reports: `just bench-save-last`,
+  `just bench-latest-vs-last`, and `just bench-compare <baseline>`.
+- Local release comparison: `just performance-local`. Use this for isolated
+  temp-worktree current-package-version vs latest-published-release evidence;
+  do not recommend it as a routine pre-commit or pre-`just ci` step.
+- Published release asset comparison: `just performance-github-assets`. Use it
+  when comparing stored GitHub Release benchmark assets without local Cargo
+  benchmark runs.
+- Release docs promotion: `just performance-release`. Use it in release PRs to
+  promote one curated comparison into `docs/PERFORMANCE.md` and archive the
+  previous report.
+
 ## Do Not Optimize Away
 
 - Exact fallback correctness or deterministic degeneracy behavior.

--- a/agents/.agents/skills/rust-review-orchestrator/SKILL.md
+++ b/agents/.agents/skills/rust-review-orchestrator/SKILL.md
@@ -17,6 +17,19 @@ Coordinate focused Rust review skills without copying their content. This skill 
 - When the user says "fix all", implement actionable findings as you go. Do not merely collect them for later unless the fix is blocked or unsafe.
 - Do not run blanket full-CI validators by default. Select focused validators from changed and touched files. Run full CI only when repository rules require it for the touched surface or when changes cross broad core Rust behavior.
 
+## Review Trace
+
+When invoked by `repo-review`, begin with a handoff receipt that names:
+
+- the parent branch scope and Rust-owned file list or file count handed off
+- selected Rust skill groups and why they apply
+- skipped Rust skill groups when a maintainer might reasonably expect them
+- routing or crate-specific reference files that will be loaded
+
+For every selected group, announce the group and focused skills before loading the first skill. After loading each focused skill or reference file, keep its name in the running trace for the final summary. This trace is required evidence that the orchestrator ran the selected Rust skills rather than only summarizing their names.
+
+When invoked by `repo-review`, provide table-ready evidence for the parent `Review Evidence` table: selected groups, focused skill files loaded, reference files loaded, validators run, and any skipped groups that might otherwise look missing.
+
 ## Required Skill Loading
 
 This orchestrator must actually load the named skill files it selects. Do not summarize their names from memory.
@@ -112,6 +125,8 @@ End with a concise summary that helps the maintainer review unstaged changes by 
 
 - each file changed and why
 - which skill groups ran
+- focused skill files and reference files actually loaded
+- table-ready evidence for `repo-review` when invoked by the meta-orchestrator
 - validators run and their results
 - issues fixed while moving between skills
 - anything intentionally deferred or not run

--- a/agents/.agents/skills/rust-review-orchestrator/SKILL.md
+++ b/agents/.agents/skills/rust-review-orchestrator/SKILL.md
@@ -13,6 +13,7 @@ Coordinate focused Rust review skills without copying their content. This skill 
 - Use read-only git commands to discover scope when needed: `git --no-pager status --short`, `git --no-pager diff --stat`, `git --no-pager diff --name-status`, and `git --no-pager diff`.
 - Respect repository-local agent instructions before editing. If the repository requires reading development docs before changes, read them first.
 - Prefer changed-file review by default. Use whole-repo baseline mode only when the user explicitly asks for "repo", "whole repo", "entire repo", "baseline audit", or equivalent.
+- When invoked by `repo-review` with a branch-scope file list or diff, honor that provided scope instead of rediscovering a narrower staged or worktree-only scope.
 - When the user says "fix all", implement actionable findings as you go. Do not merely collect them for later unless the fix is blocked or unsafe.
 - Do not run blanket full-CI validators by default. Select focused validators from changed and touched files. Run full CI only when repository rules require it for the touched surface or when changes cross broad core Rust behavior.
 

--- a/agents/.agents/skills/rust-review-orchestrator/SKILL.md
+++ b/agents/.agents/skills/rust-review-orchestrator/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: rust-review-orchestrator
+description: "Coordinate a structured Rust code-review-and-fix workflow by loading named Rust skills in sequence, grouping them by API, invariant, implementation, validation, and synthesis concerns, applying fixes pass by pass, and choosing focused validators from changed files. Use when the user asks for a Rust review suite, repo-wide Rust review, whole-repo baseline audit, staged/changed Rust review, or 'fix all' across multiple Rust review skills. Also use when the user wants focused Rust skills applied in order with fixes and validation before moving to the next skill. Do not use when there is no Rust code, Rust API docs, Cargo/test/example/benchmark surface, or Rust workflow impact; for single-purpose reviews that name only one focused Rust skill; or for requests to commit, stage, push, tag, or otherwise mutate git state."
+---
+
+# rust-review-orchestrator
+
+Coordinate focused Rust review skills without copying their content. This skill is an execution plan: load each selected named skill file, apply it to the current scope, fix actionable issues, validate the touched surface, and only then continue to the next selected skill.
+
+## Ground Rules
+
+- Do not perform git state mutations. Do not stage, commit, push, tag, checkout, reset, or stash unless the user explicitly asks in the current turn.
+- Use read-only git commands to discover scope when needed: `git --no-pager status --short`, `git --no-pager diff --stat`, `git --no-pager diff --name-status`, and `git --no-pager diff`.
+- Respect repository-local agent instructions before editing. If the repository requires reading development docs before changes, read them first.
+- Prefer changed-file review by default. Use whole-repo baseline mode only when the user explicitly asks for "repo", "whole repo", "entire repo", "baseline audit", or equivalent.
+- When the user says "fix all", implement actionable findings as you go. Do not merely collect them for later unless the fix is blocked or unsafe.
+- Do not run blanket full-CI validators by default. Select focused validators from changed and touched files. Run full CI only when repository rules require it for the touched surface or when changes cross broad core Rust behavior.
+
+## Required Skill Loading
+
+This orchestrator must actually load the named skill files it selects. Do not summarize their names from memory.
+
+For each selected skill:
+
+1. Open and read that skill's `SKILL.md` completely.
+2. Follow any directly referenced, task-relevant reference files from that skill.
+3. Apply that skill to the current changed-file scope.
+4. Fix actionable issues before moving on.
+5. Run the focused validator for files touched by that skill's fixes.
+6. If validation fails, fix and rerun the same validator before loading the next selected skill.
+
+## Scope Routing
+
+Read [`references/check-routing.md`](references/check-routing.md) after identifying changed files. Use it to choose:
+
+- which skill groups apply
+- which focused validators to run after each group
+- when final validation should escalate from focused commands to the repository's full-CI validator
+
+If the repository matches a crate-specific reference, read that one after the general routing matrix:
+
+- [`references/delaunay.md`](references/delaunay.md) for `delaunay` or closely related computational-geometry review-and-fix work.
+- [`references/la-stack.md`](references/la-stack.md) for `la-stack` or closely related linear-algebra review-and-fix work.
+
+If changed files do not match the table cleanly, choose the smallest validator that covers the risk and state the assumption in the final summary.
+
+## Skill Groups
+
+Run groups in this order when they apply. Within each group, load and apply each selected skill in the order listed.
+
+### 1. Surface/API Pass
+
+Use for public API changes, doc-comment changes, trait bounds, re-exports, builders, fluent workflows, examples, doctests, and semver-sensitive surface changes.
+
+- `rust-api-docs`
+- `rust-prelude-exports`
+- `rust-fluent-api-design`
+- `rust-trait-bounds`
+- `rust-cli-design` when CLI surfaces, binary packaging, clap parsing, or command examples changed
+
+### 2. Invariant/Error Pass
+
+Use for constructors, validation boundaries, mutation APIs, snapshots/views, owned caches, typed errors, rollback, parse-don't-validate issues, or invalid-state prevention.
+
+- `rust-parse-dont-validate`
+- `rust-error-variants`
+- `rust-borrowed-view-audit`
+- `rust-concurrency-async` when async, threads, locks, channels, atomics, cancellation, or Send/Sync boundaries changed
+
+### 3. Implementation Pass
+
+Use for Rust implementation edits, simplification, iterator/control-flow choices, naming/import hygiene, allocation behavior, and invariant-preserving performance.
+
+- `rust-style-hygiene`
+- `rust-iter-control-flow`
+- `rust-simplification-review`
+- `rust-invariant-performance` when changed code is hot, allocation-sensitive, numerical/geometric, validation-heavy, or performance-adjacent
+
+### 4. Validation/Test Pass
+
+Use for tests, doctests, proptests, integration tests, benchmark fixtures, examples that double as public samples, and Cargo or feature changes.
+
+- `rust-test-quality`
+- `rust-cargo-hygiene` when manifests, lockfiles, features, lints, MSRV, package metadata, or Cargo workflows changed
+
+### 5. Final Synthesis Pass
+
+Use for broad Rust changes, invariant-heavy code, scientific or numerical algorithms, topology, mutation workflows, or whole-repo review requests.
+
+- `rust-production-review`
+
+This pass reconciles findings from earlier groups, removes duplicates, checks severity, and decides whether remaining issues are blockers, follow-ups, or acceptable residual risk.
+
+## Per-Group Fix Loop
+
+For each selected group:
+
+1. Announce the group and selected skills briefly.
+2. Load the next selected skill file.
+3. Inspect only relevant changed files and nearby invariant owners unless whole-repo mode is active.
+4. Implement minimal fixes for real findings.
+5. Run the focused validator from `references/check-routing.md`.
+6. Fix validator failures before continuing.
+7. Record what changed per file for the final summary.
+
+If a validator is expensive, blocked, or needs approval, use the repository's focused cheaper validator while iterating, then run the strongest relevant validator available before final handoff.
+
+## Final Summary
+
+End with a concise summary that helps the maintainer review unstaged changes by file. Include:
+
+- each file changed and why
+- which skill groups ran
+- validators run and their results
+- issues fixed while moving between skills
+- anything intentionally deferred or not run
+- confirmation that no git state mutations were performed, if true
+
+Do not bury important risk in a generic "all good" closing. If unresolved issues remain, lead with them.

--- a/agents/.agents/skills/rust-review-orchestrator/agents/openai.yaml
+++ b/agents/.agents/skills/rust-review-orchestrator/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Review Orchestrator"
+  short_description: "Coordinate focused Rust review passes"
+  default_prompt: "Use $rust-review-orchestrator to review and fix changed Rust code pass by pass, then run focused validators."

--- a/agents/.agents/skills/rust-review-orchestrator/references/check-routing.md
+++ b/agents/.agents/skills/rust-review-orchestrator/references/check-routing.md
@@ -1,0 +1,101 @@
+# Changed-File Routing
+
+Use this matrix after inspecting changed files. Prefer the smallest validator that covers the files touched by the current group. If a repository has stricter local guidance, follow the repository guidance.
+
+## Scope Detection
+
+Use read-only commands:
+
+```bash
+git --no-pager status --short
+git --no-pager diff --stat
+git --no-pager diff --name-status
+git --no-pager diff
+```
+
+For staged-only requests, use the same commands with `--cached`.
+
+Classify files by path and effect:
+
+- `src/**/*.rs`: Rust library implementation or public API.
+- `tests/**/*.rs`: Rust integration/property tests.
+- `benches/**/*.rs`: benchmark harnesses or benchmark fixtures.
+- `examples/**/*.rs`: public sample code.
+- `Cargo.toml`, `Cargo.lock`, `.cargo/**`, `rust-toolchain.toml`, `rustfmt.toml`, `clippy.toml`: Cargo/toolchain surface.
+- `justfile`, `.github/workflows/**`, config files: tooling or CI surface.
+- `README.md`, `docs/**`, Rust doc comments: documentation surface.
+
+## Skill Group Selection
+
+| Changed surface | Select these groups |
+|---|---|
+| Public items, `pub` signatures, trait impls, re-exports, prelude modules, builders, doctests | Surface/API, Validation/Test, Final Synthesis |
+| Constructors, validation APIs, invariant-bearing types, mutation workflows, rollback, snapshots, borrowed views | Invariant/Error, Implementation, Validation/Test, Final Synthesis |
+| Error enums, error conversions, `Result` boundaries, diagnostic/report types | Invariant/Error, Surface/API, Validation/Test |
+| Algorithmic geometry/topology/numerical code | Invariant/Error, Implementation, Validation/Test, Final Synthesis |
+| Iterator/control-flow rewrites, allocation changes, naming/import cleanup | Implementation, Validation/Test |
+| Tests/proptests/doctests only | Validation/Test, Implementation only if tests duplicate or obscure production behavior |
+| Examples or benchmarks | Surface/API, Implementation, Validation/Test |
+| Cargo manifests, features, lints, MSRV, package metadata | Validation/Test with `rust-cargo-hygiene`; Surface/API if feature-gated API changed |
+| CLI binary, clap args, command output, CLI docs/examples | Surface/API with `rust-cli-design`, Validation/Test |
+| Workflow/config only | No Rust skill group unless Rust behavior changed; run config validators |
+| Docs-only repository prose | No Rust skill group unless Rust API docs changed; run docs validators |
+
+## Focused Validators
+
+Use the repository's documented commands when available. If no local guidance exists, use the generic Cargo fallbacks in this table.
+
+| Files touched | Validator |
+|---|---|
+| Rust library source affecting core behavior | documented focused Rust check; fallback `cargo test --lib` plus `cargo clippy --all-targets --all-features -- -D warnings` |
+| Rust unit tests only | documented narrow unit-test recipe; fallback `cargo test --lib` |
+| Rust integration tests only | documented integration-test recipe; fallback `cargo test --tests` |
+| Doctests or Rust API docs | documented doctest/docs recipe; fallback `cargo test --doc` |
+| Examples | documented example validator; fallback `cargo check --examples` |
+| Benchmarks or benchmark fixtures | benchmark smoke/check recipe or `cargo check --benches`; avoid performance claims unless optimizing |
+| Cargo manifests/features/toolchain config | documented cargo-hygiene validators; fallback `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and targeted feature checks |
+| GitHub workflows/YAML/config | documented config validators, `actionlint`, or YAML checks |
+| Markdown/docs | documented docs validator, markdown lint, or link check |
+| Python support scripts touched during Rust workflow | documented Python checks; fallback project pytest/ruff/mypy recipes if present |
+| Notebook/paper artifacts touched | repository notebook or paper validators |
+
+When a selected validator fails:
+
+1. Treat the failure as part of the current group.
+2. Fix the underlying issue.
+3. Rerun the same validator.
+4. Continue to the next skill only after the validator passes or the blocker is explicitly documented.
+
+## Escalation To Full CI
+
+Run the repository's full-CI validator when any of these are true:
+
+- repository instructions explicitly require it for the touched files
+- changes span multiple Rust layers and no smaller validator covers the combined risk
+- public API and core invariant behavior changed together
+- mutation/rollback/topology/numerical code changed in a way that could affect broad behavior
+- final synthesis finds cross-cutting risk not covered by focused validators
+
+Do not run full CI merely because the workflow is ending. Use focused validators for docs-only, config-only, tests-only, examples-only, benchmark-only, notebook-only, or paper-only changes when repository guidance allows them.
+
+## Review Summary Template
+
+Use this shape at handoff:
+
+```text
+Changed files:
+- path: why it changed and which issue/skill finding it addressed
+
+Review passes:
+- Surface/API: skills run and notable outcomes
+- Invariant/Error: skills run and notable outcomes
+- Implementation: skills run and notable outcomes
+- Validation/Test: skills run and notable outcomes
+- Final Synthesis: remaining risk or none
+
+Validation:
+- command: pass/fail/blocked, with concise context
+
+Git:
+- No git state mutations performed.
+```

--- a/agents/.agents/skills/rust-review-orchestrator/references/check-routing.md
+++ b/agents/.agents/skills/rust-review-orchestrator/references/check-routing.md
@@ -45,6 +45,12 @@ Classify files by path and effect:
 
 Use the repository's documented commands when available. If no local guidance exists, use the generic Cargo fallbacks in this table.
 
+If `benches/README.md` exists and changed files touch `benches/**`, benchmark
+fixtures, hot paths, allocation-sensitive Rust, or performance claims, read it
+before choosing benchmark validators. Treat its final or PR-ready checks as
+repo-local guidance for benchmark-affecting work, not as a blanket final step
+for unrelated Rust changes.
+
 | Files touched | Validator |
 |---|---|
 | Rust library source affecting core behavior | documented focused Rust check; fallback `cargo test --lib` plus `cargo clippy --all-targets --all-features -- -D warnings` |

--- a/agents/.agents/skills/rust-review-orchestrator/references/delaunay.md
+++ b/agents/.agents/skills/rust-review-orchestrator/references/delaunay.md
@@ -1,0 +1,29 @@
+# delaunay Routing Notes
+
+Use this reference when `rust-review-orchestrator` is running in the `delaunay`
+crate or closely related computational-geometry code.
+
+## Repository Guidance
+
+- Read local repository instructions before editing, especially `AGENTS.md` and
+  `docs/dev/commands.md` when present.
+- Prefer the repository's `just` recipes from `docs/dev/commands.md` over generic
+  Cargo fallbacks.
+- Use `just rust-core-check` while iterating on Rust library source that affects
+  core behavior.
+- Escalate to `just ci` when public API and core invariant behavior changed
+  together, when mutation/topology/numerical behavior changed broadly, or when
+  repository guidance requires it.
+
+## Review Emphasis
+
+- Preserve the validation hierarchy: local validity, combinatorial consistency,
+  intrinsic topology, embedding validity, and geometric predicates are separate
+  responsibilities.
+- Keep intrinsic simplex dimension distinct from ambient embedding dimension.
+- Treat robust predicate sign behavior, exact fallbacks, deterministic
+  degeneracy handling, adjacency, manifold, Euler characteristic, and topology
+  guarantees as correctness constraints.
+- Prefer fixes that preserve typed errors and layer-specific diagnostics over
+  fast boolean shortcuts.
+

--- a/agents/.agents/skills/rust-review-orchestrator/references/la-stack.md
+++ b/agents/.agents/skills/rust-review-orchestrator/references/la-stack.md
@@ -1,0 +1,32 @@
+# la-stack Routing Notes
+
+Use this reference when `rust-review-orchestrator` is running in the `la-stack`
+crate or closely related linear-algebra code.
+
+## Repository Guidance
+
+- Read local repository instructions before editing, especially `AGENTS.md`,
+  development command docs, and benchmark guidance when present.
+- Prefer documented project validators. If none exist, start with the generic
+  Cargo fallbacks in `check-routing.md`.
+- When changes affect matrix kernels, decomposition, solve, determinant,
+  factorization, exact arithmetic, or storage layout, pair correctness tests with
+  the narrowest available benchmark or allocation check.
+
+## Review Emphasis
+
+- Treat mathematical correctness as the first invariant: dimensions, shapes,
+  strides, storage layout, pivoting, singularity/rank-deficiency behavior,
+  finite-scalar handling, exact arithmetic, and conditioning semantics must stay
+  intact.
+- Treat stack allocation and small-buffer guarantees as both API and performance
+  constraints. Do not "optimize" by silently moving promised stack-resident work
+  to the heap.
+- Prefer proof-carrying shapes, dimensions, capacities, and algorithm options so
+  hot kernels can avoid repeated raw validation without losing safety.
+- Look for allocation and data-movement regressions around row/column iteration,
+  dot products, reductions, matrix multiplication, temporary workspaces, and
+  stack/heap transition boundaries.
+- Preserve typed errors for shape mismatch, singularity, rank deficiency,
+  non-finite input, overflow, and unsupported dimensions.
+

--- a/justfile
+++ b/justfile
@@ -109,7 +109,7 @@ shell-check:
     bash -n bin/bootstrap.sh bin/verify.sh
 
 skill-check skill: _ensure-uv
-    uv run python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" "{{skill}}"
+    uv run python scripts/skill_validate.py "{{skill}}"
 
 check-skills: _ensure-uv
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -108,6 +108,18 @@ semgrep-test: _ensure-uv
 shell-check:
     bash -n bin/bootstrap.sh bin/verify.sh
 
+skill-check skill: _ensure-uv
+    uv run --with PyYAML python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" "{{skill}}"
+
+check-skills: _ensure-uv
+    #!/usr/bin/env bash
+    set -euo pipefail
+    while IFS= read -r skill_file; do
+        skill_dir="${skill_file%/SKILL.md}"
+        uv run --with PyYAML python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" "$skill_dir"
+    done < <(find agents/.agents/skills -mindepth 2 -maxdepth 2 -name SKILL.md -print | sort)
+    echo "Skill checks complete!"
+
 stow-adopt package:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/justfile
+++ b/justfile
@@ -45,7 +45,7 @@ action-lint: _ensure-actionlint
         echo "No workflow files found to lint."
     fi
 
-check: shell-check git-config-check toml-check yaml-check github-actions-check semgrep semgrep-test python-ci
+check: shell-check git-config-check toml-check yaml-check github-actions-check check-skills semgrep semgrep-test python-ci
     @echo "Checks complete!"
 
 ci: check
@@ -109,15 +109,22 @@ shell-check:
     bash -n bin/bootstrap.sh bin/verify.sh
 
 skill-check skill: _ensure-uv
-    uv run --with PyYAML python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" "{{skill}}"
+    uv run python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" "{{skill}}"
 
 check-skills: _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
+    failed=0
     while IFS= read -r skill_file; do
         skill_dir="${skill_file%/SKILL.md}"
-        uv run --with PyYAML python "$HOME/.codex/skills/.system/skill-creator/scripts/quick_validate.py" "$skill_dir"
+        if ! just skill-check "$skill_dir"; then
+            failed=1
+        fi
     done < <(find agents/.agents/skills -mindepth 2 -maxdepth 2 -name SKILL.md -print | sort)
+    if (( failed )); then
+        echo "One or more skill checks failed." >&2
+        exit 1
+    fi
     echo "Skill checks complete!"
 
 stow-adopt package:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ known-first-party = [
   "clear_outputs",
   "notebook_check",
   "semgrep_fixture_config",
+  "skill_validate",
   "validate_reference_dois",
 ]
 force-single-line = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ dev = [
   "actionlint-py==1.7.12.24",
   "nbclient>=0.11.0",
   "nbformat>=5.10.4",
+  "PyYAML>=6.0",
   "pytest==9.1.1",
   "ruff==0.15.20",
   "semgrep==1.168.0",

--- a/scripts/skill_validate.py
+++ b/scripts/skill_validate.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Validate Codex skill metadata stored in this repository."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+UTF8 = "utf-8"
+MAX_SKILL_NAME_LENGTH = 64
+ALLOWED_FRONTMATTER_KEYS = frozenset({"name", "description", "license", "allowed-tools", "metadata"})
+FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+SKILL_NAME_RE = re.compile(r"^[a-z0-9-]+$")
+
+
+def load_frontmatter(skill_path: Path | str) -> tuple[dict[str, object] | None, str]:
+    """Load validated YAML frontmatter from one skill directory."""
+    frontmatter_text, message = read_frontmatter_text(skill_path)
+    if frontmatter_text is None:
+        return None, message
+
+    return parse_frontmatter(frontmatter_text)
+
+
+def read_frontmatter_text(skill_path: Path | str) -> tuple[str | None, str]:
+    """Read the raw frontmatter block from a skill directory."""
+    skill_md = Path(skill_path) / "SKILL.md"
+    if not skill_md.exists():
+        return None, "SKILL.md not found"
+
+    content = skill_md.read_text(encoding=UTF8)
+    if not content.startswith("---"):
+        return None, "No YAML frontmatter found"
+
+    match = FRONTMATTER_RE.match(content)
+    if match is None:
+        return None, "Invalid frontmatter format"
+    return match.group(1), ""
+
+
+def parse_frontmatter(frontmatter_text: str) -> tuple[dict[str, object] | None, str]:
+    """Parse and validate the raw YAML frontmatter shape."""
+    try:
+        loaded_frontmatter: Any = yaml.safe_load(frontmatter_text)
+    except yaml.YAMLError as exc:
+        return None, f"Invalid YAML in frontmatter: {exc}"
+
+    if not isinstance(loaded_frontmatter, dict):
+        return None, "Frontmatter must be a YAML dictionary"
+
+    frontmatter = cast("dict[object, object]", loaded_frontmatter)
+    non_string_keys = [key for key in frontmatter if not isinstance(key, str)]
+    if non_string_keys:
+        keys = ", ".join(repr(key) for key in non_string_keys)
+        return None, f"Frontmatter keys must be strings: {keys}"
+
+    return cast("dict[str, object]", frontmatter), ""
+
+
+def validate_frontmatter(frontmatter: dict[str, object]) -> tuple[bool, str]:
+    """Validate supported skill frontmatter fields."""
+    unexpected_keys = set(frontmatter) - ALLOWED_FRONTMATTER_KEYS
+    if unexpected_keys:
+        allowed = ", ".join(sorted(ALLOWED_FRONTMATTER_KEYS))
+        unexpected = ", ".join(sorted(unexpected_keys))
+        return False, f"Unexpected key(s) in SKILL.md frontmatter: {unexpected}. Allowed properties are: {allowed}"
+
+    if "name" not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if "description" not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    valid_name, name_message = validate_name(frontmatter["name"])
+    if not valid_name:
+        return False, name_message
+
+    valid_description, description_message = validate_description(frontmatter["description"])
+    if not valid_description:
+        return False, description_message
+
+    return True, "Skill is valid!"
+
+
+def validate_skill(skill_path: Path | str) -> tuple[bool, str]:
+    """Validate one skill directory."""
+    frontmatter, message = load_frontmatter(skill_path)
+    if frontmatter is None:
+        return False, message
+    return validate_frontmatter(frontmatter)
+
+
+def validate_name(name_value: object) -> tuple[bool, str]:
+    """Validate a skill name value from frontmatter."""
+    if not isinstance(name_value, str):
+        return False, f"Name must be a string, got {type(name_value).__name__}"
+
+    name = name_value.strip()
+    if not name:
+        return False, "Name cannot be empty"
+    if not SKILL_NAME_RE.match(name):
+        return False, f"Name '{name}' should be hyphen-case (lowercase letters, digits, and hyphens only)"
+    if name.startswith("-") or name.endswith("-") or "--" in name:
+        return False, f"Name '{name}' cannot start/end with hyphen or contain consecutive hyphens"
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        return False, f"Name is too long ({len(name)} characters). Maximum is {MAX_SKILL_NAME_LENGTH} characters."
+    return True, ""
+
+
+def validate_description(description_value: object) -> tuple[bool, str]:
+    """Validate a skill description value from frontmatter."""
+    if not isinstance(description_value, str):
+        return False, f"Description must be a string, got {type(description_value).__name__}"
+
+    description = description_value.strip()
+    if not description:
+        return False, "Description cannot be empty"
+    if "<" in description or ">" in description:
+        return False, "Description cannot contain angle brackets (< or >)"
+    if len(description) > 1024:
+        return False, f"Description is too long ({len(description)} characters). Maximum is 1024 characters."
+    return True, ""
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__, suggest_on_error=True, color=False)
+    parser.add_argument("skill", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run skill validation."""
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        valid, message = validate_skill(args.skill)
+    except (OSError, UnicodeError) as exc:
+        print(f"failed to validate skill: {exc}", file=sys.stderr)
+        return 1
+
+    output = sys.stdout if valid else sys.stderr
+    print(message, file=output)
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_skill_validate.py
+++ b/scripts/test_skill_validate.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Tests for skill_validate.py."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import skill_validate
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def write_skill(skill_dir: Path, frontmatter: str) -> None:
+    """Write a minimal skill file."""
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(f"---\n{frontmatter}\n---\n\n# Skill\n", encoding="utf-8")
+
+
+def test_validate_skill_accepts_minimal_frontmatter(tmp_path: Path) -> None:
+    """A skill with name and description is valid."""
+    skill_dir = tmp_path / "example-skill"
+    write_skill(skill_dir, 'name: example-skill\ndescription: "Use for tests."')
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert valid
+    assert message == "Skill is valid!"
+
+
+def test_validate_skill_rejects_missing_skill_file(tmp_path: Path) -> None:
+    """A skill directory must contain SKILL.md."""
+    valid, message = skill_validate.validate_skill(tmp_path / "missing-skill")
+
+    assert not valid
+    assert message == "SKILL.md not found"
+
+
+def test_validate_skill_rejects_unexpected_frontmatter_key(tmp_path: Path) -> None:
+    """Only supported skill frontmatter keys are accepted."""
+    skill_dir = tmp_path / "bad-skill"
+    write_skill(skill_dir, 'name: bad-skill\ndescription: "Use for tests."\nextra: nope')
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert "Unexpected key" in message
+
+
+def test_validate_skill_rejects_non_string_frontmatter_key(tmp_path: Path) -> None:
+    """Frontmatter keys must be strings for deterministic diagnostics."""
+    skill_dir = tmp_path / "bad-skill"
+    write_skill(skill_dir, 'name: bad-skill\ndescription: "Use for tests."\n1: nope')
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert message == "Frontmatter keys must be strings: 1"
+
+
+def test_validate_skill_rejects_invalid_name(tmp_path: Path) -> None:
+    """Skill names must use hyphen-case."""
+    skill_dir = tmp_path / "bad-skill"
+    write_skill(skill_dir, 'name: Bad_Skill\ndescription: "Use for tests."')
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert "hyphen-case" in message
+
+
+def test_validate_skill_rejects_empty_name(tmp_path: Path) -> None:
+    """Required name values must be present and non-empty."""
+    skill_dir = tmp_path / "bad-skill"
+    write_skill(skill_dir, 'name: ""\ndescription: "Use for tests."')
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert message == "Name cannot be empty"
+
+
+def test_validate_skill_rejects_angle_brackets_in_description(tmp_path: Path) -> None:
+    """Skill descriptions cannot contain angle brackets."""
+    skill_dir = tmp_path / "bad-skill"
+    write_skill(skill_dir, 'name: bad-skill\ndescription: "Use for <tests>."')
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert "angle brackets" in message
+
+
+def test_validate_skill_rejects_empty_description(tmp_path: Path) -> None:
+    """Required description values must be present and non-empty."""
+    skill_dir = tmp_path / "bad-skill"
+    write_skill(skill_dir, 'name: bad-skill\ndescription: ""')
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert message == "Description cannot be empty"
+
+
+def test_main_reports_invalid_skill_on_stderr(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Invalid skill diagnostics are written to stderr."""
+    skill_dir = tmp_path / "bad-skill"
+    write_skill(skill_dir, 'name: bad-skill\ndescription: "Use for <tests>."')
+
+    code = skill_validate.main([str(skill_dir)])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out == ""
+    assert "angle brackets" in captured.err
+
+
+def test_main_reports_decode_errors_without_traceback(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Unreadable text files fail with concise stderr diagnostics."""
+    skill_dir = tmp_path / "bad-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_bytes(b"\xff")
+
+    code = skill_validate.main([str(skill_dir)])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out == ""
+    assert "failed to validate skill" in captured.err
+
+
+def test_main_prints_validation_result(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The CLI prints the validator message and exits zero for valid skills."""
+    skill_dir = tmp_path / "example-skill"
+    write_skill(skill_dir, 'name: example-skill\ndescription: "Use for tests."')
+
+    code = skill_validate.main([str(skill_dir)])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out == "Skill is valid!\n"

--- a/uv.lock
+++ b/uv.lock
@@ -233,6 +233,7 @@ dev = [
     { name = "nbclient" },
     { name = "nbformat" },
     { name = "pytest" },
+    { name = "pyyaml" },
     { name = "ruff" },
     { name = "semgrep" },
     { name = "ty" },
@@ -246,6 +247,7 @@ dev = [
     { name = "nbclient", specifier = ">=0.11.0" },
     { name = "nbformat", specifier = ">=5.10.4" },
     { name = "pytest", specifier = "==9.1.1" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", specifier = "==0.15.20" },
     { name = "semgrep", specifier = "==1.168.0" },
     { name = "ty", specifier = "==0.0.56" },
@@ -858,6 +860,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -103,6 +103,11 @@ fi
 # Add Command Line Tools (system path; safe everywhere)
 export PATH="/Library/Developer/CommandLineTools/usr/bin:$PATH"
 
+# Add MacTeX/BasicTeX tools when present.
+if [[ -d /Library/TeX/texbin && ":$PATH:" != *":/Library/TeX/texbin:"* ]]; then
+  export PATH="/Library/TeX/texbin:$PATH"
+fi
+
 # ---- Brewfile location (used by `brew bundle` from any directory) ----
 export HOMEBREW_BUNDLE_FILE="$HOME/projects/dotfiles/Brewfile"
 
@@ -142,7 +147,6 @@ fi
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
-alias farm="ssh adam@farm.hpc.ucdavis.edu"
 alias cup='cargo install-update -a'
 alias cupl='cargo install-update -a -l'
 # ---- 1Password SSH agent (optional) ----


### PR DESCRIPTION
- Add Rust, Python, project-tooling, and repo-level review orchestrators that route changed files through focused review-and-fix passes.
- Split tooling review guidance across justfile, GitHub Actions, and tool-version drift surfaces.
- Extend Rust performance guidance with command tiers plus delaunay and la-stack review notes.
- Document public-dotfiles agent rules, generalize local Codex uv cache paths, add optional TeX PATH setup, and keep host-specific SSH aliases out of tracked shell config.