### PR TITLE
Added: Notebook cell ID checks and static analysis review guidance

### DIFF
--- a/agents/.agents/skills/jupyter-notebook-review/SKILL.md
+++ b/agents/.agents/skills/jupyter-notebook-review/SKILL.md
@@ -17,9 +17,14 @@ CLIs, or examples; notebooks should orchestrate those APIs and analyze generated
 5. Edit notebooks with `nbformat` or the helper scripts; do not hand-edit large notebook JSON by string substitution.
 6. Validate with `uv run scripts/notebook_check.py --lint NOTEBOOK.ipynb` when the helper is copied into a repo, or with the skill-local script through
    `uv run`. The lint path compiles cells, runs notebook-specific AST checks, and requires Ruff lint, Ruff format, and ty on extracted notebook code unless a
-   check is explicitly disabled. Execute with `--execute` when dependencies and runtime are reasonable.
-7. Ensure each cell has a stable, descriptive `id` that names its purpose, such as `setup-code`, `load-data`, or `render-plot`.
+   check is explicitly disabled. Execute only when runtime behavior or a generated artifact is part of the task; do not treat execution as routine lint.
+7. Ensure every code, markdown, and raw cell has a unique, stable, descriptive `id` that names its purpose, such as `setup-code`, `load-data`, or
+   `render-plot`. Follow repository naming rules; otherwise prefer lowercase kebab-case.
 8. Clear outputs before finalizing unless the repository intentionally tracks rendered notebook outputs.
+
+## Project References
+
+- For the `delaunay` repository, read [`references/delaunay.md`](references/delaunay.md) after the repository's `AGENTS.md` and routed development guidance.
 
 ## Related Python Skills
 
@@ -64,6 +69,18 @@ Prefer:
 - a headless recipe such as `just notebook-execute` for CI, remote servers, and HPC jobs
 - data and generated artifacts under `target/`, `runs/`, or another documented output directory
 - fresh-kernel execution through `nbconvert`, `nbclient`, or a repository notebook check recipe
+
+Treat notebook cost as parameter-dependent. Do not create permanent `slow/` notebook categories or an aggregate execute-all recipe unless the repository
+explicitly requires one. Routine checks should remain lint-only when notebooks may become expensive under altered parameters.
+
+### Generated And Tracked Artifacts
+
+Keep ordinary execution scratch-only. Write executed notebooks and generated files under `target/`, `$SCRATCH`, or another repository-designated disposable
+directory. Refresh tracked figures or reports only when the task includes that artifact and through a named repository workflow.
+
+When documentation and papers consume the same generated figure, prefer one canonical tracked asset over duplicate copies. Notebook code should default to a
+scratch destination; let the named refresh recipe supply a tracked path through a validated parameter or environment variable instead of hard-coding a direct
+`savefig` or `write_image` call into a tracked documentation directory.
 
 ### Boundary Parsing And Invariants
 
@@ -283,9 +300,9 @@ def run_command(command: list[str], *, cwd: Path, timeout: int = 120) -> subproc
 
 Use bundled scripts from this skill when useful:
 
-- `scripts/notebook_check.py --summary NOTEBOOK.ipynb` prints a compact cell inventory.
-- `scripts/notebook_check.py --lint NOTEBOOK.ipynb` validates JSON, compiles code cells, requires Ruff lint, Ruff format, and ty by default, and reports output
-  counts.
+- `scripts/notebook_check.py --summary NOTEBOOK.ipynb` prints a compact cell inventory including cell IDs.
+- `scripts/notebook_check.py --lint NOTEBOOK.ipynb` validates JSON and cell IDs, compiles code cells, requires Ruff lint, Ruff format, and ty by default, and
+  reports output counts.
 - `scripts/notebook_check.py --execute NOTEBOOK.ipynb --repo-root PATH` executes in memory without writing outputs back.
 - `scripts/clear_outputs.py NOTEBOOK.ipynb` clears outputs and execution counts in place.
 

