### PR TITLE
Added: Skill metadata validation and C++ production review

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,10 @@ To add a skill:
 
 1. create `agents/.agents/skills/<skill-id>/SKILL.md`;
 2. add YAML frontmatter with `name` and a triggering `description`;
-3. add `agents/.agents/skills/<skill-id>/agents/openai.yaml` with
-   `display_name`, a 25–64 character `short_description`, and a
-   `default_prompt` that explicitly mentions `$skill-id`;
+3. add `agents/.agents/skills/<skill-id>/agents/openai.yaml` with a required
+   `interface` mapping containing `display_name`, a 25–64 character
+   `short_description`, and a `default_prompt` that explicitly mentions
+   `$skill-id`;
 4. validate and re-stow the package:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -226,7 +226,10 @@ To add a skill:
 
 1. create `agents/.agents/skills/<skill-id>/SKILL.md`;
 2. add YAML frontmatter with `name` and a triggering `description`;
-3. validate and re-stow the package:
+3. add `agents/.agents/skills/<skill-id>/agents/openai.yaml` with
+   `display_name`, a 25–64 character `short_description`, and a
+   `default_prompt` that explicitly mentions `$skill-id`;
+4. validate and re-stow the package:
 
 ```sh
 just skill-check agents/.agents/skills/<skill-id>

--- a/agents/.agents/skills/academic-authorship-boundary/SKILL.md
+++ b/agents/.agents/skills/academic-authorship-boundary/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: academic-authorship-boundary
-description: Preserve human authorship for scholarly writing. Use when working on Adam's Praxis, theses, papers, manuscripts, publication drafts, academic sections, reviewer responses, or any request that involves text intended to appear under Adam's name. Also use when asked to outline, critique, review, proofread, cite-check, structure, or build academic writing while avoiding AI-authored prose.
+description: "Preserve human authorship for scholarly work. Use for Adam's Praxis, theses, papers, manuscripts, publication drafts, reviewer responses, or requests to outline, critique, proofread, cite-check, or structure academic writing without generating prose that will appear under Adam's name."
 ---
 
 # Academic Authorship Boundary

--- a/agents/.agents/skills/changelog-commit-message/SKILL.md
+++ b/agents/.agents/skills/changelog-commit-message/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-commit-message
-description: "Write repository-aware commit messages from staged changes that parse into useful Keep a Changelog entries. USE FOR: generating a commit message, writing a changelog-friendly commit, summarizing staged changes, Conventional Commits, git-cliff/release-plz/cocogitto-compatible messages, semver-sensitive commit messages, deciding commit type/scope/body/footer from staged diffs. DO NOT USE FOR: making code changes, staging files, committing unless explicitly asked, generic prose summaries, PR descriptions, or repositories without staged changes unless the user explicitly asks to draft from unstaged changes."
+description: "Write repository-aware commit messages from staged changes that produce useful Keep a Changelog entries. Use for Conventional Commits, semver-sensitive type/scope/body/footer decisions, and git-cliff, release-plz, or cocogitto compatibility. Do not stage or commit unless explicitly asked."
 ---
 
 # changelog-commit-message

--- a/agents/.agents/skills/codecov-test-gaps/SKILL.md
+++ b/agents/.agents/skills/codecov-test-gaps/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codecov-test-gaps
-description: "Review the latest GitHub Actions run for .github/workflows/codecov.yml, inspect the Codecov/coverage report, and add missing tests when uncovered code represents meaningful behavior; supports whole-repo coverage baseline audits when explicitly requested. USE FOR: Codecov report review, latest codecov.yml workflow run, coverage regression investigation, uncovered lines/branches, missing tests from CI coverage, GitHub Actions coverage artifacts, adding tests to improve coverage, deciding whether a coverage gap is worth testing. DO NOT USE FOR: generic test review without Codecov data (use language-specific test-quality skills), writing superficial coverage-only tests, changing production code solely to satisfy coverage, unrelated CI failures, or repositories without a Codecov workflow unless the user asks to adapt the workflow."
+description: "Inspect the latest .github/workflows/codecov.yml run and coverage report, then add tests for meaningful uncovered behavior. Use for Codecov regressions, uncovered lines or branches, CI coverage artifacts, and deciding whether a gap deserves a test. Do not write superficial coverage-only tests or alter production behavior solely for coverage."
 ---
 
 # codecov-test-gaps

--- a/agents/.agents/skills/course-study-workflow/SKILL.md
+++ b/agents/.agents/skills/course-study-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: course-study-workflow
-description: "Create and maintain course study artifacts from lectures, slides, textbooks, readings, assignments, notes, and practice questions. USE FOR: lecture outlines, topic outlines, study summaries, quiz or exam prep, practice quizzes/exams, grading responses, repair notes for weak concepts, cumulative midterm/final review, allowed exam sheets, formula sheets, topic sheets, oral exam review, and course-specific source-to-summary workflows. Use when Codex needs to preserve a Markdown outline as the source of truth and derive LaTeX, PDF, DOCX, slide, quiz, or exam-sheet artifacts from it."
+description: "Create and maintain Markdown-first course study artifacts from lectures, slides, readings, assignments, notes, and practice questions. Use for outlines, summaries, quiz or exam preparation, practice assessments, repair notes, formula sheets, and derived LaTeX, PDF, DOCX, or slide materials."
 ---
 
 # Course Study Workflow

--- a/agents/.agents/skills/cpp-production-review/SKILL.md
+++ b/agents/.agents/skills/cpp-production-review/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: cpp-production-review
+description: "Review C++ source, headers, tests, and code-facing build configuration for production readiness. Use for C++23 modernization, correctness and undefined behavior, lifetime and ownership, API and invariant design, numerical robustness, concurrency, performance, portability, dependency migrations, deletion, and test quality. Route build-system and CI mechanics to project-tooling-review."
+---
+
+# C++ Production Review
+
+Review C++ as production code whose correctness, portability, and maintenance life matter. Assume C++23 unless the repository declares another standard.
+
+Prioritize observable defects, undefined behavior, broken invariants, and release risks over stylistic churn. Prefer deletion and standard-library facilities when they reduce real complexity, but do not modernize code merely to demonstrate newer syntax.
+
+## Ground Rules
+
+- Read repository-local guidance before reviewing or editing.
+- Do not mutate git state unless the user explicitly requests it.
+- Honor a parent orchestrator's handed-off scope instead of silently narrowing it.
+- Default to changed C++ files and the nearby code needed to understand their contracts.
+- Use whole-repository baseline mode only when the user explicitly requests a repository-wide, release-readiness, or baseline audit.
+- Keep diagnostic reviews read-only. When fixes are requested, make minimal fixes pass by pass and validate each pass before continuing.
+- Verify current compiler, standard-library, dependency, and tool behavior from authoritative sources when currentness matters. Do not rely on memory for version claims.
+- Treat passing compilation as necessary but insufficient evidence. Tests, sanitizers, static analysis, and invariant reasoning find different classes of defects.
+
+## Scope and Trace
+
+At the start, record:
+
+- scope mode and the source, header, and test files in scope
+- declared C++ standard and supported compiler/standard-library combinations
+- build configurations and validators available locally and in CI
+- dependency upgrades or removals under consideration
+- untracked or user-owned work that must remain untouched
+
+When invoked by a repository orchestrator, provide table-ready evidence naming the files inspected, pass groups applied, findings or explicit no-finding results, fixes, and validators.
+
+## Review Order
+
+Run applicable passes in this order. Complete the evidence and focused validation for one pass before moving to the next when edits are authorized.
+
+### 1. Language, Build, and Dependency Contract
+
+Establish what the code actually compiles against.
+
+Check:
+
+- targets request C++23 consistently and do not depend on accidental global flags
+- the claimed minimum GCC, Clang, AppleClang, MSVC, libstdc++, and libc++ versions implement every used C++23 facility
+- source files include what they use and do not receive dependencies through transitive includes
+- preprocessor definitions, assertion settings, exception/RTTI settings, and release/debug differences do not silently alter correctness
+- dependency APIs used by the code match the versions the build resolves
+- compiler extensions are disabled unless deliberately required
+
+For dependency upgrades:
+
+1. Inventory every include and symbol used from each dependency.
+2. Compare declared dependencies with actual target usage.
+3. Read the upstream release notes, migration guide, and current API documentation.
+4. Separate source migration, semantic behavior changes, and build-system changes.
+5. Upgrade one dependency boundary at a time when practical.
+6. Compile and test after each boundary change.
+7. Remove a dependency only after all uses and transitive assumptions are gone.
+
+Flag unpinned or externally hidden dependency resolution as a reproducibility risk, but leave registry and lockfile mechanics to project tooling.
+
+### 2. Correctness, Lifetime, and Undefined Behavior
+
+Treat undefined behavior and lifetime errors as release blockers.
+
+Check:
+
+- every object, reference, pointer, iterator, view, span, and callable wrapper has a valid lifetime
+- container mutation cannot invalidate references or iterators that remain in use
+- ownership is explicit and resources use RAII
+- constructors establish complete valid states and destructors are correct for polymorphic bases
+- values are initialized on every path
+- indexing, pointer arithmetic, shifts, signed overflow, narrowing, and size conversions are safe
+- casts preserve alignment, aliasing, constness, and dynamic-type requirements
+- lambdas do not outlive captured references
+- exception paths, early returns, and allocation failures cannot leak resources or leave partial mutation
+- C APIs, varargs, formatting, and raw memory operations use correct types and bounds
+- assertions do not replace validation for reachable external input
+
+Require a local safety argument for unavoidable raw ownership, placement construction, union tricks, FFI, or other code whose correctness is not apparent from the type system.
+
+### 3. Invariants and State Transitions
+
+Check:
+
+- domain invariants are stated near the owning type and enforced at construction or mutation boundaries
+- invalid states cannot be created by ordinary public API use
+- coordinated fields update atomically from the caller's perspective
+- failed operations preserve the prior valid state or document a deliberate destructive contract
+- cached, derived, adjacency, orientation, indexing, topology, and bookkeeping state cannot drift from canonical storage
+- sentinel values and magic integers are replaced by types or explicit optional state where that improves correctness
+
+Trace mutation-heavy operations through complete success and failure paths. For graph, mesh, topology, or simulation code, review operation sequences rather than isolated calls.
+
+### 4. Numerical and Scientific Robustness
+
+Treat numerical behavior as correctness, not polish.
+
+Check:
+
+- units, dimensions, sign conventions, orientation, and boundary conditions are explicit and consistent
+- integer counts and combinatorial expressions cannot overflow at supported problem sizes
+- floating-point equality is used only when exact equality is intended
+- tolerances are scale-aware and justified
+- non-finite values, cancellation, underflow, overflow, and near-degenerate inputs are handled
+- random-number engines and distributions have explicit ownership, seeding, reproducibility, and concurrency semantics
+- parallel or reordered evaluation does not invalidate reproducibility claims
+- tests use independent expected results where feasible rather than reimplementing the same algorithm
+
+Do not endorse scientific claims solely because code compiles or regression snapshots remain unchanged.
+
+### 5. API and Type Design
+
+Review public and cross-module interfaces as long-lived contracts.
+
+Check:
+
+- public surface area is minimal and cohesive
+- types encode important invariants and units
+- ownership and nullability are visible in signatures
+- `const`, value categories, forwarding, and move behavior match the contract
+- parameters avoid unnecessary copies without introducing dangling views
+- return values make failure and absence explicit
+- exceptions, error values, and process termination have deliberate boundaries
+- templates and concepts constrain the intended operations and produce actionable diagnostics
+- virtual interfaces have correct destruction, override, and ownership semantics
+- implementation details and storage layout are not exposed without need
+
+Prefer simple value types and ordinary functions over elaborate abstraction. Do not force fluent, generic, or metaprogrammed designs where they obscure invariants.
+
+### 6. Concurrency and Reentrancy
+
+Apply when threads, task systems, parallel algorithms, global state, caches, or shared random-number generators are present.
+
+Check:
+
+- data-race freedom and happens-before relationships are demonstrable
+- mutex scope and lock ordering avoid deadlocks and excessive contention
+- atomics use the weakest correct ordering with a written invariant
+- task lifetimes cannot outlive referenced state
+- cancellation and exceptions cannot strand partial work
+- logging, RNGs, caches, and singleton state are thread-safe or explicitly thread-confined
+- parallelism preserves required ordering and determinism
+
+Do not recommend parallelization before the sequential invariant and measurement baseline are sound.
+
+### 7. Performance and Allocation
+
+Make performance findings concrete.
+
+Check:
+
+- time and space complexity match expected workloads
+- hot loops avoid accidental allocation, formatting, synchronization, virtual dispatch, and repeated lookup
+- copies and moves of large structures are intentional
+- containers and data layout fit dominant access patterns
+- capacities are reserved when sizes are predictable
+- views such as `std::span` or ranges improve traversal without creating lifetime hazards
+- benchmarks isolate the operation and prevent optimization artifacts
+
+Do not trade correctness or clarity for speculative micro-optimization. Require measurement for non-obvious performance rewrites.
+
+### 8. C++23 Simplification and Deletion
+
+Use C++23 to remove complexity where support is real across the declared compiler matrix.
+
+Consider standard facilities such as `std::span`, `std::string_view`, ranges, concepts, `std::expected`, `std::optional`, `std::variant`, `std::format`, `std::print`, `std::filesystem`, `std::chrono`, and scoped algorithms when they replace custom or third-party machinery cleanly.
+
+Check before replacing:
+
+- compiler and standard-library availability on every supported platform
+- semantic differences, especially allocation, ownership, formatting, locale, time-zone, and error behavior
+- performance and binary-size impact
+- whether the existing dependency supplies functionality not covered by C++23
+
+Identify and classify:
+
+- unreachable or unbuilt source files
+- commented-out implementations and stale feature branches embedded in code
+- duplicate executables, wrappers, helpers, and tests
+- declarations or dependencies with no actual use
+- compatibility workarounds for unsupported compiler versions
+- debug output or generated artifacts accidentally committed
+
+Prefer deletion when a surface is unsupported, untested, and superseded. Preserve historically or scientifically important artifacts in documentation or release notes rather than keeping dead production paths.
+
+### 9. Tests and Diagnostics
+
+Check:
+
+- tests assert behavior and invariants rather than merely execute code
+- negative tests verify exit status or structured errors, not only matching output text
+- deterministic unit tests cover empty, boundary, invalid, degenerate, and large inputs
+- randomized tests record seeds and validate invariants after operation sequences
+- regression tests exist for fixed defects
+- concurrency tests do not depend on timing alone
+- release and debug configurations both receive meaningful coverage
+- warnings, sanitizer reports, and static-analysis findings fail validation rather than being marked successful
+- logging does not hide errors, leak sensitive paths/data, or dominate hot loops
+
+Use property, fuzz, or model-based testing for parsers, topology mutations, state machines, and serialization when their risk justifies it.
+
+## Validation
+
+Choose the strongest focused validators the repository already supports. For a release baseline, prefer:
+
+1. clean configure and build with the primary supported compiler
+2. complete tests with failures propagated
+3. a second supported compiler or platform configuration
+4. warnings-as-errors for project code where dependencies are isolated as system headers
+5. AddressSanitizer plus UndefinedBehaviorSanitizer
+6. ThreadSanitizer for concurrent code
+7. MemorySanitizer or Valgrind where practical
+8. clang-tidy, cppcheck, or the repository's static-analysis contract
+9. release-mode smoke tests of shipped executables
+
+Record commands, compiler and dependency versions, pass/fail status, and any validator intentionally not run. Do not claim platform support from a configuration file alone.
+
+## Finding Severity
+
+- **P0 — Release blocker:** build failure, undefined behavior, data race, memory/resource safety defect, invariant corruption, scientifically invalid result, or tests that cannot detect failure.
+- **P1 — Must fix for production:** reachable wrong behavior, non-reproducible dependency/build contract, unsafe error handling, serious portability failure, or untested critical path.
+- **P2 — High-value improvement:** meaningful API, maintainability, performance, diagnostic, or test improvement that need not block a preserved legacy release.
+- **P3 — Optional:** low-risk cleanup or stylistic modernization. Keep this category small.
+
+For every finding, provide file and line evidence, the failure scenario, why it matters, and the smallest credible remediation. Distinguish confirmed defects from hypotheses requiring a validator or platform that is unavailable.
+
+## Final Report
+
+Lead with unresolved P0/P1 findings. Include:
+
+- release-readiness verdict
+- findings ordered by severity with file/line evidence
+- deletion and dependency-removal candidates, with proof still required
+- dependency migration risks and source changes expected
+- validators run and exact results
+- supported-platform claims actually demonstrated
+- intentionally deferred work and residual risk
+- files changed, if fixes were authorized
+- confirmation that no git state mutation occurred, when true

--- a/agents/.agents/skills/cpp-production-review/agents/openai.yaml
+++ b/agents/.agents/skills/cpp-production-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "C++ Production Review"
+  short_description: "Senior C++23 production review"
+  default_prompt: "Use $cpp-production-review to review C++23 code for correctness, safety, invariants, performance, portability, and test quality."

--- a/agents/.agents/skills/docs-review-orchestrator/SKILL.md
+++ b/agents/.agents/skills/docs-review-orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-review-orchestrator
-description: "Coordinate documentation review and fixes for software, infrastructure, operations, and scientific repositories. Use for branch, staged, changed-file, release-readiness, or whole-repo reviews that span an active documentation suite, generated-doc ownership, Rust API docs, scientific crate metadata, citations, or publication boundaries. Always route generic repository documentation to repository-docs-review; add scientific-crate-docs-review, rust-api-docs, scientific-citation-audit, or academic-authorship-boundary only when their actual files or claims are in scope."
+description: "Coordinate multi-pass documentation reviews across active repository docs, generated-doc ownership, Rust API docs, scientific crate metadata, citations, and academic publication boundaries. Use for branch, staged, release-readiness, or repository-wide documentation work requiring more than one focused documentation skill."
 ---
 
 # Documentation Review Orchestrator

--- a/agents/.agents/skills/github-issue-planning/SKILL.md
+++ b/agents/.agents/skills/github-issue-planning/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-issue-planning
-description: "Plan and maintain GitHub issue ordering with native dependency metadata, Projects v2 fields, labels, and milestones. USE FOR: reordering issues, fixing Blocking/Is blocked by relationships, dependency graphs, milestone triage, label hygiene, project metadata, release planning, roadmap sequencing, blocked-by cycles, GitHub issue planning. DO NOT USE FOR: editing code, pull request review, CI debugging, generic issue body edits, or dependency notes that should remain plain markdown unless the user explicitly asks for body text."
+description: "Plan and maintain GitHub issues using native dependency metadata, Projects v2 fields, labels, and milestones. Use for ordering work, Blocking/Is blocked by relationships, dependency cycles, milestone triage, roadmap sequencing, and project metadata. Do not edit code or substitute body prose for native metadata."
 ---
 
 # github-issue-planning

--- a/agents/.agents/skills/github-issue-planning/SKILL.md
+++ b/agents/.agents/skills/github-issue-planning/SKILL.md
@@ -19,7 +19,9 @@ bodies; inspect the source of truth before editing.
 - If the user mentions "blocked", "blocking", "is blocked by", or issue
   ordering, assume native GitHub issue dependencies may be involved.
 
-Use `gh` only for repository metadata. Do not edit issue bodies unless the user
+Use `gh` only for repository and issue metadata, including the dependency,
+label, and milestone operations described below. Do not edit code. Do not edit
+issue bodies or substitute body prose for native metadata unless the user
 explicitly asks for text changes.
 
 ### 2. Inspect current issue metadata

--- a/agents/.agents/skills/jupyter-notebook-review/SKILL.md
+++ b/agents/.agents/skills/jupyter-notebook-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jupyter-notebook-review
-description: "Review and fix Jupyter notebooks for reproducible execution, sound Python style, Polars-first dataframe workflows, and reliable Plotly/Matplotlib visualization. USE FOR: .ipynb review, notebook cleanup, hidden-state fixes, clearing outputs, headless execution failures, uv/Jupyter environment setup, converting pandas-style notebook code to Polars, improving CSV/Parquet/JSON loading, plotting diagnostics, notebook CI checks, and notebook front ends that wrap binaries or APIs. DO NOT USE FOR: ordinary Python package review without notebooks; scientific/numerical correctness review beyond notebook hygiene; slide/document/spreadsheet artifacts."
+description: "Review and fix Jupyter notebooks for reproducible execution, Python quality, Polars-first data workflows, and reliable Plotly or Matplotlib output. Use for .ipynb cleanup, hidden state, output clearing, headless execution, notebook environments, data loading, plotting diagnostics, and notebook CI. Route reusable scientific logic to its focused reviewer."
 ---
 
 # jupyter-notebook-review

--- a/agents/.agents/skills/project-tooling-review/SKILL.md
+++ b/agents/.agents/skills/project-tooling-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: project-tooling-review
-description: "Review and fix repository tooling surfaces that define how maintainers run, validate, and update a project. Use for justfile recipe design, GitHub Actions workflows, CI command drift, repository-owned Semgrep/static-analysis rules and fixtures, tool-version and installer drift, uv tool and cargo-install managed CLI updates, Brewfile and uv/cargo/rustup tooling configuration, lint/format/type-check command surfaces, release/support scripts wiring, docs that describe project commands, and cross-language validation recipes. Use when the user asks to review project tooling, just recipes, CI workflows, GitHub Actions, static analysis, tool versions, command consistency, or repository workflow ergonomics. Do not use for Rust or Python source review except where tooling invokes those validators; use the language orchestrators for code behavior. Do not use for requests to commit, stage, push, tag, or otherwise mutate git state."
+description: "Review and fix repository tooling: just recipes, GitHub Actions, CI command drift, repository-owned static analysis, tool versions, installers, linters, formatters, type checks, support scripts, and command documentation. Use for tooling workflow correctness and maintainer ergonomics; route application behavior to the appropriate language reviewer."
 ---
 
 # project-tooling-review

--- a/agents/.agents/skills/python-cli-review/SKILL.md
+++ b/agents/.agents/skills/python-cli-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: python-cli-review
-description: "Review general Python CLI and application code for correctness, user-facing behavior, privacy-sensitive output, parsing robustness, filesystem safety, and pytest coverage. USE FOR: Python command-line tools, single-file apps, parsers, date/time handling, local file import/export, stdout/stderr behavior, argparse/Click/Typer interfaces, and non-scientific application logic. DO NOT USE FOR: Python support tooling such as changelog/release/CI scripts (use python-support-scripts); numerical, geometric, statistical, or scientific code (use python-scientific-review); test-only quality audits (use python-test-quality); Rust code review; formatting-only cleanup; or unrelated unchanged code unless a baseline audit is requested."
+description: "Review Python CLI and application code for correctness, user-visible behavior, privacy-sensitive output, parsing, date/time handling, filesystem safety, and pytest coverage. Use for argparse, Click, Typer, local import or export, stdout/stderr contracts, and non-scientific application logic. Route scientific code and development support scripts to their focused skills."
 ---
 
 # python-cli-review

--- a/agents/.agents/skills/python-parse-dont-validate/SKILL.md
+++ b/agents/.agents/skills/python-parse-dont-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: python-parse-dont-validate
-description: "Audit Python code for parse-don't-validate design, type-checkable invariants, boundary parsing, typed configuration/report models, dataclasses/attrs/Pydantic validation, Enum/Literal/NewType/refined wrappers, and mypy/pyright-friendly invalid-state prevention. Use for Python reviews asking whether raw dicts, strings, floats, counts, paths, subprocess output, JSON/CSV/TOML/YAML, CLI args, or optional fields should be parsed into validated domain types before computation. Do not use for general Python style, test quality, or scientific numerical correctness unless the issue is invariant storage or discarded validation evidence."
+description: "Audit Python boundary parsing and invalid-state prevention. Use for raw dictionaries, strings, counts, paths, optionals, CLI arguments, environment variables, subprocess output, JSON, CSV, TOML, YAML, dataclasses, attrs, Pydantic, Enum, Literal, NewType wrappers, and type-checkable domain invariants. Do not use for general style or numerical correctness."
 ---
 
 # Python Parse Don't Validate

--- a/agents/.agents/skills/python-review-orchestrator/SKILL.md
+++ b/agents/.agents/skills/python-review-orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: python-review-orchestrator
-description: "Coordinate a structured Python code-review-and-fix workflow by loading named Python skills in sequence, grouping them by notebook, boundary, scientific, support-tooling, validation, and synthesis concerns, applying fixes pass by pass, and choosing focused validators from changed files. Use when the user asks for a Python review suite, repo-wide Python review, whole-repo baseline audit, staged/changed Python review, notebook-and-script cleanup, or 'fix all' across multiple Python review skills. Also use when the user wants focused Python skills applied in order with fixes and validation before moving to the next skill. Do not use when there is no Python code, notebook, pytest, Python config, data fixture, or Python workflow impact; for single-purpose reviews that name only one focused Python skill; or for requests to commit, stage, push, tag, or otherwise mutate git state."
+description: "Coordinate multi-pass Python reviews by selecting focused skills for notebooks, CLI and boundary behavior, scientific code, support tooling, and tests. Use for changed, staged, PR, release-readiness, repository-wide, or fix-all Python work spanning multiple concerns. Use a focused Python skill directly for single-concern reviews."
 ---
 
 # python-review-orchestrator

--- a/agents/.agents/skills/python-scientific-review/SKILL.md
+++ b/agents/.agents/skills/python-scientific-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: python-scientific-review
-description: "Perform rigorous senior-level review of Python that implements numerical, geometric, statistical, or scientific-computing logic alongside a Rust crate on changed code or whole-repo baseline audits when explicitly requested. USE FOR: Python that implements numerical/geometric/statistical/topological algorithms, validates Rust numerical output, checks reproducibility of scientific results, generates scientific fixtures (point clouds, meshes, distributions), audits NumPy/SciPy correctness, reviews Hypothesis property tests over numerical inputs, or checks Rust interoperability for numerical formats (coordinates, indexing, dtypes). DO NOT USE FOR: changelog generators, benchmark runners, release helpers, CI scripts, fixture/diagnostic CLIs, or other Python support tooling (use python-support-scripts); general Python web/app code; formatting-only cleanup; Rust code review (use rust-production-review or other Rust skills); or unrelated unchanged code unless a baseline audit is requested."
+description: "Review Python numerical, geometric, statistical, or scientific-computing code for correctness, reproducibility, robust NumPy or SciPy use, scientific fixtures, property tests, and Rust interoperability. Use for scientific algorithms and validation code; route release helpers, benchmark runners, and other development tooling to python-support-scripts."
 ---
 
 # python-scientific-review

--- a/agents/.agents/skills/python-scientific-review/agents/openai.yaml
+++ b/agents/.agents/skills/python-scientific-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Python Scientific Review"
+  short_description: "Review scientific Python correctness"
+  default_prompt: "Use $python-scientific-review to review this Python scientific code for numerical correctness, reproducibility, and robust validation."

--- a/agents/.agents/skills/python-support-scripts/SKILL.md
+++ b/agents/.agents/skills/python-support-scripts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: python-support-scripts
-description: "Review Python support scripts and dev tooling that live alongside Rust crates on changed code or whole-repo baseline audits when explicitly requested: changelog generators, benchmark runners, release helpers, CI scripts, and fixture/diagnostic utilities. USE FOR: Python that parses commit messages, runs cargo bench/Criterion and aggregates results, generates CHANGELOG.md, scrapes GitHub Actions logs, prepares release artifacts, runs subprocess commands, manipulates Cargo metadata, validates fixtures, or stitches together CI workflows. Focus on transform/parse correctness, determinism, fixture-driven tests, malformed-input handling, subprocess discipline, and CLI ergonomics. DO NOT USE FOR: numerical/geometric/scientific algorithms, NumPy/SciPy correctness, or scientific reproducibility (use python-scientific-review); Rust code review (use rust-production-review or other Rust skills); generic Python web/app code; formatting-only cleanup; unrelated unchanged code unless a baseline audit is requested."
+description: "Review Python development and release tooling for transform correctness, determinism, malformed-input handling, subprocess discipline, fixture-driven tests, and CLI ergonomics. Use for changelog generators, benchmark runners, release helpers, CI scripts, Cargo metadata tools, GitHub Actions diagnostics, and fixture utilities. Route scientific algorithms to python-scientific-review."
 ---
 
 # python-support-scripts

--- a/agents/.agents/skills/python-support-scripts/agents/openai.yaml
+++ b/agents/.agents/skills/python-support-scripts/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Python Support Scripts"
+  short_description: "Review Python development tooling"
+  default_prompt: "Use $python-support-scripts to review these Python development scripts for deterministic behavior, robust parsing, and safe subprocess use."

--- a/agents/.agents/skills/python-test-quality/SKILL.md
+++ b/agents/.agents/skills/python-test-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: python-test-quality
-description: "Evaluate Python tests and Python code for meaningful pytest coverage, behavior assertions, fixture quality, CLI/file I/O boundaries, parser/date-time edge cases, and error-path testing on changed code or whole-repo baseline audits when explicitly requested. USE FOR: Python test review, missing pytest cases, weak assertions, brittle fixtures, coverage gaps that need behavior tests, CLI output capture, tmp_path/monkeypatch/capsys usage, parametrized boundary tests, exception and malformed-input coverage. DO NOT USE FOR: numerical/scientific correctness (use python-scientific-review); Rust-adjacent support scripts and release tooling (use python-support-scripts); Codecov report triage itself (use codecov-test-gaps); formatting-only cleanup; unrelated unchanged code unless a baseline audit is requested."
+description: "Review Python tests for meaningful behavior coverage, assertion quality, fixtures, CLI and file-I/O boundaries, parser and date/time edge cases, and error paths. Use for pytest, parametrization, tmp_path, monkeypatch, capsys, malformed inputs, and focused coverage gaps. Route Codecov report triage to codecov-test-gaps."
 ---
 
 # python-test-quality

--- a/agents/.agents/skills/python-test-quality/agents/openai.yaml
+++ b/agents/.agents/skills/python-test-quality/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Python Test Quality"
+  short_description: "Review pytest behavior and coverage"
+  default_prompt: "Use $python-test-quality to review these Python tests for meaningful behavior coverage, strong assertions, and robust fixtures."

--- a/agents/.agents/skills/repo-review/SKILL.md
+++ b/agents/.agents/skills/repo-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-review
-description: "Coordinate a repo review-and-fix workflow by routing branch changes or explicit whole-repo baseline checkpoints to rust-review-orchestrator, python-review-orchestrator, project-tooling-review, and docs-review-orchestrator as needed, then synthesizing cross-surface validation. Use when the user asks for branch, PR, repo-wide, staged, changed, clean-repo checkpoint, full repo review as-is, whole-repo baseline, or mixed Rust/Python/tooling/documentation review; repository review suites; release-readiness reviews; or fix-all work across code, tooling, and documentation. Do not use for single-surface requests that clearly name only Rust, Python, notebooks, documentation, citations, Justfile, GitHub Actions, or tool-version review; use the focused skill directly. Do not use for commit, stage, push, tag, checkout, reset, stash, or other git-state mutations."
+description: "Coordinate review-and-fix work across Rust, Python, project tooling, and documentation. Use for branch, PR, staged, release-readiness, repository-wide, or fix-all reviews spanning multiple surfaces, and route each surface to its focused orchestrator. Use a focused skill directly for single-language or single-surface reviews."
 ---
 
 # repo-review

--- a/agents/.agents/skills/repository-docs-review/SKILL.md
+++ b/agents/.agents/skills/repository-docs-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repository-docs-review
-description: "Review and fix an active repository documentation suite without assuming a programming language or scientific domain. Use for branch, staged, changed-file, release-readiness, or whole-repo reviews spanning README, AGENTS, CONTRIBUTING, SECURITY, CODE_OF_CONDUCT, docs/**, runbooks, architecture guides, ADRs, navigation, support docs, generated-document ownership, and cross-document consistency. Route command truth, language behavior, Rust API docs, scientific citations, scientific Rust release metadata, and scholarly manuscript prose to their focused owners when those surfaces are actually present."
+description: "Review and fix an active repository documentation suite for navigation, operational clarity, generated-file ownership, and cross-document consistency. Use for README, AGENTS, CONTRIBUTING, SECURITY, codes of conduct, docs/**, runbooks, architecture guides, and ADRs. Route command truth, language behavior, citations, Rust API docs, and scholarly prose to their focused owners."
 ---
 
 # Repository Documentation Review
@@ -100,6 +100,13 @@ validator when the repository already defines one.
 
 If a check needs unavailable network access or installation, run the strongest local
 substitute and report the remaining gap.
+
+For LaTeX paper checks on macOS, when a repository recipe reports `chktex` as
+missing, check `/Library/TeX/texbin/chktex` before installing another TeX
+distribution. MacTeX may provide the binary outside the inherited `PATH`; when
+present, run the repository recipe with `PATH=/Library/TeX/texbin:$PATH`. Keep
+this to mechanical source/build validation and route manuscript prose through
+the academic-authorship boundary.
 
 ## Specialist Handoffs
 

--- a/agents/.agents/skills/rust-api-docs/SKILL.md
+++ b/agents/.agents/skills/rust-api-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-api-docs
-description: "Audit Rust API documentation for required sections, intra-doc links, crate-level docs, and API-supporting private helper docs on changed APIs or whole-repo baseline audits when explicitly requested. USE FOR: doc comment structure on public API, # Errors / # Panics / # Safety / # Examples sections, intra-doc links, crate-level //! overviews, module-level docs, changed private helpers that encode public API behavior, missing or weak descriptions, deny(missing_docs) and broken_intra_doc_links lint configuration, semver-relevant doc updates, docs.rs feature visibility. DO NOT USE FOR: doctest test quality (use rust-test-quality), broad private helper documentation audits unrelated to API behavior (use rust-test-quality), error variant design (use rust-error-variants), trait bound docs (use rust-trait-bounds), non-Rust code, or unrelated unchanged APIs unless a baseline audit is requested."
+description: "Audit Rust API documentation for completeness, required Errors, Panics, Safety, and Examples sections, intra-doc links, crate and module docs, docs.rs visibility, and API-supporting private helper docs. Use for public documentation coverage and semver-relevant doc changes; route doctest behavior to rust-test-quality."
 ---
 
 # rust-api-docs

--- a/agents/.agents/skills/rust-api-docs/agents/openai.yaml
+++ b/agents/.agents/skills/rust-api-docs/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust API Docs"
+  short_description: "Audit Rust API documentation quality"
+  default_prompt: "Use $rust-api-docs to audit this Rust public API for complete documentation, required sections, and valid intra-doc links."

--- a/agents/.agents/skills/rust-cargo-hygiene/SKILL.md
+++ b/agents/.agents/skills/rust-cargo-hygiene/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-cargo-hygiene
-description: "Audit Cargo.toml, feature flags, MSRV, lints, and crate-level configuration for release readiness on changed manifests or whole-repo baseline audits when explicitly requested. USE FOR: Cargo.toml review, feature flag design, default-features gating, dev/build/runtime dependency placement, dependency version specifiers, MSRV pin, edition, [lints] table, clippy.toml/rustfmt.toml, crate-level deny/warn lints (including unsafe_code = forbid), workspace inheritance, [package.metadata.docs.rs] config, semver-sensitive Cargo manifest changes, preparing a crate release. DO NOT USE FOR: source-level Rust review (use rust-production-review or other Rust skills), CI/CD workflow logic, non-Rust packaging, or unrelated unchanged manifests unless a baseline audit is requested."
+description: "Audit Cargo manifests and crate configuration for release readiness. Use for feature flags, default-features gating, dependency placement and versions, MSRV, edition, workspace inheritance, lints, rustfmt or clippy configuration, docs.rs metadata, crate-level lint policy, and semver-sensitive manifest changes. Route CI workflow logic to project-tooling-review."
 ---
 
 # rust-cargo-hygiene

--- a/agents/.agents/skills/rust-cargo-hygiene/agents/openai.yaml
+++ b/agents/.agents/skills/rust-cargo-hygiene/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Cargo Hygiene"
+  short_description: "Audit Cargo manifests and crate configuration"
+  default_prompt: "Use $rust-cargo-hygiene to audit this crate's Cargo manifests, features, dependencies, MSRV, lints, and release metadata."

--- a/agents/.agents/skills/rust-concurrency-async/SKILL.md
+++ b/agents/.agents/skills/rust-concurrency-async/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-concurrency-async
-description: "Audit Rust concurrency, async, and transactional mutation code for Send/Sync discipline, blocking hazards, lock/channel design, cancellation safety, transaction guard design, and failure atomicity on changed code or whole-repo baseline audits. USE FOR: async/await, Tokio/async-std, Send/Sync bounds, spawn_blocking, cancellation safety, owner-bound transaction guards, rollback-on-drop, rollback-preserving snapshots, restore-before-retry, failure-atomic mutation windows, Mutex/RwLock/parking_lot/tokio::sync, atomics, channels, lock ordering, deadlocks, deterministic side effects, structured concurrency, async traits/lifetimes, futures, and streams. DO NOT USE FOR: synchronous correctness without concurrency/cancellation/transaction concerns (use rust-production-review), error design (use rust-error-variants), trait bounds (use rust-trait-bounds), iterators (use rust-iter-control-flow), non-Rust code, or unrelated unchanged code unless a baseline audit is requested."
+description: "Audit Rust concurrency, async, and transactional mutation for Send/Sync discipline, blocking hazards, locks, channels, atomics, cancellation safety, structured concurrency, rollback guards, and failure atomicity. Use for Tokio or async-std, task lifetimes, lock ordering, deadlocks, async traits, futures, streams, and owner-bound transactions."
 ---
 
 # rust-concurrency-async

--- a/agents/.agents/skills/rust-concurrency-async/agents/openai.yaml
+++ b/agents/.agents/skills/rust-concurrency-async/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Concurrency and Async"
+  short_description: "Audit Rust concurrency and async safety"
+  default_prompt: "Use $rust-concurrency-async to audit this Rust concurrency or async code for blocking, cancellation, synchronization, and failure-atomicity hazards."

--- a/agents/.agents/skills/rust-error-variants/SKILL.md
+++ b/agents/.agents/skills/rust-error-variants/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-error-variants
-description: "Audit Rust error enums and error pathways for correctness, debuggability, and orthogonality on changed code or whole-repo baseline audits when explicitly requested. USE FOR: Rust review comments asking whether appropriate Error variants were added/used, error enum design, thiserror/Display messages, anyhow/Result mapping, preserving typed errors, adding missing variants, replacing generic validation errors, checking error pathway correctness, ensuring variants are mutually exclusive and actionable. DO NOT USE FOR: general Rust style/naming review (use rust-style-hygiene), test/doctest coverage review (use rust-test-quality), non-Rust code, or unrelated unchanged code unless a baseline audit is requested."
+description: "Audit Rust error enums and pathways for correctness, debuggability, and orthogonality. Use for typed variants, thiserror and Display messages, anyhow or Result mapping, missing or overly generic errors, preserved error evidence, and mutually exclusive actionable failure categories. Route naming-only issues and general test coverage to their focused skills."
 ---
 
 # rust-error-variants

--- a/agents/.agents/skills/rust-error-variants/agents/openai.yaml
+++ b/agents/.agents/skills/rust-error-variants/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Error Variants"
+  short_description: "Audit Rust error enums and pathways"
+  default_prompt: "Use $rust-error-variants to audit these Rust error enums and pathways for typed, actionable, and orthogonal failures."

--- a/agents/.agents/skills/rust-invariant-performance/SKILL.md
+++ b/agents/.agents/skills/rust-invariant-performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-invariant-performance
-description: "Audit Rust code for best practical performance while preserving correctness invariants, parse-don't-validate boundaries, typed errors, safety, and API orthogonality. USE FOR: performance-sensitive Rust crates such as delaunay, la-stack, markov-chain-monte-carlo, and causal-triangulations; hot-path review for numerical, geometric, topological, linear-algebra, probabilistic, sampler, construction, validation, and repair code; allocation and complexity audits; benchmark-guided optimization reviews; PR or whole-repo performance baseline audits where correctness constraints must remain intact. DO NOT USE FOR: performance suggestions that ignore invariants, generic style/import cleanup (use rust-style-hygiene), general production correctness review without a performance focus (use rust-production-review), parse-don't-validate review without a performance focus (use rust-parse-dont-validate), or non-Rust code."
+description: "Audit performance-sensitive Rust while preserving invariants, boundary parsing, typed errors, safety, and API orthogonality. Use for hot numerical, geometric, topological, linear-algebra, probabilistic, construction, validation, and repair paths; allocation and complexity analysis; benchmark-guided optimization; and performance/correctness tradeoffs."
 ---
 
 # rust-invariant-performance

--- a/agents/.agents/skills/rust-iter-control-flow/SKILL.md
+++ b/agents/.agents/skills/rust-iter-control-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-iter-control-flow
-description: "Audit Rust iterator, closure, and pattern-matching control-flow idioms for clarity, allocation discipline, and exhaustiveness on changed code or whole-repo baseline audits when explicitly requested. USE FOR: iterator chain review, collect/try_fold/flat_map decisions, avoiding intermediate Vec collects, closure capture clarity, Fn/FnMut/FnOnce choice, match vs if let vs let else, while let, matches! macro, exhaustive matching, @ bindings, slice patterns, refutable/irrefutable patterns, when imperative loops are clearer than iterator chains. DO NOT USE FOR: trait bounds (use rust-trait-bounds), error variants (use rust-error-variants), async patterns (use rust-concurrency-async), prelude/export decisions (use rust-prelude-exports), non-Rust code, or unrelated unchanged code unless a baseline audit is requested."
+description: "Audit Rust iterator, closure, loop, and pattern-matching control flow for clarity, allocation discipline, and exhaustiveness. Use for collect versus try_fold or flat_map, intermediate allocations, closure capture and Fn traits, match, if-let, or let-else choices, slice patterns, and cases where an imperative loop is clearer."
 ---
 
 # rust-iter-control-flow

--- a/agents/.agents/skills/rust-iter-control-flow/agents/openai.yaml
+++ b/agents/.agents/skills/rust-iter-control-flow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Iterator Control Flow"
+  short_description: "Audit Rust iterator and pattern control flow"
+  default_prompt: "Use $rust-iter-control-flow to review this Rust iterator, closure, loop, and pattern-matching control flow for clarity and allocation discipline."

--- a/agents/.agents/skills/rust-parse-dont-validate/SKILL.md
+++ b/agents/.agents/skills/rust-parse-dont-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-parse-dont-validate
-description: "Audit Rust code for parse-don't-validate design, invariant-bearing types, smart constructors, fallible setters, infallible getters, private fields, and invalid-state prevention on changed code, whole repositories, or pull requests when requested. USE FOR: Rust reviews asking whether invalid values can be stored, whether constructors/builders/setters validate immediately, whether computations can become infallible after validation, whether public fields bypass invariants, whether refined newtypes should encode constraints, whether validation is delayed until use, whole-repo parse-don't-validate baseline audits, or PR audits focused on invariant boundaries. DO NOT USE FOR: general Rust style/import review (use rust-style-hygiene), generic test-quality review (use rust-test-quality), error enum design alone (use rust-error-variants), or non-Rust code."
+description: "Audit Rust for parse-don't-validate design and invalid-state prevention. Use for invariant-bearing types, smart constructors, private fields, fallible setters, infallible getters, refined newtypes, validation evidence, mutation boundaries, and questions about whether invalid values can be stored or delayed validation remains reachable."
 ---
 
 # rust-parse-dont-validate

--- a/agents/.agents/skills/rust-parse-dont-validate/agents/openai.yaml
+++ b/agents/.agents/skills/rust-parse-dont-validate/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Parse Don't Validate"
+  short_description: "Audit Rust invariant-bearing types"
+  default_prompt: "Use $rust-parse-dont-validate to audit this Rust code for invariant-bearing types, boundary parsing, and invalid-state prevention."

--- a/agents/.agents/skills/rust-prelude-exports/SKILL.md
+++ b/agents/.agents/skills/rust-prelude-exports/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-prelude-exports
-description: "Audit Rust prelude modules and public re-export surfaces for minimality, orthogonality, and usability in doctests, integration tests, examples, and benchmarks on changed APIs or whole-repo baseline audits when explicitly requested. USE FOR: Rust review comments asking whether new functionality has appropriate prelude exports, designing crate::prelude modules, scoped preludes (geometry/simulation/testing), public use/re-export decisions, doctest import ergonomics, integration test/example/benchmark import surfaces, avoiding bloated or overlapping preludes. DO NOT USE FOR: Rust naming/import style inside implementation code (use rust-style-hygiene), test quality itself (use rust-test-quality), error design (use rust-error-variants), non-Rust code, or unrelated unchanged APIs unless a baseline audit is requested."
+description: "Audit Rust prelude modules and public re-exports for minimality, orthogonality, and usability. Use for crate or scoped preludes, public use decisions, doctest and example imports, integration-test or benchmark ergonomics, and avoiding bloated or overlapping export surfaces. Route implementation import style to rust-style-hygiene."
 ---
 
 # rust-prelude-exports

--- a/agents/.agents/skills/rust-prelude-exports/agents/openai.yaml
+++ b/agents/.agents/skills/rust-prelude-exports/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Prelude Exports"
+  short_description: "Audit Rust preludes and public re-exports"
+  default_prompt: "Use $rust-prelude-exports to audit this crate's preludes and public re-exports for minimality, orthogonality, and usability."

--- a/agents/.agents/skills/rust-production-review/SKILL.md
+++ b/agents/.agents/skills/rust-production-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-production-review
-description: "Perform a senior-level Rust review for production-quality, performance-critical libraries with strong invariants on changed code or whole-repo baseline audits when explicitly requested. USE FOR: comprehensive Rust code review, systems programming review, computational geometry, topology, linear algebra, numerical algorithms, invariant-heavy data structures, public library API design, semver-sensitive changes, performance-critical correctness review, numerical robustness, ownership/mutability design, concurrency safety, and maintainability. DO NOT USE FOR: surface-only style/naming/import cleanup (use rust-style-hygiene), focused error variant audits (use rust-error-variants), focused test/doctest audits (use rust-test-quality), focused prelude/export audits (use rust-prelude-exports), focused trait-bound cleanup (use rust-trait-bounds), non-Rust code, generated code, or unrelated unchanged code unless a baseline audit is requested."
+description: "Perform a comprehensive production review of Rust libraries with strong invariants or performance requirements. Use for correctness, ownership and mutation design, public API and semver stability, numerical robustness, concurrency safety, performance, and maintainability. Use narrower Rust skills for single-concern style, error, test, export, trait-bound, or documentation reviews."
 ---
 
 # rust-production-review

--- a/agents/.agents/skills/rust-review-orchestrator/SKILL.md
+++ b/agents/.agents/skills/rust-review-orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-review-orchestrator
-description: "Coordinate a structured Rust code-review-and-fix workflow by loading named Rust skills in sequence, grouping them by API, invariant, scientific correctness, implementation, validation, and synthesis concerns, applying fixes pass by pass, and choosing focused validators from changed files. Use when the user asks for a Rust review suite, repo-wide Rust review, whole-repo baseline audit, staged/changed Rust review, or 'fix all' across multiple Rust review skills. Also use when the user wants focused Rust skills applied in order with fixes and validation before moving to the next skill. Do not use when there is no Rust code, Rust API docs, Cargo/test/example/benchmark surface, or Rust workflow impact; for single-purpose reviews that name only one focused Rust skill; or for requests to commit, stage, push, tag, or otherwise mutate git state."
+description: "Coordinate multi-pass Rust reviews by selecting focused skills for APIs, invariants and errors, scientific correctness, implementation, tests, Cargo, and final synthesis. Use for changed, staged, PR, release-readiness, repository-wide, or fix-all Rust work spanning multiple concerns. Use a focused Rust skill directly for single-concern reviews."
 ---
 
 # rust-review-orchestrator

--- a/agents/.agents/skills/rust-scientific-correctness/SKILL.md
+++ b/agents/.agents/skills/rust-scientific-correctness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-scientific-correctness
-description: "Audit Rust scientific and numerical code for mathematical validity, numerical robustness, independent validation, reproducibility, and truthful scientific claims on changed code or whole-repo baseline audits when explicitly requested. USE FOR: scientific Rust crates such as delaunay, la-stack, markov-chain-monte-carlo, and causal-triangulations; floating-point and exact arithmetic; linear algebra; computational geometry or topology; numerical predicates and solvers; probabilistic algorithms; tolerances and error bounds; scientific fixtures; and scientific benchmark validity. DO NOT USE FOR: general production review without a scientific correctness focus (use rust-production-review), performance optimization or benchmark mechanics (use rust-invariant-performance), test mechanics alone (use rust-test-quality), citation metadata or credit completeness (use scientific-citation-audit), or non-Rust scientific code (use python-scientific-review)."
+description: "Audit Rust scientific and numerical code for mathematical validity, numerical robustness, independent validation, reproducibility, and truthful claims. Use for floating-point or exact arithmetic, linear algebra, computational geometry and topology, predicates, solvers, stochastic algorithms, tolerances, error bounds, scientific fixtures, and benchmark validity."
 ---
 
 # Rust Scientific Correctness

--- a/agents/.agents/skills/rust-simplification-review/SKILL.md
+++ b/agents/.agents/skills/rust-simplification-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-simplification-review
-description: "Review Rust code and tests for safe simplification, deletion, deduplication, and redundancy removal in invariant-heavy libraries. USE FOR: Rust review passes focused on simplifying code, deleting dead or redundant helpers, consolidating duplicate tests, shrinking public or crate-internal surfaces, and removing accidental complexity without weakening correctness, domain invariants, API orthogonality, performance, diagnostics, or regression coverage. DO NOT USE FOR: broad production-readiness review (use rust-production-review), surface-only naming/import cleanup (use rust-style-hygiene), focused test coverage audits without simplification goals (use rust-test-quality), non-Rust code, generated code, or unrelated unchanged code unless a baseline simplification audit is requested."
+description: "Review Rust code and tests for safe deletion, deduplication, and simplification without weakening behavior, invariants, API orthogonality, performance, diagnostics, or regression coverage. Use for dead or redundant helpers, duplicate tests, accidental complexity, and unnecessarily broad public or crate-internal surfaces."
 ---
 
 # rust-simplification-review

--- a/agents/.agents/skills/rust-simplification-review/agents/openai.yaml
+++ b/agents/.agents/skills/rust-simplification-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Simplification Review"
+  short_description: "Simplify Rust without weakening behavior"
+  default_prompt: "Use $rust-simplification-review to find safe Rust deletions, deduplication, and simplifications without weakening behavior or coverage."

--- a/agents/.agents/skills/rust-style-hygiene/SKILL.md
+++ b/agents/.agents/skills/rust-style-hygiene/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-style-hygiene
-description: "Enforce idiomatic Rust naming, import usage, and path clarity on changed code or whole-repo baseline audits when explicitly requested. USE FOR: Rust style review, function/method naming critique, import placement and grouping, fully-qualified path simplification, redundant prefix removal (get_, process_, handle_), use-statement organization. DO NOT USE FOR: behavior/correctness review (use rust-test-quality), non-Rust code, generated code, or unrelated unchanged files unless a baseline audit is requested."
+description: "Audit Rust code for idiomatic naming, import placement and grouping, path clarity, redundant prefixes, and unnecessary fully qualified paths. Use for focused style and hygiene reviews; route behavior, correctness, documentation, and test-quality concerns to their focused skills."
 ---
 
 # rust-style-hygiene

--- a/agents/.agents/skills/rust-style-hygiene/agents/openai.yaml
+++ b/agents/.agents/skills/rust-style-hygiene/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Style Hygiene"
+  short_description: "Audit Rust naming, imports, and paths"
+  default_prompt: "Use $rust-style-hygiene to audit this Rust code for idiomatic naming, import organization, and path clarity."

--- a/agents/.agents/skills/rust-test-quality/SKILL.md
+++ b/agents/.agents/skills/rust-test-quality/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-test-quality
-description: "Evaluate Rust code for test coverage, doctests, public API panic behavior, and documentation quality on changed code or whole-repo baseline audits when explicitly requested. USE FOR: Rust test review, public functions that panic for recoverable conditions, missing or trivial doctests on public APIs, missing /// docs on private helpers, weak assertions, missing boundary/error/negative cases, brittle or duplicated tests, doctest correctness vs actual behavior. DO NOT USE FOR: style/naming/import critique (use rust-style-hygiene), non-Rust code, or unrelated unchanged files unless a baseline audit is requested."
+description: "Review Rust tests, doctests, public panic behavior, and supporting documentation for meaningful risk coverage. Use for weak assertions, missing boundary, error, or negative cases, brittle or duplicated tests, public API examples, doctest correctness, recoverable panics, and private helper docs that explain public behavior."
 ---
 
 # rust-test-quality

--- a/agents/.agents/skills/rust-test-quality/agents/openai.yaml
+++ b/agents/.agents/skills/rust-test-quality/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Test Quality"
+  short_description: "Review Rust tests, doctests, and panics"
+  default_prompt: "Use $rust-test-quality to review these Rust tests and doctests for meaningful risk coverage, strong assertions, and appropriate panic behavior."

--- a/agents/.agents/skills/rust-trait-bounds/SKILL.md
+++ b/agents/.agents/skills/rust-trait-bounds/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: rust-trait-bounds
-description: "Audit Rust trait bounds, generic constraints, and where clauses for simplification, idiomatic placement, and API clarity on changed code or whole-repo baseline audits when explicitly requested. USE FOR: Rust review comments asking whether trait bounds or where clauses can be simplified, redundant bounds, overly broad generic constraints, associated type constraints, HRTBs, impl/function generic cleanup, public API bound ergonomics, moving bounds from structs to impls/methods, choosing inline bounds vs where clauses. DO NOT USE FOR: Rust naming/import style (use rust-style-hygiene), error design (use rust-error-variants), test/doctest coverage (use rust-test-quality), prelude/export decisions (use rust-prelude-exports), non-Rust code, or unrelated unchanged code unless a baseline audit is requested."
+description: "Audit Rust trait bounds, generic constraints, associated types, HRTBs, and where clauses for minimality and API clarity. Use for redundant or overly broad bounds, moving constraints from types to impls or methods, choosing inline versus where-clause placement, and public generic ergonomics."
 ---
 
 # rust-trait-bounds

--- a/agents/.agents/skills/rust-trait-bounds/agents/openai.yaml
+++ b/agents/.agents/skills/rust-trait-bounds/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Rust Trait Bounds"
+  short_description: "Audit Rust generic constraints and bounds"
+  default_prompt: "Use $rust-trait-bounds to audit these Rust trait bounds and generic constraints for minimality, placement, and public API clarity."

--- a/agents/.agents/skills/scientific-crate-docs-review/SKILL.md
+++ b/agents/.agents/skills/scientific-crate-docs-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: scientific-crate-docs-review
-description: "Review and fix the scientific Rust crate documentation overlay that couples Cargo metadata, README release claims, CITATION.cff, REFERENCES.md, scientific topic docs, release guidance, and generated changelog ownership. Use with repository-docs-review for scientific Rust documentation suites, release-readiness checks, version and credit synchronization, algorithm provenance, or scientific validation documentation. Do not use for generic repository docs, ordinary operational runbooks, Rust /// docs, Cargo feature design, or scholarly manuscript prose."
+description: "Review the scientific Rust documentation layer coupling Cargo metadata, README release claims, CITATION.cff, REFERENCES.md, scientific topic docs, release guidance, and generated changelogs. Use for scientific crate release readiness, version and credit synchronization, algorithm provenance, and validation documentation alongside repository-docs-review."
 ---
 
 # Scientific Crate Documentation Review

--- a/scripts/skill_validate.py
+++ b/scripts/skill_validate.py
@@ -143,7 +143,7 @@ def validate_openai_metadata(metadata: dict[str, object], skill_name: str) -> tu
 
     default_prompt = cast("str", interface["default_prompt"])
     invocation = f"${skill_name}"
-    if invocation not in default_prompt:
+    if re.search(rf"{re.escape(invocation)}(?![a-z0-9-])", default_prompt) is None:
         return False, f"interface.default_prompt must mention {invocation}"
 
     return True, "Skill is valid!"

--- a/scripts/skill_validate.py
+++ b/scripts/skill_validate.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 
 UTF8 = "utf-8"
 MAX_SKILL_NAME_LENGTH = 64
+MIN_SHORT_DESCRIPTION_LENGTH = 25
+MAX_SHORT_DESCRIPTION_LENGTH = 64
 ALLOWED_FRONTMATTER_KEYS = frozenset({"name", "description", "license", "allowed-tools", "metadata"})
 FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
 SKILL_NAME_RE = re.compile(r"^[a-z0-9-]+$")
@@ -94,7 +96,57 @@ def validate_skill(skill_path: Path | str) -> tuple[bool, str]:
     frontmatter, message = load_frontmatter(skill_path)
     if frontmatter is None:
         return False, message
-    return validate_frontmatter(frontmatter)
+
+    valid_frontmatter, frontmatter_message = validate_frontmatter(frontmatter)
+    if not valid_frontmatter:
+        return False, frontmatter_message
+
+    openai_metadata, metadata_message = load_openai_metadata(skill_path)
+    if openai_metadata is None:
+        return False, metadata_message
+
+    return validate_openai_metadata(openai_metadata, cast("str", frontmatter["name"]))
+
+
+def load_openai_metadata(skill_path: Path | str) -> tuple[dict[str, object] | None, str]:
+    """Load product UI metadata from one skill directory."""
+    metadata_path = Path(skill_path) / "agents" / "openai.yaml"
+    if not metadata_path.exists():
+        return None, "agents/openai.yaml not found"
+
+    try:
+        loaded_metadata: Any = yaml.safe_load(metadata_path.read_text(encoding=UTF8))
+    except yaml.YAMLError as exc:
+        return None, f"Invalid YAML in agents/openai.yaml: {exc}"
+
+    if not isinstance(loaded_metadata, dict):
+        return None, "agents/openai.yaml must be a YAML dictionary"
+
+    return cast("dict[str, object]", loaded_metadata), ""
+
+
+def validate_openai_metadata(metadata: dict[str, object], skill_name: str) -> tuple[bool, str]:
+    """Validate required user-facing skill metadata."""
+    loaded_interface = metadata.get("interface")
+    if not isinstance(loaded_interface, dict):
+        return False, "agents/openai.yaml must contain an 'interface' dictionary"
+    interface = cast("dict[str, object]", loaded_interface)
+
+    for field in ("display_name", "short_description", "default_prompt"):
+        value = interface.get(field)
+        if not isinstance(value, str) or not value.strip():
+            return False, f"interface.{field} must be a non-empty string"
+
+    short_description = cast("str", interface["short_description"]).strip()
+    if not MIN_SHORT_DESCRIPTION_LENGTH <= len(short_description) <= MAX_SHORT_DESCRIPTION_LENGTH:
+        return False, (f"interface.short_description must be {MIN_SHORT_DESCRIPTION_LENGTH}-{MAX_SHORT_DESCRIPTION_LENGTH} characters")
+
+    default_prompt = cast("str", interface["default_prompt"])
+    invocation = f"${skill_name}"
+    if invocation not in default_prompt:
+        return False, f"interface.default_prompt must mention {invocation}"
+
+    return True, "Skill is valid!"
 
 
 def validate_name(name_value: object) -> tuple[bool, str]:

--- a/scripts/test_skill_validate.py
+++ b/scripts/test_skill_validate.py
@@ -13,10 +13,20 @@ if TYPE_CHECKING:
     import pytest
 
 
-def write_skill(skill_dir: Path, frontmatter: str) -> None:
+def write_skill(skill_dir: Path, frontmatter: str, *, include_openai_metadata: bool = True) -> None:
     """Write a minimal skill file."""
     skill_dir.mkdir()
     (skill_dir / "SKILL.md").write_text(f"---\n{frontmatter}\n---\n\n# Skill\n", encoding="utf-8")
+    if include_openai_metadata:
+        agents_dir = skill_dir / "agents"
+        agents_dir.mkdir()
+        (agents_dir / "openai.yaml").write_text(
+            "interface:\n"
+            '  display_name: "Example Skill"\n'
+            '  short_description: "Validate an example skill"\n'
+            f'  default_prompt: "Use ${skill_dir.name} to validate this example."\n',
+            encoding="utf-8",
+        )
 
 
 def test_validate_skill_accepts_minimal_frontmatter(tmp_path: Path) -> None:
@@ -36,6 +46,47 @@ def test_validate_skill_rejects_missing_skill_file(tmp_path: Path) -> None:
 
     assert not valid
     assert message == "SKILL.md not found"
+
+
+def test_validate_skill_rejects_missing_openai_metadata(tmp_path: Path) -> None:
+    """A standalone skill must include user-facing metadata."""
+    skill_dir = tmp_path / "example-skill"
+    write_skill(skill_dir, 'name: example-skill\ndescription: "Use for tests."', include_openai_metadata=False)
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert message == "agents/openai.yaml not found"
+
+
+def test_validate_skill_rejects_short_ui_description(tmp_path: Path) -> None:
+    """UI descriptions must remain useful when shown in skill lists."""
+    skill_dir = tmp_path / "example-skill"
+    write_skill(skill_dir, 'name: example-skill\ndescription: "Use for tests."')
+    (skill_dir / "agents" / "openai.yaml").write_text(
+        'interface:\n  display_name: "Example Skill"\n  short_description: "Too short"\n  default_prompt: "Use $example-skill to validate this example."\n',
+        encoding="utf-8",
+    )
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert message == "interface.short_description must be 25-64 characters"
+
+
+def test_validate_skill_rejects_prompt_without_invocation(tmp_path: Path) -> None:
+    """Default prompts must explicitly invoke their owning skill."""
+    skill_dir = tmp_path / "example-skill"
+    write_skill(skill_dir, 'name: example-skill\ndescription: "Use for tests."')
+    (skill_dir / "agents" / "openai.yaml").write_text(
+        'interface:\n  display_name: "Example Skill"\n  short_description: "Validate an example skill"\n  default_prompt: "Validate this example."\n',
+        encoding="utf-8",
+    )
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert message == "interface.default_prompt must mention $example-skill"
 
 
 def test_validate_skill_rejects_unexpected_frontmatter_key(tmp_path: Path) -> None:

--- a/scripts/test_skill_validate.py
+++ b/scripts/test_skill_validate.py
@@ -89,6 +89,22 @@ def test_validate_skill_rejects_prompt_without_invocation(tmp_path: Path) -> Non
     assert message == "interface.default_prompt must mention $example-skill"
 
 
+def test_validate_skill_rejects_prompt_with_partial_invocation(tmp_path: Path) -> None:
+    """A longer skill name must not satisfy the invocation requirement."""
+    skill_dir = tmp_path / "example-skill"
+    write_skill(skill_dir, 'name: example-skill\ndescription: "Use for tests."')
+    (skill_dir / "agents" / "openai.yaml").write_text(
+        'interface:\n  display_name: "Example Skill"\n  short_description: "Validate an example skill"\n'
+        '  default_prompt: "Use $example-skill-extra to validate this example."\n',
+        encoding="utf-8",
+    )
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert message == "interface.default_prompt must mention $example-skill"
+
+
 def test_validate_skill_rejects_unexpected_frontmatter_key(tmp_path: Path) -> None:
     """Only supported skill frontmatter keys are accepted."""
     skill_dir = tmp_path / "bad-skill"


### PR DESCRIPTION
Require skills to provide validated interface metadata with concise UI descriptions and invocation-ready default prompts.

Add comprehensive C++23 production review guidance and clarify existing skill routing.