--- a/agents/.agents/skills/jupyter-notebook-review/references/delaunay.md
+++ b/agents/.agents/skills/jupyter-notebook-review/references/delaunay.md
@@ -1,0 +1,45 @@
+# delaunay Notebook Review Notes
+
+Use this reference when applying `jupyter-notebook-review` to the `delaunay`
+repository. Read `AGENTS.md`, `docs/dev/notebooks.md`, `docs/dev/commands.md`,
+and `docs/dev/docs.md` first; repository guidance overrides stale details here.
+
+## Cell Identity
+
+- Require every code, markdown, and raw cell to have a unique lowercase
+  kebab-case ID of at most 64 characters.
+- Preserve descriptive IDs when editing cells. Reject generated hexadecimal or
+  UUID identifiers and positional names such as `cell-1`.
+- Use `just notebook-check` as the authoritative repository validator. The
+  structured checker owns presence, shape, length, and uniqueness; Semgrep adds
+  qualitative guards for generated and positional names.
+
+## Execution
+
+- Keep routine validation lint-only with `just notebook-lint` or
+  `just notebook-check`.
+- Execute one notebook deliberately with `just notebook-execute <path>` only
+  when runtime behavior or its artifact is in scope.
+- Do not add an execute-all recipe or a permanent `slow/` notebook directory.
+  Runtime depends on user-controlled parameters.
+
+## Artifact Ownership
+
+- Ordinary execution writes under `target/notebooks/<notebook-stem>/` and must
+  not modify source notebooks.
+- Refresh tracked figures only through their named recipes:
+  `just spherical-readme-hero`, `just validation-doc-figures`, or
+  `just paper-figures`.
+- Keep canonical tracked figures under `docs/assets/`. Documentation and papers
+  should reuse the same asset instead of maintaining paper-local copies.
+- Default notebook save paths to scratch output. Let named recipes provide
+  tracked destinations through validated environment overrides; do not call
+  `savefig` or `write_image` directly on `docs/assets/` or `docs/images/` paths.
+
+## Handoff Validation
+
+- Run `just notebook-check` for notebook source changes.
+- Run the named refresh recipe only when the requested change includes the
+  tracked artifact, then verify its documentation and paper consumers.
+- When notebook checker Python changes, also run the focused Python checks and
+  tests selected by `docs/dev/commands.md`.

--- a/agents/.agents/skills/jupyter-notebook-review/scripts/notebook_check.py
+++ b/agents/.agents/skills/jupyter-notebook-review/scripts/notebook_check.py
@@ -20,7 +20,8 @@ RUFF_LOCATION_RE = re.compile(r"\s*-->\s+.+?:(?P<line>\d+):(?P<column>\d+)")
 TY_LOCATION_RE = re.compile(r"^.+?:(?P<line>\d+):(?P<column>\d+): (?P<message>.+)$")
 CELL_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 GENERATED_CELL_ID_RE = re.compile(
-    r"^(?:[a-f0-9]{8}|[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}|(?:cell|code|markdown|raw|section|step)-?[0-9]+)$"
+    r"^(?:(?i:[a-f0-9]{8}|[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12})|"
+    r"(?:cell|code|markdown|raw|section|step)-?[0-9]+)$"
 )
 
 

--- a/agents/.agents/skills/jupyter-notebook-review/scripts/notebook_check.py
+++ b/agents/.agents/skills/jupyter-notebook-review/scripts/notebook_check.py
@@ -18,6 +18,10 @@ from typing import Any, override
 RUFF_EXTEND_IGNORE = "INP001"
 RUFF_LOCATION_RE = re.compile(r"\s*-->\s+.+?:(?P<line>\d+):(?P<column>\d+)")
 TY_LOCATION_RE = re.compile(r"^.+?:(?P<line>\d+):(?P<column>\d+): (?P<message>.+)$")
+CELL_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+GENERATED_CELL_ID_RE = re.compile(
+    r"^(?:[a-f0-9]{8}|[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}|(?:cell|code|markdown|raw|section|step)-?[0-9]+)$"
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,6 +86,26 @@ def code_cells(notebook: dict[str, Any]) -> list[tuple[int, dict[str, Any], str]
     return cells
 
 
+def cell_id_diagnostics(notebook: dict[str, Any]) -> list[Diagnostic]:
+    """Return diagnostics for stable, unique nbformat cell identifiers."""
+    diagnostics: list[Diagnostic] = []
+    first_cell_by_id: dict[str, int] = {}
+    for index, cell in enumerate(notebook.get("cells", []), start=1):
+        cell_id = cell.get("id")
+        if not isinstance(cell_id, str) or not cell_id:
+            diagnostics.append(Diagnostic("error", index, "missing cell id; add a stable descriptive identifier"))
+            continue
+        if CELL_ID_RE.fullmatch(cell_id) is None:
+            diagnostics.append(Diagnostic("error", index, f"cell id {cell_id!r} must be 1-64 ASCII letters, digits, underscores, or hyphens"))
+            continue
+        first_cell = first_cell_by_id.setdefault(cell_id, index)
+        if first_cell != index:
+            diagnostics.append(Diagnostic("error", index, f"cell id {cell_id!r} duplicates cell {first_cell}"))
+        if GENERATED_CELL_ID_RE.fullmatch(cell_id) is not None:
+            diagnostics.append(Diagnostic("warning", index, f"cell id {cell_id!r} looks generated or positional; name the cell's purpose"))
+    return diagnostics
+
+
 def summarize(path: Path) -> None:
     """Print a compact notebook inventory."""
     notebook = load_notebook(path)
@@ -92,8 +116,9 @@ def summarize(path: Path) -> None:
         first_line = next((line.strip() for line in source.splitlines() if line.strip()), "")
         outputs = len(cell.get("outputs", [])) if cell.get("cell_type") == "code" else 0
         execution_count = cell.get("execution_count") if cell.get("cell_type") == "code" else ""
+        cell_id = cell.get("id", "<missing>")
         print(
-            f"  cell {index:03d} {cell.get('cell_type', 'unknown'):<8} "
+            f"  cell {index:03d} {cell.get('cell_type', 'unknown'):<8} id={cell_id!s:<24} "
             f"lines={len(source.splitlines()):<3} outputs={outputs:<2} exec={execution_count!s:<4} {first_line[:100]}"
         )
 
@@ -365,7 +390,7 @@ def external_tool_diagnostics(path: Path, notebook: dict[str, Any], options: Lin
 def lint(path: Path, options: LintOptions) -> int:
     """Validate notebook JSON, compile code cells, and run Python lint checks."""
     notebook = load_notebook(path)
-    diagnostics = [*code_cell_diagnostics(path, notebook, options), *external_tool_diagnostics(path, notebook, options)]
+    diagnostics = [*cell_id_diagnostics(notebook), *code_cell_diagnostics(path, notebook, options), *external_tool_diagnostics(path, notebook, options)]
 
     for diagnostic in diagnostics:
         stream = sys.stderr if diagnostic.severity == "error" else sys.stdout

--- a/agents/.agents/skills/jupyter-notebook-review/scripts/test_notebook_check.py
+++ b/agents/.agents/skills/jupyter-notebook-review/scripts/test_notebook_check.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Tests for the Jupyter notebook review skill helper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import pytest
+
+SCRIPT = Path(__file__).with_name("notebook_check.py")
+SPEC = importlib.util.spec_from_file_location("notebook_check", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    message = "notebook_check.py could not be loaded"
+    raise RuntimeError(message)
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def notebook_with_ids(*cell_ids: Any) -> dict[str, Any]:
+    """Return a minimal notebook-shaped mapping with the requested cell IDs."""
+    cells = []
+    for cell_id in cell_ids:
+        cell = {"cell_type": "markdown", "metadata": {}, "source": []}
+        if cell_id is not None:
+            cell["id"] = cell_id
+        cells.append(cell)
+    return {"cells": cells, "metadata": {}, "nbformat": 4, "nbformat_minor": 5}
+
+
+def test_cell_id_diagnostics_accepts_unique_nbformat_ids() -> None:
+    """Valid descriptive IDs should pass without diagnostics."""
+    assert MODULE.cell_id_diagnostics(notebook_with_ids("setup-code", "Render_Plot", "load_data")) == []
+
+
+def test_cell_id_diagnostics_rejects_missing_malformed_and_duplicate_ids() -> None:
+    """Presence, nbformat shape, and uniqueness are hard requirements."""
+    diagnostics = MODULE.cell_id_diagnostics(notebook_with_ids(None, "bad id", "load-data", "load-data"))
+
+    assert [(item.severity, item.cell) for item in diagnostics] == [("error", 1), ("error", 2), ("error", 4)]
+
+
+def test_cell_id_diagnostics_warns_on_generated_and_positional_ids() -> None:
+    """Generated and positional IDs should prompt descriptive replacements."""
+    diagnostics = MODULE.cell_id_diagnostics(notebook_with_ids("abcdef12", "123e4567-e89b-42d3-a456-426614174000", "cell-3", "load-data"))
+
+    assert [(item.severity, item.cell) for item in diagnostics] == [("warning", 1), ("warning", 2), ("warning", 3)]
+
+
+def test_lint_enforces_cell_id_diagnostics(tmp_path: Path) -> None:
+    """Cell ID errors should fail lint, while warnings fail only in strict mode."""
+    notebook_path = tmp_path / "example.ipynb"
+    options = MODULE.LintOptions(run_ruff=False, run_format=False, run_ty=False)
+
+    notebook_path.write_text(json.dumps(notebook_with_ids(None)), encoding="utf-8")
+    assert MODULE.lint(notebook_path, options) == 1
+
+    notebook_path.write_text(json.dumps(notebook_with_ids("cell-1")), encoding="utf-8")
+    assert MODULE.lint(notebook_path, options) == 0
+    assert MODULE.lint(notebook_path, MODULE.LintOptions(strict=True, run_ruff=False, run_format=False, run_ty=False)) == 1
+
+
+def test_summary_displays_cell_ids(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Summary output should expose stable IDs for notebook review."""
+    notebook_path = tmp_path / "example.ipynb"
+    notebook_path.write_text(json.dumps(notebook_with_ids("setup-code")), encoding="utf-8")
+
+    MODULE.summarize(notebook_path)
+
+    assert "id=setup-code" in capsys.readouterr().out

--- a/agents/.agents/skills/jupyter-notebook-review/scripts/test_notebook_check.py
+++ b/agents/.agents/skills/jupyter-notebook-review/scripts/test_notebook_check.py
@@ -40,16 +40,18 @@ def test_cell_id_diagnostics_accepts_unique_nbformat_ids() -> None:
 
 def test_cell_id_diagnostics_rejects_missing_malformed_and_duplicate_ids() -> None:
     """Presence, nbformat shape, and uniqueness are hard requirements."""
-    diagnostics = MODULE.cell_id_diagnostics(notebook_with_ids(None, "bad id", "load-data", "load-data"))
+    diagnostics = MODULE.cell_id_diagnostics(notebook_with_ids(None, "", 123, "bad id", "load-data", "load-data", "a" * 64, "a" * 65))
 
-    assert [(item.severity, item.cell) for item in diagnostics] == [("error", 1), ("error", 2), ("error", 4)]
+    assert [(item.severity, item.cell) for item in diagnostics] == [("error", 1), ("error", 2), ("error", 3), ("error", 4), ("error", 6), ("error", 8)]
 
 
 def test_cell_id_diagnostics_warns_on_generated_and_positional_ids() -> None:
     """Generated and positional IDs should prompt descriptive replacements."""
-    diagnostics = MODULE.cell_id_diagnostics(notebook_with_ids("abcdef12", "123e4567-e89b-42d3-a456-426614174000", "cell-3", "load-data"))
+    diagnostics = MODULE.cell_id_diagnostics(
+        notebook_with_ids("abcdef12", "123e4567-e89b-42d3-a456-426614174000", "ABCDEF12", "123E4567-e89B-42d3-A456-426614174000", "cell-3", "load-data")
+    )
 
-    assert [(item.severity, item.cell) for item in diagnostics] == [("warning", 1), ("warning", 2), ("warning", 3)]
+    assert [(item.severity, item.cell) for item in diagnostics] == [("warning", 1), ("warning", 2), ("warning", 3), ("warning", 4), ("warning", 5)]
 
 
 def test_lint_enforces_cell_id_diagnostics(tmp_path: Path) -> None:

--- a/agents/.agents/skills/project-tooling-review/SKILL.md
+++ b/agents/.agents/skills/project-tooling-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-tooling-review
-description: "Review and fix repository tooling surfaces that define how maintainers run, validate, and update a project. Use for justfile recipe design, GitHub Actions workflows, CI command drift, tool-version and installer drift, uv tool and cargo-install managed CLI updates, Brewfile and uv/cargo/rustup tooling configuration, lint/format/type-check command surfaces, release/support scripts wiring, docs that describe project commands, and cross-language validation recipes. Use when the user asks to review project tooling, just recipes, CI workflows, GitHub Actions, tool versions, command consistency, or repository workflow ergonomics. Do not use for Rust or Python source review except where tooling invokes those validators; use the language orchestrators for code behavior. Do not use for requests to commit, stage, push, tag, or otherwise mutate git state."
+description: "Review and fix repository tooling surfaces that define how maintainers run, validate, and update a project. Use for justfile recipe design, GitHub Actions workflows, CI command drift, repository-owned Semgrep/static-analysis rules and fixtures, tool-version and installer drift, uv tool and cargo-install managed CLI updates, Brewfile and uv/cargo/rustup tooling configuration, lint/format/type-check command surfaces, release/support scripts wiring, docs that describe project commands, and cross-language validation recipes. Use when the user asks to review project tooling, just recipes, CI workflows, GitHub Actions, static analysis, tool versions, command consistency, or repository workflow ergonomics. Do not use for Rust or Python source review except where tooling invokes those validators; use the language orchestrators for code behavior. Do not use for requests to commit, stage, push, tag, or otherwise mutate git state."
 ---
 
 # project-tooling-review
@@ -40,13 +40,17 @@ After identifying changed files, load only the references that apply:
 - [`references/justfile.md`](references/justfile.md) for `justfile`, command recipes, local validator tiers, recipe naming, and docs that describe `just` commands.
 - [`references/github-actions.md`](references/github-actions.md) for `.github/workflows/**`, Actions permissions/triggers/caches/matrices, CI use of `just`, and workflow validation.
 - [`references/tool-versions.md`](references/tool-versions.md) for `Brewfile`, `uv`, `cargo install`, `rustup`, lockfiles, action versions, language toolchains, and version drift.
+- [`references/static-analysis.md`](references/static-analysis.md) for repository-owned Semgrep/Opengrep rules, fixtures, path scoping, and validation.
+- [`references/delaunay.md`](references/delaunay.md) in the `delaunay` repository for its Semgrep fixture harness, notebook execution policy, and generated-asset
+  ownership.
 
 If multiple surfaces changed, review them in this order:
 
 1. Tool versions and installers, so commands use the intended tools.
 2. `justfile` recipes and local command contracts.
-3. GitHub Actions and remote CI wiring.
-4. Docs and handoff summaries that describe the command surface.
+3. Repository-owned static-analysis rules, fixtures, and scan scope.
+4. GitHub Actions and remote CI wiring.
+5. Docs and handoff summaries that describe the command surface.
 
 ## Review Goals
 

--- a/agents/.agents/skills/project-tooling-review/agents/openai.yaml
+++ b/agents/.agents/skills/project-tooling-review/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Project Tooling Review"
-  short_description: "Review just, CI, and tool versions"
-  default_prompt: "Use $project-tooling-review to review and fix project tooling, just recipes, CI workflows, and tool-version drift."
+  short_description: "Review just, CI, static analysis, and tools"
+  default_prompt: "Use $project-tooling-review to review and fix project tooling, just recipes, CI workflows, repository-owned static analysis, and tool-version drift."

--- a/agents/.agents/skills/project-tooling-review/references/delaunay.md
+++ b/agents/.agents/skills/project-tooling-review/references/delaunay.md
@@ -1,0 +1,40 @@
+# delaunay Tooling Review Notes
+
+Use this reference when applying `project-tooling-review` to the `delaunay`
+repository. Read `AGENTS.md` and the routed owners under `docs/dev/` first;
+repository guidance overrides stale details here.
+
+## Semgrep Surface
+
+- `semgrep.yaml` is the source of truth for repository-owned rules.
+- `tests/semgrep/` contains annotated positive and negative fixtures.
+- `scripts/semgrep_fixture_config.py` selects annotated rules from the shared
+  configuration for each fixture. Keep the shared config authoritative.
+- Preserve existing rule IDs when extending the same policy.
+- The normal repository scan excludes deliberate fixture violations; use
+  `just semgrep-test` to validate fixtures and `just semgrep` to check the real
+  repository for false positives.
+- Raw notebook JSON is suitable for narrow qualitative Semgrep patterns. Keep
+  structural notebook validation in `scripts/notebook_check.py`.
+- In synthetic TeX fixtures, use the annotation form recognized by Semgrep test
+  mode; `% ruleid` is not recognized by the current harness, while
+  `// ruleid` is.
+
+## Notebook And Asset Policy
+
+- `just notebook-check` is lint-only and must not execute notebooks.
+- Do not add an aggregate execute-all recipe or permanent runtime-based notebook
+  directories. Execution cost is parameter-dependent.
+- Ordinary notebook output belongs under `target/notebooks/`. Tracked figures
+  are refreshed only through named recipes.
+- Canonical validation figures live under `docs/assets/validation/` and are
+  reused by documentation and papers; do not restore paper-local copies.
+
+## Focused Validation
+
+- Validate Semgrep configuration, then run `just semgrep-test` and
+  `just semgrep`.
+- Run `just lint-config` after configuration changes and the focused Markdown
+  validator when tooling guidance changes.
+- Follow `docs/dev/commands.md` rather than defaulting configuration-only work
+  to full `just ci`.

--- a/agents/.agents/skills/project-tooling-review/references/static-analysis.md
+++ b/agents/.agents/skills/project-tooling-review/references/static-analysis.md
@@ -1,0 +1,50 @@
+# Repository-Owned Static Analysis Review
+
+Use this reference for Semgrep, Opengrep, or similar repository-owned rule
+configuration and fixtures.
+
+## Ownership
+
+- Identify the narrow invariant each rule owns before editing it.
+- Do not duplicate a structured parser or domain validator with a weaker text
+  rule. Let parsers own schema, type, uniqueness, and graph invariants; use
+  static analysis for recognizable policy-breaking source patterns.
+- Preserve an existing rule ID when broadening the same invariant so SARIF
+  history and suppressions remain stable. Introduce a new ID for a genuinely
+  different policy.
+
+## Rule Design
+
+- Prefer AST-aware language rules for source semantics and bounded regex or
+  generic rules for serialized/configuration text.
+- Keep path includes and excludes explicit, especially for deliberate violation
+  fixtures that normal repository scans must ignore.
+- Bound multiline patterns to the smallest useful construct. Avoid patterns that
+  can drift across unrelated cells, documents, jobs, or declarations.
+- Use YAML block scalars deliberately. Strip the trailing newline with `|-` when
+  it is not part of the intended regex.
+- Keep messages actionable: identify the approved replacement, owner, or
+  workflow rather than only naming the forbidden pattern.
+
+## Fixtures
+
+- Add at least one `ruleid` case for each new behavior and one `ok` case for the
+  closest approved form.
+- Exercise meaningful variants, such as single-line/multiline syntax, canonical
+  paths, generated IDs, or direct versus parameterized destinations.
+- Use the annotation syntax recognized by the fixture harness even when the
+  fixture's native comment syntax differs.
+
+## Validation
+
+Run these layers in order when the repository provides them:
+
+1. configuration/schema validation
+2. the focused fixture suite
+3. the real repository scan to detect false positives
+4. the repository's matching configuration/documentation validators
+
+Do not treat fixture success as sufficient: a rule can match its synthetic case
+and still be too broad for real code. Conversely, do not remove a useful rule
+only because an unrelated pre-existing violation exists; narrow paths or migrate
+the baseline deliberately.


### PR DESCRIPTION
- Validate stable, unique notebook cell IDs and expose them in summaries.
- Keep routine notebook review lint-only and clarify generated artifact ownership.
- Extend tooling reviews with static-analysis rules, fixtures, and delaunay-specific guidance.