### PR TITLE
fix(skills): preserve review coverage and evidence across repairs

### DIFF
--- a/agents/.agents/skills/review-graph/references/evidence-contract.md
+++ b/agents/.agents/skills/review-graph/references/evidence-contract.md
@@ -24,6 +24,9 @@ deterministic verifier.
   missing predecessor evidence.
 - Reuse evidence only after recapturing source state and verifying the complete
   identity. Mark mismatches stale rather than overwriting them.
+- Mutation impact alone does not establish proof eligibility. Cross-capture
+  audit reuse requires the unchanged-input transition proof below; never rewrite
+  an old envelope's fingerprints or accept an unaffected-node label as evidence.
 - Treat exact review reuse as typed non-executable evidence. Preserve the
   router's exact requirement-to-evidence mapping; do not create a leaf or
   independent-review node for reused work.
@@ -225,12 +228,46 @@ recaptured plan. The only accepted review evidence without a planned executable
 node is an exact evidence ID declared by the routing ledger and preserved
 unchanged in the plan, expectation, and proof. Its envelope must match the
 routed requirement, skill, path, mode, static references, and source state
-through the normal review-evidence gate. Independent planned and exact-reuse
+(or the verified audit-reuse transition below). Independent planned and exact-reuse
 identities additionally retain the exact trusted change target and ordered
 planned paths. A synthesis record is accepted only
 after every planned predecessor and declared exact-reuse record have accepted
 mapped evidence, and its native payload names those exact predecessor evidence
 IDs.
+
+### Cross-Capture Audit Reuse
+
+The sole cross-source exception is a planner-bound `AuditReuseTransition` for a
+complete, predecessor-free audit. The compiler seals an `AuditInputIdentity`
+into the native report and expectation: owned paths, inspected paths, nearby
+contract owners, and loaded instruction digests. Preserve and verify the report
+and envelope at their original source state; do not create a synthetic audit or
+claim that a worker executed again.
+
+The transition binds the original evidence ID, artifact digest, source and
+target triples, persisted artifact/metadata locations, and target instruction
+digests. The plan contains shared `ReviewSourceSnapshot` records. Their v2
+repository fingerprints commit to every captured repository path identity,
+index identity, scoped fingerprints, and capture context. Recompute these
+commitments before comparing dependencies; unbound caller-authored path maps
+cannot establish reuse. Capture boundaries, HEAD, branch, and index must match.
+
+Require unchanged owned/inspected/nearby paths, applicable instructions, routed
+requirements and scope, skill/reference digests, and execution profile. Full
+owned-path inspection is mandatory; blocked, limited, partial, legacy-unbound,
+validation, independent-review, fix, revalidation, and synthesis results cannot
+use this exception. Changed or newly applicable instructions invalidate reuse.
+
+The runtime reroutes qualifying audits as non-executable exact reuse and binds
+the transitions/snapshots in the plan digest. Scheduling and synthesis reload
+the original sources; finalization discovers them without manual source
+transcription. The bundle verifier independently checks each transition against
+the routed identity, raw artifact digest, and target proof state, then runs the
+ordinary native/envelope gates at the original state. Missing transitions,
+tampered snapshots, substituted artifacts, or changed inputs fail closed.
+Validators and syntheses remain current-state executions. Repeated transitions
+retain the original audit provenance while rebinding only the verified reuse
+claim to the newest capture.
 
 Use the planner's canonical typed artifact structures:
 

--- a/agents/.agents/skills/review-graph/references/node-contract.md
+++ b/agents/.agents/skills/review-graph/references/node-contract.md
@@ -95,6 +95,9 @@ Create every worker in every profile with `fork_turns: "none"` and never dispatc
 a later node through a follow-up to a completed worker. In adaptive execution,
 use fresh independent workers when possible; if creation fails before accepted
 evidence, record the attempt and execute that same node in the coordinator.
+Capacity-only failures first permit the single bounded unchanged-dispatch retry
+in `runtime-contract.md`. Reserve locally before creation; journal `in-flight`
+only after successful creation, not when selecting the next ready node.
 Isolated-only instead stops and emits the resume manifest from
 `planning-contract.md`.
 
@@ -312,9 +315,12 @@ Accept a result only when:
 - the named skill file and digest are the dispatched file and digest
 - every dispatched static routing/repository reference appears under
   `References loaded` with its dispatched digest
-- inspected files overlap the assigned scope or the report explains why the
-  scope contains no applicable contract
-- `completed` and `no-findings` results contain concrete inspection evidence
+- audit inspected files are unique and owned by the dispatch; `no-findings`
+  inspects every owned path, while `completed` names every omitted owned path
+  once with a structured, accepted limitation
+- `completed` and `no-findings` audits contain concrete inspection evidence;
+  bundle-only synthesis may have no inspected source files and instead binds
+  its complete predecessor evidence
 - audit, synthesis, and revalidation results with `completed` or `no-findings`
   matched all three state identities before and after and changed no repository
   path or git state

--- a/agents/.agents/skills/review-graph/references/planning-contract.md
+++ b/agents/.agents/skills/review-graph/references/planning-contract.md
@@ -236,7 +236,13 @@ Map every validation requirement to exactly one unit and accepted execution or
 verified reuse. A failed validator is evidence for its owning reviewer, not an
 automatic review finding.
 
-Require at least one baseline validator. Require all applicable language
+Require at least one baseline validator in every review scope. The validation
+requirement's `baseline: true` identifies the repository check (such as
+`just ci`); it does not select baseline review scope or expand captured paths.
+A minimal branch template therefore marks its repository check `baseline: true`
+while retaining `requested_scope: branch`. Other targeted units may use false.
+The bootstrap help and validation-requirement schema expose this distinction.
+Require all applicable language
 production syntheses, `repository-independent-review` for concrete change
 targets, and `repository-production-review` for final broad reconciliation.
 
@@ -279,6 +285,47 @@ stale old-plan nodes to terminal `awaiting-replan`, and emits replacement
 identities with lineage. Old immutable dispatches cannot be scheduled from that
 state.
 
+Supply the immediately preceding `previous_capture`, not the initial planning
+template's capture. Its fingerprint triple must equal the prior plan state.
+`capture_scope.py` records per-path content/type/mode identities for the whole
+repository and an index identity. V2 repository fingerprints bind those maps
+and the capture context together. Compare the maps to derive `changed_paths`, including repeated
+edits to already-dirty files, additions, removals, and mode changes. Reject
+caller-declared deltas that differ, capture-boundary changes, and HEAD, branch,
+or index mutation before publication. Older manifests without these identities
+require a fresh pre-repair capture; status strings cannot recover content deltas.
+
+`newly_touched_paths` is the new captured inventory minus the previous captured
+inventory, never minus node-owned coverage. Invalidate changed-path owners,
+expanded or changed review contracts, applicable instruction dependencies, and
+their transitive downstream nodes. Validator ownership comes from its captured
+paths, not the commands stored in its node coverage. Verified optional `sources`
+also contribute inspected nearby-contract dependencies.
+
+For supplied accepted audit `sources`, preserve original artifacts and verify
+complete compiler-bound ownership, inspected dependencies, instructions,
+skill/reference identities, and unchanged inputs between content-bound v2
+captures. Only predecessor-free, complete audits without limitations qualify.
+Convert their exact routed requirements to non-executable reuse before
+materialization; exclude their original IDs from the stale set. Required
+validators, independent reviews, and syntheses still execute against the new
+capture. Unbound legacy reports/captures and failed unchanged-input checks leave
+the audit executable; never assert reuse solely because a node was unaffected.
+
+The plan's `audit_reuse_transitions` binds each original evidence ID, source and
+target states, artifact digest and persisted source locations, and current
+instruction digests. `reuse_source_snapshots` stores the needed origin/target
+captures once, shared across transitions. These records participate in the plan
+digest and final proof verification. Neither the original envelope nor its raw
+artifact is rewritten. Repeated epochs verify prior reuse and retain its origin
+only while the inputs still match; a changed dependency returns it to execution.
+
+`next-ready`, `synthesis-bundle` with a plan, and `finalize-proof` discover and
+reverify these sources automatically. Synthesis exposes both original and
+verified source states. Missing/tampered artifacts or changed instruction/skill
+files block consumption and require repair or replanning. The output's `capture`
+is the next epoch's previous capture; `lifecycle_input` drives the new graph.
+
 Derive synthesis edges in the planner. Every synthesis waits for required
 validation, its routed audits and validators, and its routed exact reuse.
 `repository-production-review` also depends on every selected non-repository
@@ -286,6 +333,12 @@ synthesis and every exact-reuse mapping. Caller predecessor lists may add but
 not omit these dependencies.
 
 ## Failure And Resume
+
+Capacity-only creation failures permit one unchanged-dispatch retry after waiting
+up to 30 seconds for host lifecycle progress. A completed worker may still occupy
+a slot. Track reservations separately from started work and append `in-flight`
+only after creation succeeds. Exhausting this bounded retry follows the profile
+rules below; never replay accepted reviews or validators to recover capacity.
 
 In adaptive grouped execution, a failed worker creation or pre-acceptance worker
 result selects coordinator execution for that exact node. Preserve the failed
@@ -323,6 +376,44 @@ Accept a result after its elapsed cap only when the complete native report
 arrived and every ordinary isolation, skill, reference, structure, and
 fingerprint check passes.
 
+## Late Validation Expansion
+
+Accepted review `validation_requirements` are proof obligations, not advisory
+text. `next-ready` reparses journal-bound artifacts and blocks synthesis for an
+unmapped requirement or a command/directory/environment/dependency mismatch.
+`finalize-proof` performs the same reconciliation even if every original node
+already has accepted evidence. A generic CI pass cannot cover a different
+validation identity.
+
+Use `reconcile-validation-requirements` with `--journal`, `--dispatches`,
+`--current-capture`, and an input containing `plan` and `source_state` to inspect
+requirements and their exact origin/digest. To expand, supply `artifact_store`
+and full `validation_requirements` from the planning schema. Keep the discovered
+requirement ID, ordered commands, working directory for each command, environment,
+and dependency policy; explicitly plan toolchain, platform, expected artifacts,
+isolation, and remaining execution fields. Units must be required and source-bound.
+An existing requirement ID cannot be repurposed for different commands.
+
+Alternatively, record an actual user scope decision in `user_exclusions`, using
+the returned `originating_evidence_id`, `requirement_id`, `requirement_digest`,
+and a specific `reason`. Do not infer exclusion from unavailable capacity or a
+passing unrelated check. Exclusions remain visible in synthesis and final proof.
+
+Expansion requires quiescent workers and no blocked/source-mutated nodes. It
+coalesces only the new requirements, preserves existing validator units and
+accepted non-synthesis artifacts, and adds validators to synthesis dependencies.
+It emits an immutable plan revision, dispatch set, and journal with reverified
+acceptance events under an external expansion directory. Follow the returned
+`lifecycle_input_path`, `dispatches_path`, and `journal_path`; preserve the original
+journal and artifacts as lineage. Source fingerprints do not change, no mutation
+epoch is fabricated, and accepted CI/audit workers are not redispatched. Previously
+accepted synthesis must be refreshed because its evidence inputs changed.
+
+The hashed synthesis `plan_context` includes consulted-router closure, routing
+exceptions and exclusions, exact review reuse, requirement-to-node and validation
+evidence mappings, late-validation reconciliation, and catalog-handoff closure.
+This is a runtime-derived compact projection, not a coordinator-authored ledger.
+
 ## Completion Gate
 
 Report `complete` only when:
@@ -332,14 +423,16 @@ Report `complete` only when:
 - every consulted catalog is exhaustive and path-valid
 - no budget-deferred, capability-blocked, or failed routing disposition remains
 - every late handoff is resolved
+- every accepted late validation need has matching required validator evidence
+  or an exact explicit user exclusion
 - routing was rerun after every surface-changing fix
 - every epoch and selected node completed and was accepted
 - required documentation/citation coverage completed
 - baseline and all required validation completed
 - applicable language and repository synthesis completed
 - required independent review completed for a concrete change
-- all accepted reports have matching source fingerprints; isolated completion
-  additionally has no isolation failure
+- accepted reports match the final source fingerprints or have verified
+  unchanged-input audit reuse; isolated completion has no isolation failure
 - final findings, changes, validation, and lifecycle ledgers reconcile
 
 Bind completion to the exact planner-derived proof expectation and proof, the

--- a/agents/.agents/skills/review-graph/references/routing-catalog.json
+++ b/agents/.agents/skills/review-graph/references/routing-catalog.json
@@ -68,7 +68,7 @@
       "target_kind": "router",
       "default_priority": "required-routing-synthesis",
       "synthesis_dependency": null,
-      "path_patterns": ["README.md", "AGENTS.md", "CONTRIBUTING.md", "SECURITY.md", "CITATION.cff", "docs/**"],
+      "path_patterns": ["README.md", "AGENTS.md", "CONTRIBUTING.md", "SECURITY.md", "CITATION.cff", "REFERENCES.md", "BIBLIOGRAPHY.md", "CITATIONS.md", "docs/**"],
       "semantic_triggers": ["Active documentation, API docs, scientific claims, citations, publication material, or release-readiness coverage are in scope."]
     },
     {
@@ -674,7 +674,7 @@
       "target_kind": "leaf",
       "default_priority": "required-routing-synthesis",
       "synthesis_dependency": "repository-synthesis",
-      "path_patterns": ["README.md", "AGENTS.md", "CONTRIBUTING.md", "SECURITY.md", "docs/**"],
+      "path_patterns": ["README.md", "AGENTS.md", "CONTRIBUTING.md", "SECURITY.md", "REFERENCES.md", "BIBLIOGRAPHY.md", "CITATIONS.md", "docs/**"],
       "semantic_triggers": ["Active docs, navigation, operations, architecture, policies, release guidance, generated ownership, or cross-document consistency are material."]
     },
     {
@@ -750,8 +750,8 @@
       "target_kind": "leaf",
       "default_priority": "required-routing-synthesis",
       "synthesis_dependency": "repository-synthesis",
-      "path_patterns": ["CITATION.cff", "**/*.bib", "docs/**", "papers/**"],
-      "semantic_triggers": ["DOIs, source identity, bibliography, algorithm provenance, scientific credit, or citation claims are material."]
+      "path_patterns": ["README.md", "CITATION.cff", "REFERENCES.md", "BIBLIOGRAPHY.md", "CITATIONS.md", "**/*.bib", "docs/**", "papers/**"],
+      "semantic_triggers": ["DOIs, source identity, bibliography, public README citation guidance, algorithm provenance, scientific credit, or citation claims are material."]
     },
     {
       "catalog_id": "docs.authorship",

--- a/agents/.agents/skills/review-graph/references/runtime-contract.md
+++ b/agents/.agents/skills/review-graph/references/runtime-contract.md
@@ -1,12 +1,11 @@
 # Review Graph Runtime Contract
 
-The runtime owns identities, fingerprints, artifacts, and proof reconciliation
-for all profiles. Load maintainer contracts only for implementation changes or
-rejection diagnosis.
+The runtime owns identities, fingerprints, artifacts, and proof reconciliation.
+Load maintainer contracts only for implementation changes or rejection diagnosis.
 
 ## Bootstrap And Route
 
-The versioned public contracts are:
+Public contracts:
 
 - `schemas/planning-input-v1.schema.json`
 - `schemas/review-payload-v1.schema.json`
@@ -16,7 +15,7 @@ The versioned public contracts are:
 
 `--help` links input definitions and examples.
 
-Bootstrap capture provenance into the compact routing and validation template:
+Bootstrap capture provenance into the routing/validation template:
 
 ```sh
 uv run --locked python scripts/review_graph_bootstrap.py \
@@ -24,36 +23,33 @@ uv run --locked python scripts/review_graph_bootstrap.py \
 ```
 
 Bootstrap binds capture identities with JSON-path diagnostics. Runtime commands
-consume its stage inputs; `review_graph_plan.py --input` prints the bundled plan.
+consume its stage inputs; `review_graph_plan.py --input` prints the plan.
 
-Every graph needs a repository check with `baseline: true`. This is not baseline
-review scope: a branch `just ci` requirement keeps `requested_scope: branch`.
+Every graph needs a repository check with `baseline: true`, independent of review
+scope: branch `just ci` keeps `requested_scope: branch`.
 
 Supply `consulted_routers`, validation requirements, and sparse
 `routing_overrides`: `catalog_id`, `disposition`, `reason`,
 `applicability_evidence`, `review_surface`, `owners`, plus applicable validation,
 instruction, reference, and reuse `evidence_id` fields. Catalog identities are derived.
 
-The planner expands omissions to `not-applicable`, applies the repository
-classifier, and selects independent review for a concrete change plus every
-consulted surface synthesis and repository synthesis. Use
-`routing-projection` for the complete candidate list and classifier signals.
+The planner marks omissions `not-applicable`, applies the repository classifier,
+and selects independent review for concrete changes, consulted surface syntheses,
+and repository synthesis. `routing-projection` lists all candidates and signals.
 
 ## Materialize And Schedule
 
-Run `materialize-dispatches` with the plan, source triple, repository root,
-authorization, state command, and external artifact store. Dispatches bind
-compiler/journal operations, artifact paths, payload schemas, instruction digests,
-command policy, validation units, and predecessors.
-`worker_input_path` names an immutable per-node file containing that exact
-dispatch wrapper and worker prompt. Send it directly; do not extract wrappers
-from the aggregate. `next-ready` verifies these files and returns their paths
-inside `ready_dispatches`.
+`materialize-dispatches` takes plan, source triple, repository root, authorization,
+state command, and external artifact store; binds compiler/journal operations,
+artifact paths, payload schemas, instruction digests, command policy, validation
+units, and predecessors.
+`worker_input_path` names the immutable per-node dispatch wrapper and prompt.
+Send it directly; do not extract aggregate wrappers. `next-ready` verifies these
+files and returns their paths in `ready_dispatches`.
 
-`inspection_profile` defaults to `shared-read-only`: overlapping audit nodes
-receive one persisted, digest-bound structural observation while retaining
-separate semantic judgments. Use `independent-source` to disable this bounded
-reuse.
+`inspection_profile` defaults to `shared-read-only`: overlapping audits share a
+persisted, digest-bound structural observation, not semantic judgments.
+`independent-source` disables this reuse.
 
 `journal-append` serializes `in-flight`, `accepted`, `blocked`, `invalidated`,
 and terminal `awaiting-replan` states; acceptance requires compiled evidence.
@@ -68,16 +64,19 @@ Its CLI field contract is:
 | `awaiting-replan` | forbidden | forbidden | required |
 
 Reserve ready dispatches locally; append `in-flight` only after creation succeeds.
-A final result need not release host capacity immediately. On a capacity-only
-failure, preserve that exact reservation, wait for lifecycle/capacity progress
-(at most 30 seconds), and retry once. Do not probe with throwaway workers or
-replay accepted work. If still unavailable, use the profile's fallback/resume
-policy and record the failed attempts; no worker means no execution evidence.
+A final result may not immediately release capacity. On capacity-only failure,
+preserve the reservation, wait for lifecycle/capacity progress (at most 30 seconds),
+and retry once. Never probe with throwaway workers or replay accepted work.
+If unavailable, apply the profile's fallback/resume policy and record attempts;
+no worker means no execution evidence.
+For unstarted adaptive nodes, `fallback-to-coordinator` takes lifecycle input plus
+`node_id`, `worker_created: false`, `reason`, `artifact_store`, and flags
+`--dispatches`, `--journal`, `--current-capture`. Follow returned paths; other
+dispatches/artifacts remain unchanged. Never rematerialize for one executor.
 
-`--journal` may initially be missing or zero-byte; `next-ready` treats both as
-empty without writing. `journal-append` creates a missing file when its parent
-exists. Nonempty journals reject blank records.
-After each event, request only dependency-ready work:
+`next-ready` treats missing/zero-byte journals as empty without writing.
+`journal-append` creates missing files if their parent exists. Nonempty journals
+reject blank records. After each event, request dependency-ready work:
 
 ```sh
 uv run --locked python scripts/review_graph_runtime.py next-ready \
@@ -86,9 +85,12 @@ uv run --locked python scripts/review_graph_runtime.py next-ready \
   --output-dir <proof-store>
 ```
 
-The runtime verifies journal, dispatch, and current-source identities.
-`--output-dir` prints JSON `output_path` and `output_generation` after publication;
-filenames use the journal generation for immutable, replayable output.
+The runtime verifies journal, dispatch, and current-source identities, accepting
+both established empty-reuse-field plan digests without rewriting records.
+Freeze the runtime/skill checkout per run; compatibility never permits changed
+non-empty plan fields or ignored instruction digests.
+`--output-dir` prints JSON `output_path`/`output_generation` after publication;
+journal-generation filenames ensure immutable, replayable output.
 
 ## Review Workers
 
@@ -97,44 +99,41 @@ instructions. Exclude coordinator conclusions, routing, and journals. Shared
 observations do not replace independent judgment. Reviews attest to commands;
 validator-command duplicates need explicit authorization and reusable evidence.
 
-Return only a `ReviewPayload` object. Write its exact bytes to the candidate,
-then execute `worker_payload_persistence.command` unchanged. Its complete argv
-includes the executable, runtime script, and bound paths; it validates and
-atomically publishes `worker_payload_path`.
+Return only `ReviewPayload`. Write its exact bytes to the candidate, then execute
+`worker_payload_persistence.command` unchanged. Its complete argv includes the
+executable, script, and bound paths; it validates and atomically publishes
+`worker_payload_path`.
 
 Use the materialized payload schema for fields and enum values.
 
-`compile-node` copies accepted bytes to a read-only content-addressed sibling
-and records that sealed path in evidence metadata. The dispatch-bound payload
-path remains staging only; later valid retries cannot replace accepted proof
-bytes.
+`compile-node` seals accepted bytes in a read-only content-addressed sibling,
+recorded in evidence metadata. The dispatch-bound path remains staging;
+retries cannot replace accepted proof bytes.
 
 Use empty arrays for absent fields. `blocked` requires a limitation;
 `no-findings` requires no findings and inspection of every audit-owned path.
-A completed audit may omit an owned path only when `scope_limitations` contains
-exactly one path-specific reason for it. Inspected paths must be unique and
-owned by the dispatch. Payload persistence and compilation both enforce this.
-Bundle-only synthesis may leave `files_inspected` empty; predecessor evidence
-remains mandatory. Do not invent source reads to satisfy a field.
+A completed audit may omit an owned path only with exactly one path-specific
+`scope_limitations` reason. Inspected paths must be unique and dispatch-owned;
+persistence and compilation both enforce this.
+Bundle-only synthesis allows empty `files_inspected`, but requires predecessor
+evidence. Never invent source reads.
 The compiler rejects validator-owned
 commands and non-catalog handoffs. One schema mismatch permits one retry using
 field diagnostics; a second mismatch blocks the node. For authorized fixes,
 each change names finding IDs, files, what changed, why, and the preserved
 contract; the trusted dispatch records mutation facts.
 
-Run `compile-node` with the node ID, signed dispatch set, captures, and journal.
-It reads only the bound payload, preserves its bytes, assigns identities,
-renders and verifies native evidence, then journals it. `compile-review` remains
-available for diagnosis.
+`compile-node` takes node ID, signed dispatches, captures, and journal; reads only
+the bound payload, preserves bytes, assigns identities, renders/verifies native
+evidence, then journals it. `compile-review` supports diagnosis.
 
 ## Independent Review And Validation
 
-The conclusion-blind independent worker returns the six sections defined by
-`repository-independent-review`. Pass the native result to `compile-node`; its
-compiler verifies target/path
-provenance, line bounds, before/after fingerprints, dispatched adversarial
-checks, findings, and catalog handoffs; it assigns identities, appends the
-envelope and Machine Evidence, and emits journal-compatible metadata.
+The conclusion-blind independent worker returns `repository-independent-review`'s
+six sections. Pass the native result to `compile-node`, which verifies target/path
+provenance, line bounds, before/after fingerprints, dispatched adversarial checks,
+findings, and catalog handoffs; assigns identities; appends the envelope and
+Machine Evidence; and emits journal-compatible metadata.
 
 Coalesced validators read only `review-validator/references/graph-dispatch.md`,
 publish through `persist-worker-payload`, and return identical bytes. Snapshot
@@ -145,44 +144,51 @@ excludes fail. Unexpected workspace effects fail. Source-adjacent intermediates
 and outside-repository artifacts stay under the dispatched isolation root.
 Known cache/build roots use bounded metadata manifests; other recursive content
 uses content digests.
+Isolation roots must not overlap the repository, including through symlinks or
+ignored directories. Planning, materialization, and snapshots enforce this
+before execution.
 
-Use `synthesis-bundle` to verify accepted artifacts and derive the compact,
-hashed findings, mappings, validation, handoff, limitation, and artifact view.
-Synthesis receives that bundle, never full predecessor reports.
-Supply its `plan` to include hashed router closure, exclusions, exact reuse,
-requirement/validator mappings, and handoff reconciliation in `plan_context`.
+`synthesis-bundle` verifies accepted artifacts, hashing findings, mappings,
+validation, handoffs, limitations, and artifacts. Synthesis receives only this
+bundle, never full reports. Supply `plan` for hashed router closure, exclusions,
+exact reuse, requirement/validator mappings, and handoff reconciliation in
+`plan_context`.
 
 ## Mutation, Handoffs, And Proof
 
-Accepted late validation requirements block synthesis and final proof until
-exactly planned or explicitly user-excluded. Run
+Accepted late validation requirements block synthesis/proof until exactly planned
+or explicitly user-excluded. Run
 `reconcile-validation-requirements --input <request.json> --journal <journal>
 --dispatches <dispatches.json> --current-capture <capture.json> --output <result.json>`.
-Start with `plan` and `source_state` to inspect discoveries. To expand, add
+Supply `plan` and `source_state` to inspect discoveries. Expand with
 `validation_requirements` (planning-schema objects) and `artifact_store`, or
-explicit `user_exclusions` bound to the returned origin, requirement ID/digest,
-and reason. Follow returned lifecycle, journal, and dispatch paths. Source state
-and accepted audits/CI stay unchanged; synthesis inputs refresh. Wait for active
-workers before expansion. Details: [planning-contract.md](planning-contract.md#late-validation-expansion).
+`user_exclusions` bound to returned origin, requirement ID/digest, and reason.
+Follow returned lifecycle/journal/dispatch paths. Source state and accepted
+audits/CI remain; synthesis inputs refresh. Wait for active workers before expansion.
+Details: [planning-contract.md](planning-contract.md#late-validation-expansion).
 
-Run `reconcile-handoffs` before expansion. Selected, exactly reused, or
-user-excluded catalog entries resolve existing handoffs; only
-`new_routing_triggers` expand routing. Final proof classification is derived
-from the typed catalog mappings reparsed from accepted evidence, not from
-caller-provided resolved IDs.
+Run `reconcile-handoffs` before expansion. Selected, exactly reused, or user-excluded
+catalog entries resolve handoffs; only `new_routing_triggers` expand routing.
+Final proof classification uses typed catalog mappings reparsed from accepted
+evidence, never caller-provided resolved IDs.
 
 After authorized repairs, run `advance-after-mutation` with the immediately
 preceding `previous_capture`, `new_capture`, and their exact `changed_paths`
 content delta. Invalidation follows owners and downstream dependencies. Supply
 accepted `sources` for verified unchanged-input audit reuse; validators,
 independent reviews, syntheses, and unproven audits rerun. Follow returned
-`lifecycle_input` and fresh dispatches; old artifacts remain unchanged.
+`lifecycle_input_path`, `dispatches_path`, `journal_path`, and `capture_path`;
+old artifacts remain unchanged. `preserved_evidence` contains only proven reuse.
+Per-node `reuse_decisions` explain disposition and reason code, distinguishing
+`coverage-limitations` from `unclassified-limitations`. Untyped caveats prevent
+reuse, never inferred informational exemptions.
 
 Persist all capture, plan, payload, compiled evidence, journal, synthesis,
 invalidation, manifest, and proof artifacts outside the reviewed repository.
 Run `finalize-proof` with the lifecycle bundle, signed dispatch set, journal,
-and `--current-capture`; it discovers accepted evidence paths without a
-caller-authored sources document. It rejects stale source state, unresolved handoffs, missing
-evidence, or verifier failures. Report `repository_validation_status`
+and `--current-capture`; it discovers accepted evidence paths, rejecting stale
+source state, unresolved handoffs, missing evidence, or verifier failures.
+Blocked events without evidence produce an incomplete proof with their reason,
+not nonexistent-artifact reads. Report `repository_validation_status`
 separately from `graph_proof_status`; structural independent-evidence
 acceptance does not imply semantic agreement or adjudicated recall.

--- a/agents/.agents/skills/review-graph/references/runtime-contract.md
+++ b/agents/.agents/skills/review-graph/references/runtime-contract.md
@@ -1,9 +1,8 @@
 # Review Graph Runtime Contract
 
-Use this contract for ordinary adaptive, isolated, and mixed execution. The
-planner and runtime own identities, fingerprints, digests, canonical artifacts,
-envelopes, and proof reconciliation. Load maintainer contracts only when
-changing those implementations or diagnosing a rejection.
+The runtime owns identities, fingerprints, artifacts, and proof reconciliation
+for all profiles. Load maintainer contracts only for implementation changes or
+rejection diagnosis.
 
 ## Bootstrap And Route
 
@@ -15,8 +14,7 @@ The versioned public contracts are:
 - `schemas/runtime-operation-inputs-v1.schema.json`
 - `runtime-operation-examples-v1.json`
 
-Every runtime subcommand links its exact input definition and a valid example
-from `--help`.
+`--help` links input definitions and examples.
 
 Bootstrap capture provenance into the compact routing and validation template:
 
@@ -25,46 +23,60 @@ uv run --locked python scripts/review_graph_bootstrap.py \
   --capture <capture.json> --input <template.json> --output <planning.json>
 ```
 
-Bootstrap binds each validator to the captured scope, worktree, and repository
-fingerprints, capture command, and paths. Schema failures aggregate missing,
-unknown, and malformed fields with JSON paths, accepted shapes, and enums.
-The bundle contains stage inputs and the terminal `plan`. Runtime
-commands accept it directly; `review_graph_plan.py --input` prints the embedded
-plan without replanning.
+Bootstrap binds capture identities with JSON-path diagnostics. Runtime commands
+consume its stage inputs; `review_graph_plan.py --input` prints the bundled plan.
+
+Every graph needs a repository check with `baseline: true`. This is not baseline
+review scope: a branch `just ci` requirement keeps `requested_scope: branch`.
 
 Supply `consulted_routers`, validation requirements, and sparse
-`routing_overrides`. Each override contains `catalog_id`, `disposition`,
-`reason`, `applicability_evidence`, `review_surface`, and `owners`; selected
-records may add `validation_requirement_ids`, `instruction_paths`, and
-`static_references`, while exact reuse may add `evidence_id`. Do not author
-router, rule, skill, path, priority, requirement, or synthesis identities.
+`routing_overrides`: `catalog_id`, `disposition`, `reason`,
+`applicability_evidence`, `review_surface`, `owners`, plus applicable validation,
+instruction, reference, and reuse `evidence_id` fields. Catalog identities are derived.
 
 The planner expands omissions to `not-applicable`, applies the repository
 classifier, and selects independent review for a concrete change plus every
 consulted surface synthesis and repository synthesis. Use
 `routing-projection` for the complete candidate list and classifier signals.
-Route shared workflows, recipes, lockfiles, toolchains, examples, and build
-configuration to tooling/documentation and every affected language owner.
 
 ## Materialize And Schedule
 
-After planning, run `materialize-dispatches` once. Its input names the accepted
-plan, source triple, repository root, authorization, state command, and external
-artifact store. Every output dispatch binds its compiler and journal operation,
-canonical evidence/artifact paths, worker payload path, recursive required
-payload shape, schema digest, applicable
-repository instructions and digests, command policy, validation unit, and
-predecessor evidence. Planning stops before dispatch when a node mode lacks a
-deterministic compiler or journal path.
+Run `materialize-dispatches` with the plan, source triple, repository root,
+authorization, state command, and external artifact store. Dispatches bind
+compiler/journal operations, artifact paths, payload schemas, instruction digests,
+command policy, validation units, and predecessors.
+`worker_input_path` names an immutable per-node file containing that exact
+dispatch wrapper and worker prompt. Send it directly; do not extract wrappers
+from the aggregate. `next-ready` verifies these files and returns their paths
+inside `ready_dispatches`.
 
 `inspection_profile` defaults to `shared-read-only`: overlapping audit nodes
 receive one persisted, digest-bound structural observation while retaining
 separate semantic judgments. Use `independent-source` to disable this bounded
 reuse.
 
-Append lifecycle events serially with `journal-append`; valid states are
-`in-flight`, `accepted`, `blocked`, `invalidated`, and terminal
-`awaiting-replan`. Accepted events require the compiled artifact and metadata.
+`journal-append` serializes `in-flight`, `accepted`, `blocked`, `invalidated`,
+and terminal `awaiting-replan` states; acceptance requires compiled evidence.
+Its CLI field contract is:
+
+| Status | Artifact + metadata | Kind | Reason |
+| --- | --- | --- | --- |
+| `in-flight` | forbidden | forbidden | forbidden |
+| `accepted` | required | optional with evidence | forbidden |
+| `blocked` | optional as a pair | optional with evidence | required |
+| `invalidated` | forbidden | forbidden | required |
+| `awaiting-replan` | forbidden | forbidden | required |
+
+Reserve ready dispatches locally; append `in-flight` only after creation succeeds.
+A final result need not release host capacity immediately. On a capacity-only
+failure, preserve that exact reservation, wait for lifecycle/capacity progress
+(at most 30 seconds), and retry once. Do not probe with throwaway workers or
+replay accepted work. If still unavailable, use the profile's fallback/resume
+policy and record the failed attempts; no worker means no execution evidence.
+
+`--journal` may initially be missing or zero-byte; `next-ready` treats both as
+empty without writing. `journal-append` creates a missing file when its parent
+exists. Nonempty journals reject blank records.
 After each event, request only dependency-ready work:
 
 ```sh
@@ -74,61 +86,23 @@ uv run --locked python scripts/review_graph_runtime.py next-ready \
   --output-dir <proof-store>
 ```
 
-The runtime verifies the journal chain, dispatch digest, and current source
-triple. Managed filenames use the journal generation, avoiding overwrite or
-caller-invented sequences.
+The runtime verifies journal, dispatch, and current-source identities.
+`--output-dir` prints JSON `output_path` and `output_generation` after publication;
+filenames use the journal generation for immutable, replayable output.
 
 ## Review Workers
 
-Create workers with `fork_turns: "none"`. Send only their exact dispatch, skill,
-references, repository instructions, and owned paths. Never send prior
-conclusions, unrelated routing, the journal, or proof-format instructions.
-Review nodes may use shared trusted read-only inspection observations, but each
-still returns an independent semantic payload. Planned validators own their
-commands; reviews attest to commands executed and normally return validation
-requirements without rerunning validator recipes. An exact duplicate-command
-authorization keeps the execution visible as reusable evidence.
+Use `fork_turns: "none"` with only the worker input, skill, references, and
+instructions. Exclude coordinator conclusions, routing, and journals. Shared
+observations do not replace independent judgment. Reviews attest to commands;
+validator-command duplicates need explicit authorization and reusable evidence.
 
-Return only this `ReviewPayload` object. Before returning, write its exact bytes
-to the dispatched candidate path and invoke the runtime-owned
-`persist-worker-payload` operation with its materialized input contract. That
-operation validates the schema before atomically renaming the candidate to
-`worker_payload_path`:
+Return only a `ReviewPayload` object. Write its exact bytes to the candidate,
+then execute `worker_payload_persistence.command` unchanged. Its complete argv
+includes the executable, runtime script, and bound paths; it validates and
+atomically publishes `worker_payload_path`.
 
-```json
-{
-  "status": "completed | no-findings | blocked",
-  "commands_executed": [],
-  "command_policy_attested": true,
-  "files_inspected": ["path"],
-  "nearby_contract_owners": ["path"],
-  "findings": [{
-    "severity": "P0 | P1 | P2 | P3",
-    "location": "path:line",
-    "summary": "actionable defect",
-    "evidence": "violated behavior or contract",
-    "remediation": "smallest safe correction"
-  }],
-  "validation_requirements": [{
-    "requirement_id": "stable-id",
-    "owner": "skill-id",
-    "reason": "risk requiring evidence",
-    "commands": ["exact command"],
-    "working_directory": "/absolute/path",
-    "environment": "relevant identity",
-    "expected_evidence": "observable success",
-    "dependency_policy": "stop-on-failure | continue-independent"
-  }],
-  "handoffs": [{
-    "catalog_id": "catalog.entry",
-    "observed_trigger": "new applicability evidence",
-    "reason": "why another owner is required",
-    "scope": ["path"]
-  }],
-  "changes": [],
-  "limitations": []
-}
-```
+Use the materialized payload schema for fields and enum values.
 
 `compile-node` copies accepted bytes to a read-only content-addressed sibling
 and records that sealed path in evidence metadata. The dispatch-bound payload
@@ -136,18 +110,22 @@ path remains staging only; later valid retries cannot replace accepted proof
 bytes.
 
 Use empty arrays for absent fields. `blocked` requires a limitation;
-`no-findings` requires no findings. The compiler rejects validator-owned
+`no-findings` requires no findings and inspection of every audit-owned path.
+A completed audit may omit an owned path only when `scope_limitations` contains
+exactly one path-specific reason for it. Inspected paths must be unique and
+owned by the dispatch. Payload persistence and compilation both enforce this.
+Bundle-only synthesis may leave `files_inspected` empty; predecessor evidence
+remains mandatory. Do not invent source reads to satisfy a field.
+The compiler rejects validator-owned
 commands and non-catalog handoffs. One schema mismatch permits one retry using
 field diagnostics; a second mismatch blocks the node. For authorized fixes,
 each change names finding IDs, files, what changed, why, and the preserved
 contract; the trusted dispatch records mutation facts.
 
-Run `compile-node` with the node ID, signed dispatch set, before/after captures,
-and journal. It selects the dispatch and reads only its bound worker payload
-path, preserving the original
-payload bytes, assigns identities, renders the native artifact and envelope,
-runs both evidence gates, and journals verified evidence. The lower-level
-`compile-review` command remains available for compiler diagnosis.
+Run `compile-node` with the node ID, signed dispatch set, captures, and journal.
+It reads only the bound payload, preserves its bytes, assigns identities,
+renders and verifies native evidence, then journals it. `compile-review` remains
+available for diagnosis.
 
 ## Independent Review And Validation
 
@@ -159,31 +137,33 @@ checks, findings, and catalog handoffs; it assigns identities, appends the
 envelope and Machine Evidence, and emits journal-compatible metadata.
 
 Coalesced validators read only `review-validator/references/graph-dispatch.md`,
-publish their `ValidationPayload` through `persist-worker-payload`, and then
-return those same bytes. Run `snapshot-workspace` immediately before
-and after the exact command sequence, then pass both snapshots to
-`compile-node`. The worker omits artifact records and digests; the runtime
-derives them from the post-execution snapshot. Every derived artifact carries
-its digest mode, distinguishing bounded metadata manifests from content
-digests. `compile-validation` derives
-command/environment digests, mappings, ledger export, and canonical evidence.
-Declared artifacts include independently verified status provenance. `ignored` requires a tracked repository
-`.gitignore`; repository-local and global excludes are rejected. Declared
-workspace effects require trusted before/after filesystem and Git snapshots;
-unexpected tracked, untracked, or ignored outputs fail acceptance. Validators
-that can create source-adjacent intermediates run under the exact dispatched
-isolation root; outside-repository artifacts must resolve beneath that root.
-Known cache/build directory roots such as `target/` use
-`bounded-directory-metadata-v3`: existence and metadata for every immediate
-entry, plus a bounded detailed sample. Recursive directory hashing uses
-`recursive-content-sha256-v2`, replacing any nested known cache/build root with
-its bounded manifest while retaining content hashing elsewhere.
+publish through `persist-worker-payload`, and return identical bytes. Snapshot
+the workspace immediately before and after commands; the runtime derives
+artifact records, digest modes, command/environment identities, mappings, and
+ledger evidence. `ignored` artifacts require a tracked `.gitignore`; other
+excludes fail. Unexpected workspace effects fail. Source-adjacent intermediates
+and outside-repository artifacts stay under the dispatched isolation root.
+Known cache/build roots use bounded metadata manifests; other recursive content
+uses content digests.
 
 Use `synthesis-bundle` to verify accepted artifacts and derive the compact,
 hashed findings, mappings, validation, handoff, limitation, and artifact view.
 Synthesis receives that bundle, never full predecessor reports.
+Supply its `plan` to include hashed router closure, exclusions, exact reuse,
+requirement/validator mappings, and handoff reconciliation in `plan_context`.
 
 ## Mutation, Handoffs, And Proof
+
+Accepted late validation requirements block synthesis and final proof until
+exactly planned or explicitly user-excluded. Run
+`reconcile-validation-requirements --input <request.json> --journal <journal>
+--dispatches <dispatches.json> --current-capture <capture.json> --output <result.json>`.
+Start with `plan` and `source_state` to inspect discoveries. To expand, add
+`validation_requirements` (planning-schema objects) and `artifact_store`, or
+explicit `user_exclusions` bound to the returned origin, requirement ID/digest,
+and reason. Follow returned lifecycle, journal, and dispatch paths. Source state
+and accepted audits/CI stay unchanged; synthesis inputs refresh. Wait for active
+workers before expansion. Details: [planning-contract.md](planning-contract.md#late-validation-expansion).
 
 Run `reconcile-handoffs` before expansion. Selected, exactly reused, or
 user-excluded catalog entries resolve existing handoffs; only
@@ -191,11 +171,12 @@ user-excluded catalog entries resolve existing handoffs; only
 from the typed catalog mappings reparsed from accepted evidence, not from
 caller-provided resolved IDs.
 
-After an authorized repair batch, run `advance-after-mutation`. It records an
-authorization upgrade when applicable, one serialized repair epoch and
-recapture, terminally invalidates stale nodes as `awaiting-replan`, includes
-newly touched paths, and emits replacement identities, lineage, and dispatches
-bound to the final source triple. Never redispatch an old immutable dispatch.
+After authorized repairs, run `advance-after-mutation` with the immediately
+preceding `previous_capture`, `new_capture`, and their exact `changed_paths`
+content delta. Invalidation follows owners and downstream dependencies. Supply
+accepted `sources` for verified unchanged-input audit reuse; validators,
+independent reviews, syntheses, and unproven audits rerun. Follow returned
+`lifecycle_input` and fresh dispatches; old artifacts remain unchanged.
 
 Persist all capture, plan, payload, compiled evidence, journal, synthesis,
 invalidation, manifest, and proof artifacts outside the reviewed repository.

--- a/agents/.agents/skills/review-graph/references/runtime-operation-examples-v1.json
+++ b/agents/.agents/skills/review-graph/references/runtime-operation-examples-v1.json
@@ -7,6 +7,7 @@
     "new_capture": {},
     "plan": {},
     "planning_template": {},
+    "previous_capture": {},
     "repair_epoch": 1,
     "source_state": ["scope-before", "worktree-before", "repository-before"],
     "state_verification_command": "capture_scope.py --mode branch"
@@ -31,6 +32,7 @@
       "handoffs": [],
       "limitations": [],
       "nearby_contract_owners": [],
+      "scope_limitations": [],
       "status": "no-findings",
       "validation_requirements": []
     }
@@ -68,7 +70,9 @@
   },
   "persist-worker-payload": {
     "candidate_path": "/tmp/review-proof/audit.worker-payload.candidate.json",
+    "mode": "audit",
     "node_id": "audit",
+    "owned_paths": ["src/lib.py"],
     "result_contract": "compact-review",
     "schema_version": 1,
     "worker_payload_path": "/tmp/review-proof/audit.worker-payload.json"
@@ -77,6 +81,10 @@
     "plan": {},
     "source_state": ["scope", "worktree", "repository"],
     "sources": []
+  },
+  "reconcile-validation-requirements": {
+    "plan": {},
+    "source_state": ["scope", "worktree", "repository"]
   },
   "routing-projection": {
     "captured_paths": ["src/lib.py"],

--- a/agents/.agents/skills/review-graph/references/runtime-operation-examples-v1.json
+++ b/agents/.agents/skills/review-graph/references/runtime-operation-examples-v1.json
@@ -46,6 +46,14 @@
       "status": "not-applicable"
     }
   },
+  "fallback-to-coordinator": {
+    "artifact_store": "/tmp/review-fallback",
+    "node_id": "audit-001",
+    "plan": {},
+    "reason": "bounded worker-capacity retry exhausted; no worker created",
+    "source_state": ["scope", "worktree", "repository"],
+    "worker_created": false
+  },
   "finalize-proof": {
     "plan": {},
     "source_state": ["scope", "worktree", "repository"],

--- a/agents/.agents/skills/review-graph/references/schemas/planning-input-v1.schema.json
+++ b/agents/.agents/skills/review-graph/references/schemas/planning-input-v1.schema.json
@@ -248,7 +248,11 @@
         "allowed_artifacts": {"items": {"$ref": "#/$defs/artifact"}, "type": "array"},
         "artifact_owner": {"type": "string"},
         "authority": {"type": "string"},
-        "baseline": {"type": "boolean"},
+        "baseline": {
+          "description": "Marks the repository's baseline check, not baseline review scope. Every graph requires at least one validation unit with baseline: true, including branch/staged/worktree reviews. For a branch gate such as just ci, set baseline: true and retain requested_scope: branch.",
+          "examples": [true],
+          "type": "boolean"
+        },
         "canonical_recipe": {"type": ["string", "null"]},
         "capture_command": {"type": "string"},
         "captured_paths": {"$ref": "#/$defs/stringArray"},
@@ -269,7 +273,10 @@
         "planning_blocker": {"type": ["string", "null"]},
         "platform": {"type": "string"},
         "request": {"type": "string"},
-        "requested_scope": {"type": "string"},
+        "requested_scope": {
+          "description": "Scope being validated; independent of the baseline flag that designates the repository check. A branch review normally uses branch even when baseline is true.",
+          "enum": ["branch", "staged", "worktree", "baseline", "release"]
+        },
         "requires_isolation": {"type": "boolean"},
         "required": {"type": "boolean"},
         "requirement_id": {"type": "string"},

--- a/agents/.agents/skills/review-graph/references/schemas/review-payload-v1.schema.json
+++ b/agents/.agents/skills/review-graph/references/schemas/review-payload-v1.schema.json
@@ -51,6 +51,18 @@
       "type": "array"
     },
     "limitations": {"items": {"type": "string"}, "type": "array"},
+    "scope_limitations": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "path": {"minLength": 1, "type": "string"},
+          "reason": {"minLength": 1, "type": "string"}
+        },
+        "required": ["path", "reason"],
+        "type": "object"
+      },
+      "type": "array"
+    },
     "nearby_contract_owners": {"items": {"type": "string"}, "type": "array"},
     "status": {"enum": ["completed", "no-findings", "blocked"]},
     "validation_requirements": {
@@ -81,6 +93,7 @@
     "handoffs",
     "changes",
     "limitations",
+    "scope_limitations",
     "commands_executed",
     "command_policy_attested"
   ],

--- a/agents/.agents/skills/review-graph/references/schemas/runtime-operation-inputs-v1.schema.json
+++ b/agents/.agents/skills/review-graph/references/schemas/runtime-operation-inputs-v1.schema.json
@@ -13,9 +13,11 @@
         "new_capture": {"type": "object"},
         "plan": {"type": "object"},
         "planning_template": {"type": "object"},
+        "previous_capture": {"type": "object"},
         "repair_epoch": {"minimum": 1, "type": "integer"},
         "routing_catalog_path": {"minLength": 1, "type": "string"},
         "source_state": {"$ref": "#/$defs/sourceState"},
+        "sources": {"items": {"$ref": "#/$defs/sourceRecord"}, "type": "array"},
         "state_verification_command": {"minLength": 1, "type": "string"}
       },
       "required": [
@@ -26,6 +28,7 @@
         "new_capture",
         "plan",
         "planning_template",
+        "previous_capture",
         "repair_epoch",
         "source_state",
         "state_verification_command"
@@ -129,12 +132,14 @@
       "additionalProperties": false,
       "properties": {
         "candidate_path": {"minLength": 1, "type": "string"},
+        "mode": {"enum": ["audit", "fix", "independent-review", "revalidation", "synthesis", "validation"]},
         "node_id": {"minLength": 1, "type": "string"},
+        "owned_paths": {"$ref": "#/$defs/stringArray"},
         "result_contract": {"enum": ["compact-review", "compact-validation", "native-independent-review"]},
         "schema_version": {"const": 1},
         "worker_payload_path": {"minLength": 1, "type": "string"}
       },
-      "required": ["candidate_path", "node_id", "result_contract", "schema_version", "worker_payload_path"],
+      "required": ["candidate_path", "mode", "node_id", "owned_paths", "result_contract", "schema_version", "worker_payload_path"],
       "type": "object"
     },
     "reconcile-handoffs": {
@@ -145,6 +150,35 @@
         "sources": {"items": {"$ref": "#/$defs/sourceRecord"}, "type": "array"}
       },
       "required": ["plan", "source_state", "sources"],
+      "type": "object"
+    },
+    "reconcile-validation-requirements": {
+      "additionalProperties": false,
+      "properties": {
+        "plan": {"type": "object"},
+        "source_state": {"$ref": "#/$defs/sourceState"},
+        "artifact_store": {"minLength": 1, "type": "string"},
+        "validation_requirements": {
+          "description": "New full validationRequirement objects from planning-input-v1; each is validated against that definition and the accepted review's exact command, working-directory, environment and dependency identity.",
+          "items": {"type": "object"},
+          "type": "array"
+        },
+        "user_exclusions": {
+          "items": {
+            "additionalProperties": false,
+            "properties": {
+              "originating_evidence_id": {"minLength": 1, "type": "string"},
+              "requirement_id": {"minLength": 1, "type": "string"},
+              "requirement_digest": {"minLength": 1, "type": "string"},
+              "reason": {"minLength": 1, "type": "string"}
+            },
+            "required": ["originating_evidence_id", "requirement_id", "requirement_digest", "reason"],
+            "type": "object"
+          },
+          "type": "array"
+        }
+      },
+      "required": ["plan", "source_state"],
       "type": "object"
     },
     "routing-projection": {
@@ -189,8 +223,9 @@
     "synthesis-bundle": {
       "additionalProperties": false,
       "properties": {
+        "plan": {"type": "object"},
         "source_state": {"$ref": "#/$defs/sourceState"},
-        "sources": {"items": {"$ref": "#/$defs/sourceRecord"}, "minItems": 1, "type": "array"}
+        "sources": {"items": {"$ref": "#/$defs/sourceRecord"}, "type": "array"}
       },
       "required": ["source_state", "sources"],
       "type": "object"

--- a/agents/.agents/skills/review-graph/references/schemas/runtime-operation-inputs-v1.schema.json
+++ b/agents/.agents/skills/review-graph/references/schemas/runtime-operation-inputs-v1.schema.json
@@ -76,6 +76,19 @@
       "required": ["dispatch", "payload"],
       "type": "object"
     },
+    "fallback-to-coordinator": {
+      "additionalProperties": false,
+      "properties": {
+        "artifact_store": {"minLength": 1, "type": "string"},
+        "node_id": {"minLength": 1, "type": "string"},
+        "plan": {"type": "object"},
+        "reason": {"minLength": 1, "type": "string"},
+        "source_state": {"$ref": "#/$defs/sourceState"},
+        "worker_created": {"const": false}
+      },
+      "required": ["artifact_store", "node_id", "plan", "reason", "source_state", "worker_created"],
+      "type": "object"
+    },
     "finalize-proof": {
       "additionalProperties": false,
       "properties": {

--- a/agents/.agents/skills/review-graph/scripts/capture_scope.py
+++ b/agents/.agents/skills/review-graph/scripts/capture_scope.py
@@ -40,10 +40,12 @@ class _PathDigest:
         self.digest = hashlib.sha256()
 
     def update(self, value: bytes) -> None:
+        """Feed bytes to both the parent and per-path digests."""
         self.parent.update(value)
         self.digest.update(value)
 
     def hexdigest(self) -> str:
+        """Return the per-path digest as a hexadecimal string."""
         return self.digest.hexdigest()
 
 

--- a/agents/.agents/skills/review-graph/scripts/capture_scope.py
+++ b/agents/.agents/skills/review-graph/scripts/capture_scope.py
@@ -12,6 +12,8 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol
 
+from review_graph_reuse import SNAPSHOT_FORMAT, source_snapshot
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -28,6 +30,21 @@ class _Digest(Protocol):
 
     def hexdigest(self) -> str:
         """Return the hexadecimal digest."""
+
+
+class _PathDigest:
+    """Collect a path identity from the same bytes as the repository digest."""
+
+    def __init__(self, parent: _Digest) -> None:
+        self.parent = parent
+        self.digest = hashlib.sha256()
+
+    def update(self, value: bytes) -> None:
+        self.parent.update(value)
+        self.digest.update(value)
+
+    def hexdigest(self) -> str:
+        return self.digest.hexdigest()
 
 
 def _run_git(git: str, repo: Path, arguments: Sequence[str]) -> bytes:
@@ -204,14 +221,27 @@ def _update_worktree_path(digest: _Digest, git: str, repo: Path, relative: str) 
     raise RuntimeError(message)
 
 
-def _worktree_fingerprint(*, git: str, identity: Sequence[tuple[str, bytes]], pathspecs: Sequence[str], paths: Sequence[str], repo: Path) -> str:
+def _worktree_fingerprint(  # noqa: PLR0913 - optional path identities share the canonical fingerprint traversal.
+    *,
+    git: str,
+    identity: Sequence[tuple[str, bytes]],
+    pathspecs: Sequence[str],
+    paths: Sequence[str],
+    repo: Path,
+    path_fingerprints: dict[str, str] | None = None,
+) -> str:
     """Hash the selected worktree state from canonical path content and modes."""
     digest = hashlib.sha256()
     for label, value in identity:
         _update_part(digest, label, value)
     _update_part(digest, "requested-paths", json.dumps(pathspecs, separators=(",", ":")).encode())
     for relative in sorted(set(paths)):
-        _update_worktree_path(digest, git, repo, relative)
+        if path_fingerprints is None:
+            _update_worktree_path(digest, git, repo, relative)
+        else:
+            path_digest = _PathDigest(digest)
+            _update_worktree_path(path_digest, git, repo, relative)
+            path_fingerprints[relative] = path_digest.hexdigest()
     return digest.hexdigest()
 
 
@@ -301,23 +331,31 @@ def _captured_path_line_bounds(*, git: str, repo: Path, mode: str, base_revision
     return bounds
 
 
-def _repository_state_fingerprint(*, git: str, repo: Path, head: str, branch: str) -> str:
+def _repository_state_snapshot(*, git: str, repo: Path, head: str, branch: str, captured_paths: Sequence[str]) -> tuple[str, dict[str, str], str]:
     """Hash HEAD, branch, index, tracked worktree, and nonignored untracked content."""
     tracked = _decode_zlist(_run_git(git, repo, ("ls-files", "-z")))
     untracked = _decode_zlist(_run_git(git, repo, ("ls-files", "--others", "--exclude-standard", "-z")))
+    path_fingerprints: dict[str, str] = {}
     worktree = _worktree_fingerprint(
         git=git,
         identity=(("head", head.encode()), ("branch", branch.encode()), ("mode", b"repository-state")),
         pathspecs=(),
         paths=(*tracked, *untracked),
         repo=repo,
+        path_fingerprints=path_fingerprints,
     )
+    index_entries = _run_git(git, repo, ("ls-files", "--stage", "-z"))
     digest = hashlib.sha256()
     _update_part(digest, "head", head.encode())
     _update_part(digest, "branch", branch.encode())
-    _update_part(digest, "index-entries", _run_git(git, repo, ("ls-files", "--stage", "-z")))
+    _update_part(digest, "index-entries", index_entries)
     _update_part(digest, "worktree", worktree.encode())
-    return digest.hexdigest()
+    # Deleted branch/index paths remain in the review scope but not ls-files.
+    for relative in sorted(set(captured_paths) - path_fingerprints.keys()):
+        path_digest = hashlib.sha256()
+        _update_worktree_path(path_digest, git, repo, relative)
+        path_fingerprints[relative] = path_digest.hexdigest()
+    return digest.hexdigest(), path_fingerprints, hashlib.sha256(index_entries).hexdigest()
 
 
 def _scope_data(git: str, repo: Path, mode: str, base: str | None, pathspecs: Sequence[str]) -> dict[str, object]:  # noqa: PLR0915
@@ -402,9 +440,11 @@ def _scope_data(git: str, repo: Path, mode: str, base: str | None, pathspecs: Se
     )
     status_arguments = _with_paths(("status", "--porcelain=v1", "-z", "--untracked-files=all"), pathspecs)
     status = _decode_zlist(_run_git(git, repo, status_arguments))
-    repository_state_fingerprint = _repository_state_fingerprint(git=git, repo=repo, head=head, branch=branch)
+    repository_state_fingerprint, repository_path_fingerprints, index_fingerprint = _repository_state_snapshot(
+        git=git, repo=repo, head=head, branch=branch, captured_paths=captured_scope_paths
+    )
 
-    return {
+    manifest = {
         "base_ref": base_ref,
         "branch": branch or None,
         "capture_mode": mode,
@@ -412,14 +452,19 @@ def _scope_data(git: str, repo: Path, mode: str, base: str | None, pathspecs: Se
         "captured_scope_paths": captured_scope_paths,
         "captured_worktree_fingerprint": captured_worktree_fingerprint,
         "head": head,
+        "index_fingerprint": index_fingerprint,
         "merge_base": merge_base,
         "repository_root": os.fspath(repo),
+        "repository_path_fingerprints": repository_path_fingerprints,
         "repository_state_fingerprint": repository_state_fingerprint,
+        "repository_state_format": SNAPSHOT_FORMAT,
         "requested_paths": list(pathspecs),
         "scope_fingerprint": scope_fingerprint,
         "status": status,
         "untracked_paths": selected_untracked,
     }
+    manifest["repository_state_fingerprint"] = source_snapshot(manifest).computed_fingerprint()
+    return manifest
 
 
 def _parser() -> argparse.ArgumentParser:

--- a/agents/.agents/skills/review-graph/scripts/fixtures/routing_regressions.json
+++ b/agents/.agents/skills/review-graph/scripts/fixtures/routing_regressions.json
@@ -1,6 +1,14 @@
 {
   "cases": [
     {
+      "id": "release-tooling-change-keeps-readme-citation-ownership-without-bibliography-changes",
+      "consulted_routers": ["review-graph", "docs-review-orchestrator", "python-review-orchestrator", "rust-review-orchestrator"],
+      "paths": ["README.md", "docs/BENCHMARKING.md", "docs/RELEASING.md", "docs/code_organization.md", "docs/dev/rust.md", "scripts/update_release_version.py"],
+      "expected_matches": {
+        "docs.citations": ["README.md", "docs/BENCHMARKING.md", "docs/RELEASING.md", "docs/code_organization.md", "docs/dev/rust.md"]
+      }
+    },
+    {
       "id": "documentation-only-does-not-activate-cpp-api-docs",
       "consulted_routers": ["review-graph", "docs-review-orchestrator"],
       "paths": ["docs/architecture.md"],
@@ -30,6 +38,15 @@
       "paths": ["scripts/tests/test_release.py", "scripts/tests/integration/conftest.py"],
       "expected_matches": {
         "python.tests": ["scripts/tests/test_release.py", "scripts/tests/integration/conftest.py"]
+      }
+    },
+    {
+      "id": "canonical-bibliography-routes-to-citation-audit",
+      "consulted_routers": ["review-graph", "docs-review-orchestrator"],
+      "paths": ["REFERENCES.md"],
+      "expected_matches": {
+        "docs.repository": ["REFERENCES.md"],
+        "docs.citations": ["REFERENCES.md"]
       }
     }
   ]

--- a/agents/.agents/skills/review-graph/scripts/fixtures/routing_surface_matrix.json
+++ b/agents/.agents/skills/review-graph/scripts/fixtures/routing_surface_matrix.json
@@ -32,6 +32,12 @@
       "expected_surfaces": ["tooling"]
     },
     {
+      "id": "canonical-bibliography",
+      "mode": "baseline",
+      "paths": ["REFERENCES.md"],
+      "expected_surfaces": ["documentation", "tooling"]
+    },
+    {
       "id": "cross-surface-shared-owners",
       "mode": "branch",
       "paths": ["Cargo.toml", "pyproject.toml", "CMakeLists.txt", "src/lib.rs", "src/tool.py", "src/model.cpp", ".github/workflows/ci.yml", "README.md"],

--- a/agents/.agents/skills/review-graph/scripts/review_graph_bootstrap.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_bootstrap.py
@@ -118,7 +118,15 @@ def _write_once(path: Path, value: object) -> None:
 
 
 def _parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        epilog=(
+            "Every graph needs a repository validation requirement with baseline: true. "
+            "This marks the repository check, not baseline review scope: a branch just ci unit uses "
+            "baseline: true with requested_scope: branch. "
+            f"Field contracts: {PLANNING_SCHEMA}#/$defs/validationRequirement"
+        ),
+    )
     parser.add_argument("--capture", type=Path, required=True, help="capture_scope.py JSON manifest")
     parser.add_argument("--input", type=Path, required=True, help="compact routing and validation template")
     parser.add_argument("--output", type=Path, required=True, help="immutable normalized planning document")
@@ -131,7 +139,8 @@ def main(argv: list[str] | None = None) -> int:
     """Normalize, validate, plan, and persist one deterministic bootstrap result."""
     args = _parser().parse_args(argv)
     try:
-        document = bootstrap_document(_read_object(args.capture), _read_object(args.input))
+        capture = _read_object(args.capture)
+        document = bootstrap_document(capture, _read_object(args.input))
         require_schema(document, PLANNING_SCHEMA)
         root = Path(str(document["repository_root"]))
         plan = plan_from_document(document, catalog_path=args.catalog, skill_roots=tuple(args.skill_root or (DEFAULT_SKILL_ROOT,)), repository_root=root)
@@ -155,6 +164,7 @@ def main(argv: list[str] | None = None) -> int:
         for operation in ("compile-node", "finalize-proof", "journal-append", "next-ready", "snapshot-workspace"):
             require_schema_definition(lifecycle_input, RUNTIME_SCHEMA, operation)
         output = {
+            "capture": capture,
             "lifecycle_input": lifecycle_input,
             "materialization_input": materialization_input,
             "plan": plan_document,

--- a/agents/.agents/skills/review-graph/scripts/review_graph_plan.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_plan.py
@@ -16,6 +16,7 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from capture_scope import _scope_data
+from review_graph_reuse import AuditInputIdentity, AuditReuseTransition, ReviewSourceSnapshot, verify_reuse_inputs
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -484,6 +485,16 @@ class WorkerBudget:
 
 
 @dataclass(frozen=True)
+class ValidationExclusion:
+    """Explicit user scope decision bound to an exact discovered requirement."""
+
+    originating_evidence_id: str
+    requirement_id: str
+    requirement_digest: str
+    reason: str
+
+
+@dataclass(frozen=True)
 class GraphPlan:
     """Complete required graph, partitioned only for isolated scheduling."""
 
@@ -511,6 +522,9 @@ class GraphPlan:
     routing_completion_blockers: tuple[str, ...]
     dispatch_allowed: bool
     blockers: tuple[str, ...]
+    audit_reuse_transitions: tuple[AuditReuseTransition, ...] = ()
+    reuse_source_snapshots: tuple[ReviewSourceSnapshot, ...] = ()
+    validation_exclusions: tuple[ValidationExclusion, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -543,6 +557,7 @@ class ReviewEvidenceExpectation:
     change_target: str | None = None
     planned_paths: tuple[str, ...] = ()
     planned_path_line_bounds: tuple[tuple[str, int], ...] = ()
+    audit_input_identity: AuditInputIdentity | None = None
 
 
 @dataclass(frozen=True)
@@ -747,6 +762,12 @@ class RepositoryReviewProofExpectation:
         if identity_mapping != reused_mapping:
             msg = "repository review proof expectation exact-reuse identities do not match the routed evidence mapping"
             raise ValueError(msg)
+        transitions = self.plan.audit_reuse_transitions
+        if len({item.evidence_id for item in transitions}) != len(transitions) or any(
+            item.evidence_id not in {evidence_id for _, evidence_id in reused_mapping} or item.target_state != self.source_state for item in transitions
+        ):
+            msg = "audit reuse transitions must uniquely match current non-executable reuse identities"
+            raise ValueError(msg)
         if any(
             not _nonempty_text(item.skill_id)
             or not _nonempty_text(item.skill_path)
@@ -793,7 +814,7 @@ class RepositoryReviewProofExpectation:
         required_validation_ids = tuple(
             sorted(requirement_id for unit in self.plan.coalesced_validation_units if unit.required or unit.baseline for requirement_id in unit.requirement_ids)
         )
-        object.__setattr__(self, "plan_digest", _sha256_json(asdict(self.plan)))
+        object.__setattr__(self, "plan_digest", graph_plan_digest(self.plan))
         object.__setattr__(self, "required_review_requirement_ids", required_review_ids)
         object.__setattr__(
             self,
@@ -1272,7 +1293,7 @@ def validate_routing_ledger(  # noqa: C901
             skill_path=item.skill_path,
             mode="independent-review" if active_entries[item.catalog_id].target_kind == "independent" else "audit",
             static_references=item.static_references,
-            planned_paths=item.review_surface if active_entries[item.catalog_id].target_kind == "independent" else (),
+            planned_paths=item.review_surface,
         )
         for item in reused_decisions
     )
@@ -1413,7 +1434,16 @@ def classify_repository_paths(paths: Sequence[str], *, release_readiness: bool =
                 add("rust", path, "shared workflow/recipe may alter Rust validation")
             if has_python:
                 add("python", path, "shared workflow/recipe may alter Python validation")
-        if basename in {"README.md", "AGENTS.md", "CONTRIBUTING.md", "SECURITY.md", "CITATION.cff"} or path.startswith("docs/"):
+        if basename in {
+            "README.md",
+            "AGENTS.md",
+            "CONTRIBUTING.md",
+            "SECURITY.md",
+            "CITATION.cff",
+            "REFERENCES.md",
+            "BIBLIOGRAPHY.md",
+            "CITATIONS.md",
+        } or path.startswith("docs/"):
             add("documentation", path, "active repository documentation")
             add("tooling", path, "documentation may describe commands or maintainer workflow")
     if release_readiness:
@@ -1672,13 +1702,13 @@ def _synthesis_reused_evidence_ids(plan: GraphPlan, node_id: str) -> tuple[str, 
         return ()
     mapping = dict(plan.exact_reused_review_evidence)
     if (node.skill_id, node.mode) == FINAL_SYNTHESIS_IDENTITY[1:]:
-        return tuple(evidence_id for _requirement_id, evidence_id in plan.exact_reused_review_evidence)
+        return tuple(dict.fromkeys(evidence_id for _requirement_id, evidence_id in plan.exact_reused_review_evidence))
     routed_requirement_ids = {
         decision.requirement_id
         for decision in plan.routing_decisions
         if decision.disposition == "exact-evidence-reused" and decision.synthesis_dependency == node.node_id
     }
-    return tuple(mapping[requirement_id] for requirement_id in mapping if requirement_id in routed_requirement_ids)
+    return tuple(dict.fromkeys(mapping[requirement_id] for requirement_id in mapping if requirement_id in routed_requirement_ids))
 
 
 def coalesce_review_requirements(
@@ -2135,7 +2165,11 @@ def plan_graph(  # noqa: C901, PLR0913, PLR0915
     audit_nodes, requirement_to_node = coalesce_review_requirements(review_requirements, reserved_node_ids=tuple(reserved_node_ids))
     validation_units, evidence_mapping = coalesce_validation_requirements(validation_requirements, reserved_node_ids=tuple(reserved_node_ids))
     if not any(unit.baseline for unit in validation_units):
-        msg = "bounded review graphs require at least one baseline validation unit"
+        msg = (
+            "bounded review graphs require at least one baseline validation unit: set validation_requirements[i].baseline=true "
+            "on the repository check (for example just ci). This flag does not select baseline review scope; "
+            "keep requested_scope=branch for a branch review"
+        )
         raise ValueError(msg)
     declared_validation_ids = {item.requirement_id for item in validation_requirements}
     missing_validation_ids = sorted(
@@ -2272,6 +2306,14 @@ def _identifier_tuple_blockers(values: Sequence[str], *, label: str) -> tuple[st
     if _duplicate_values(values):
         blockers.append(f"{label} must be unique")
     return tuple(blockers)
+
+
+def graph_plan_digest(plan: GraphPlan) -> str:
+    """Hash a plan while preserving pre-exclusion identities when none are present."""
+    document = asdict(plan)
+    if not plan.validation_exclusions:
+        document.pop("validation_exclusions")
+    return _sha256_json(document)
 
 
 def _sha256_json(value: object) -> str:
@@ -2707,6 +2749,9 @@ def _ordinary_review_native_blockers(  # noqa: C901, PLR0912
         )
     )
     scope = sections["## Scope Inspected"]
+    if expectation.audit_input_identity is not None:
+        serialized_inputs = json.dumps(asdict(expectation.audit_input_identity), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        blockers.extend(_native_values_blockers(scope, section="Scope Inspected", label="Audit input identity", expected=(serialized_inputs,)))
     if evidence.status != "blocked":
         blockers.extend(_native_nonempty_section_blockers(scope, section="Scope Inspected"))
         files = _native_field_values(scope, "Files")
@@ -3874,6 +3919,45 @@ def assess_repository_review_proof(  # noqa: C901, PLR0912
     return Assessment(not blockers, tuple(blockers))
 
 
+def review_source_state_blockers(  # noqa: PLR0911 - fail closed at each provenance boundary.
+    plan: GraphPlan, expectation: ReviewEvidenceExpectation, evidence: ReviewEvidence, source_state: tuple[str, str, str]
+) -> tuple[str, ...]:
+    """Accept old audit bytes only through a planner-bound unchanged-input proof."""
+    if expectation.source_state == source_state:
+        return ()
+    transitions = tuple(item for item in plan.audit_reuse_transitions if item.evidence_id == evidence.evidence_id)
+    if len(transitions) != 1:
+        return (f"review evidence has a different source state without verified reuse: {evidence.evidence_id}",)
+    transition = transitions[0]
+    inputs = expectation.audit_input_identity
+    if (
+        expectation.mode != "audit"
+        or evidence.mode != "audit"
+        or evidence.status not in {"completed", "no-findings"}
+        or inputs is None
+        or evidence.predecessor_evidence_ids
+        or expectation.execution_profile != plan.execution_profile
+    ):
+        return ("cross-capture reuse requires a complete independent audit leaf with bound inputs",)
+    if (transition.source_state, transition.target_state, transition.artifact_digest) != (expectation.source_state, source_state, evidence.raw_result_digest):
+        return ("audit reuse transition differs from original artifact or current source state",)
+    identities = tuple(item for item in plan.reused_review_identities if item.evidence_id == evidence.evidence_id)
+    if {item.requirement_id for item in identities} != set(evidence.requirement_ids) or any(
+        (item.skill_id, item.skill_path, item.skill_digest, item.reference_digests, item.mode, item.planned_paths)
+        != (evidence.skill_id, evidence.skill_path, evidence.skill_digest, evidence.reference_digests, "audit", inputs.owned_paths)
+        for item in identities
+    ):
+        return ("audit reuse routed requirements, scope, or skill/reference identity changed",)
+    snapshots = {item.source_state: item for item in plan.reuse_source_snapshots}
+    if len(snapshots) != len(plan.reuse_source_snapshots) or transition.source_state not in snapshots or source_state not in snapshots:
+        return ("audit reuse requires unique origin and target source snapshots",)
+    try:
+        verify_reuse_inputs(snapshots[transition.source_state], snapshots[source_state], inputs, transition)
+    except ValueError as error:
+        return (str(error),)
+    return ()
+
+
 def _review_bundle_blockers(  # noqa: C901, PLR0912
     proof_expectation: RepositoryReviewProofExpectation, proof: RepositoryReviewProof, records: Sequence[tuple[ReviewEvidenceExpectation, ReviewEvidence]]
 ) -> tuple[tuple[str, ...], dict[str, tuple[ReviewEvidenceExpectation, ReviewEvidence]]]:
@@ -3930,8 +4014,7 @@ def _review_bundle_blockers(  # noqa: C901, PLR0912
         blockers.extend(f"{evidence_id}: {blocker}" for blocker in assessment.blockers)
         if not assessment.satisfies_requirements:
             blockers.append(f"accepted review evidence does not satisfy its requirements: {evidence_id}")
-        if expectation.source_state != proof.source_state:
-            blockers.append(f"accepted review evidence has a different source state: {evidence_id}")
+        blockers.extend(review_source_state_blockers(proof_expectation.plan, expectation, evidence, proof.source_state))
     synthesis_record = by_id.get(proof.final_synthesis_evidence_id)
     if synthesis_record is not None:
         expectation, evidence = synthesis_record
@@ -5343,6 +5426,52 @@ def _compact_routing_overrides_from_document(
     return tuple(overrides)
 
 
+def validation_requirements_from_document(document: Mapping[str, Any], repository_root: Path | None) -> tuple[ValidationRequirement, ...]:
+    """Parse validation plans consistently for bootstrap and source-preserving expansion."""
+    return tuple(
+        ValidationRequirement(
+            requirement_id=_bounded_text_field(item, "requirement_id"),
+            source_state=_source_state_field(item),
+            commands=_tuple_field(item, "commands"),
+            working_directories=_tuple_field(item, "working_directories"),
+            environment=_bounded_text_field(item, "environment"),
+            toolchain=_bounded_text_field(item, "toolchain"),
+            features=_tuple_field(item, "features"),
+            platform=_bounded_text_field(item, "platform"),
+            artifact_owner=_bounded_text_field(item, "artifact_owner"),
+            mutation_lock=_bounded_text_field(item, "mutation_lock"),
+            request=_bounded_text_field(item, "request"),
+            requested_scope=_bounded_text_field(item, "requested_scope"),
+            capture_command=_bounded_text_field(item, "capture_command"),
+            captured_paths=_tuple_field(item, "captured_paths"),
+            authority=_bounded_text_field(item, "authority"),
+            selection_reason=_bounded_text_field(item, "selection_reason"),
+            mutation_classification=_bounded_text_field(item, "mutation_classification"),
+            expected_evidence=_bounded_text_field(item, "expected_evidence"),
+            elapsed_time_budget=_bounded_text_field(item, "elapsed_time_budget"),
+            dependency_policy=_bounded_text_field(item, "dependency_policy"),
+            meaningful_skips=_tuple_field(item, "meaningful_skips"),
+            execution_strategy=_bounded_text_field(item, "execution_strategy"),
+            independence_basis=_bounded_text_field(item, "independence_basis"),
+            planning_blocker=_optional_bounded_text_field(item, "planning_blocker"),
+            allowed_artifacts=_allowed_artifacts_field(item, repository_root, _optional_bounded_text_field(item, "isolation_root")),
+            canonical_recipe=_optional_bounded_text_field(item, "canonical_recipe"),
+            evidence_id=_optional_bounded_text_field(item, "evidence_id"),
+            required=_boolean_field(item, "required", default=True, label=f"validation requirement {item.get('requirement_id', '<unknown>')} required"),
+            baseline=_boolean_field(item, "baseline", default=False, label=f"validation requirement {item.get('requirement_id', '<unknown>')} baseline"),
+            expected_workspace_effects=_normalized_repository_paths(
+                _tuple_field(item, "expected_workspace_effects"),
+                label=f"validation requirement {item.get('requirement_id', '<unknown>')} expected_workspace_effects",
+            ),
+            requires_isolation=_boolean_field(
+                item, "requires_isolation", default=False, label=f"validation requirement {item.get('requirement_id', '<unknown>')} requires_isolation"
+            ),
+            isolation_root=_optional_bounded_text_field(item, "isolation_root"),
+        )
+        for item in document.get("validation_requirements", [])
+    )
+
+
 def plan_from_document(  # noqa: C901, PLR0912, PLR0915
     document: Mapping[str, Any],
     *,
@@ -5493,48 +5622,7 @@ def plan_from_document(  # noqa: C901, PLR0912, PLR0915
             )
             for item in document.get("review_requirements", [])
         )
-    validation_requirements = tuple(
-        ValidationRequirement(
-            requirement_id=_bounded_text_field(item, "requirement_id"),
-            source_state=_source_state_field(item),
-            commands=_tuple_field(item, "commands"),
-            working_directories=_tuple_field(item, "working_directories"),
-            environment=_bounded_text_field(item, "environment"),
-            toolchain=_bounded_text_field(item, "toolchain"),
-            features=_tuple_field(item, "features"),
-            platform=_bounded_text_field(item, "platform"),
-            artifact_owner=_bounded_text_field(item, "artifact_owner"),
-            mutation_lock=_bounded_text_field(item, "mutation_lock"),
-            request=_bounded_text_field(item, "request"),
-            requested_scope=_bounded_text_field(item, "requested_scope"),
-            capture_command=_bounded_text_field(item, "capture_command"),
-            captured_paths=_tuple_field(item, "captured_paths"),
-            authority=_bounded_text_field(item, "authority"),
-            selection_reason=_bounded_text_field(item, "selection_reason"),
-            mutation_classification=_bounded_text_field(item, "mutation_classification"),
-            expected_evidence=_bounded_text_field(item, "expected_evidence"),
-            elapsed_time_budget=_bounded_text_field(item, "elapsed_time_budget"),
-            dependency_policy=_bounded_text_field(item, "dependency_policy"),
-            meaningful_skips=_tuple_field(item, "meaningful_skips"),
-            execution_strategy=_bounded_text_field(item, "execution_strategy"),
-            independence_basis=_bounded_text_field(item, "independence_basis"),
-            planning_blocker=_optional_bounded_text_field(item, "planning_blocker"),
-            allowed_artifacts=_allowed_artifacts_field(item, repository_root, _optional_bounded_text_field(item, "isolation_root")),
-            canonical_recipe=_optional_bounded_text_field(item, "canonical_recipe"),
-            evidence_id=_optional_bounded_text_field(item, "evidence_id"),
-            required=_boolean_field(item, "required", default=True, label=f"validation requirement {item.get('requirement_id', '<unknown>')} required"),
-            baseline=_boolean_field(item, "baseline", default=False, label=f"validation requirement {item.get('requirement_id', '<unknown>')} baseline"),
-            expected_workspace_effects=_normalized_repository_paths(
-                _tuple_field(item, "expected_workspace_effects"),
-                label=f"validation requirement {item.get('requirement_id', '<unknown>')} expected_workspace_effects",
-            ),
-            requires_isolation=_boolean_field(
-                item, "requires_isolation", default=False, label=f"validation requirement {item.get('requirement_id', '<unknown>')} requires_isolation"
-            ),
-            isolation_root=_optional_bounded_text_field(item, "isolation_root"),
-        )
-        for item in document.get("validation_requirements", [])
-    )
+    validation_requirements = validation_requirements_from_document(document, repository_root)
     synthesis_nodes = (
         synthesis_nodes_from_routing(routing_catalog, routing_decisions)
         if compact_routing and document.get("synthesis_nodes") is None

--- a/agents/.agents/skills/review-graph/scripts/review_graph_plan.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_plan.py
@@ -2309,11 +2309,34 @@ def _identifier_tuple_blockers(values: Sequence[str], *, label: str) -> tuple[st
 
 
 def graph_plan_digest(plan: GraphPlan) -> str:
-    """Hash a plan while preserving pre-exclusion identities when none are present."""
+    """Hash a plan without empty optional fields absent from legacy identities."""
     document = asdict(plan)
     if not plan.validation_exclusions:
         document.pop("validation_exclusions")
+    if not plan.audit_reuse_transitions:
+        document.pop("audit_reuse_transitions")
+    if not plan.reuse_source_snapshots:
+        document.pop("reuse_source_snapshots")
     return _sha256_json(document)
+
+
+def graph_plan_digest_matches(plan: GraphPlan, digest: str) -> bool:
+    """Verify canonical and previously emitted empty-reuse-field representations."""
+    if digest == graph_plan_digest(plan):
+        return True
+    legacy = asdict(plan)
+    if not plan.validation_exclusions:
+        legacy.pop("validation_exclusions")
+    return digest == _sha256_json(legacy)
+
+
+def validate_isolation_root(isolation_root: str, repository_root: Path) -> None:
+    """Reject isolation roots overlapping the captured repository before execution."""
+    root = Path(isolation_root).resolve(strict=False)
+    repository = repository_root.resolve()
+    if root.is_relative_to(repository) or repository.is_relative_to(root):
+        msg = f"isolated validation root overlaps the captured repository: {root}; use an external copied tree or worktree"
+        raise ValueError(msg)
 
 
 def _sha256_json(value: object) -> str:
@@ -5428,7 +5451,7 @@ def _compact_routing_overrides_from_document(
 
 def validation_requirements_from_document(document: Mapping[str, Any], repository_root: Path | None) -> tuple[ValidationRequirement, ...]:
     """Parse validation plans consistently for bootstrap and source-preserving expansion."""
-    return tuple(
+    requirements = tuple(
         ValidationRequirement(
             requirement_id=_bounded_text_field(item, "requirement_id"),
             source_state=_source_state_field(item),
@@ -5470,6 +5493,11 @@ def validation_requirements_from_document(document: Mapping[str, Any], repositor
         )
         for item in document.get("validation_requirements", [])
     )
+    for item in requirements:
+        _validate_validation_isolation(item)
+        if item.requires_isolation and repository_root is not None:
+            validate_isolation_root(item.isolation_root or "", repository_root)
+    return requirements
 
 
 def plan_from_document(  # noqa: C901, PLR0912, PLR0915

--- a/agents/.agents/skills/review-graph/scripts/review_graph_reuse.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_reuse.py
@@ -1,0 +1,155 @@
+"""Content-bound capture identities and immutable audit reuse transitions."""
+
+import hashlib
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import PurePosixPath
+from typing import Any
+
+SNAPSHOT_FORMAT = "review-graph-path-snapshot-v2"
+
+
+def _digest(value: object) -> str:
+    return hashlib.sha256(json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()).hexdigest()
+
+
+def _repository_path(path: str) -> bool:
+    return bool(path) and not path.startswith("/") and "\\" not in path and PurePosixPath(path).as_posix() == path and not {"..", "."} & set(path.split("/"))
+
+
+@dataclass(frozen=True)
+class ReviewSourceSnapshot:
+    """A capture whose repository fingerprint commits to its path identities."""
+
+    repository_state_format: str
+    repository_root: str
+    capture_mode: str
+    head: str
+    branch: str | None
+    base_ref: str | None
+    merge_base: str | None
+    requested_paths: tuple[str, ...]
+    captured_scope_paths: tuple[str, ...]
+    scope_fingerprint: str
+    captured_worktree_fingerprint: str
+    repository_state_fingerprint: str
+    index_fingerprint: str
+    repository_path_fingerprints: tuple[tuple[str, str], ...]
+
+    @property
+    def source_state(self) -> tuple[str, str, str]:
+        """Return the same source triple used by review evidence."""
+        return self.scope_fingerprint, self.captured_worktree_fingerprint, self.repository_state_fingerprint
+
+    @property
+    def boundary(self) -> tuple[object, ...]:
+        """Return identities that a source-only repair must preserve."""
+        return self.repository_root, self.capture_mode, self.head, self.branch, self.base_ref, self.merge_base, self.requested_paths, self.index_fingerprint
+
+    def computed_fingerprint(self) -> str:
+        """Bind capture context and the complete repository path map."""
+        fields = asdict(self)
+        fields.pop("repository_state_fingerprint")
+        return _digest(fields)
+
+    def verify(self) -> None:
+        """Reject unsupported or internally inconsistent capture identities."""
+        if self.repository_state_format != SNAPSHOT_FORMAT:
+            msg = "audit reuse requires a content-bound v2 source snapshot"
+            raise ValueError(msg)
+        paths = tuple(path for path, _ in self.repository_path_fingerprints)
+        if paths != tuple(sorted(set(paths))) or any(not _repository_path(path) for path in paths):
+            msg = "source snapshot requires unique sorted canonical repository paths"
+            raise ValueError(msg)
+        hashes = (*self.source_state, self.index_fingerprint, *(digest for _, digest in self.repository_path_fingerprints))
+        if any(re.fullmatch(r"[0-9a-f]{64}", digest) is None for digest in hashes):
+            msg = "source snapshot requires SHA-256 identities"
+            raise ValueError(msg)
+        if self.repository_state_fingerprint != self.computed_fingerprint():
+            msg = "source snapshot path identities do not match its repository fingerprint"
+            raise ValueError(msg)
+
+
+def source_snapshot(raw: dict[str, Any]) -> ReviewSourceSnapshot:
+    """Parse a capture manifest or serialized snapshot without coercing values."""
+    fields = dict(raw)
+    for field in ("requested_paths", "captured_scope_paths"):
+        value = fields.get(field)
+        if not isinstance(value, (list, tuple)) or any(not isinstance(path, str) for path in value):
+            msg = f"source snapshot {field} must contain strings"
+            raise ValueError(msg)
+        fields[field] = tuple(value)
+    identities = fields.get("repository_path_fingerprints")
+    pairs = tuple(identities.items()) if isinstance(identities, dict) else identities
+    if not isinstance(pairs, (list, tuple)) or any(
+        not isinstance(pair, (list, tuple)) or len(pair) != 2 or any(not isinstance(value, str) for value in pair) for pair in pairs
+    ):
+        msg = "source snapshot requires path/digest pairs"
+        raise ValueError(msg)
+    fields["repository_path_fingerprints"] = tuple(sorted(tuple(pair) for pair in pairs))
+    for field in ReviewSourceSnapshot.__dataclass_fields__:
+        if field in {"requested_paths", "captured_scope_paths", "repository_path_fingerprints"}:
+            continue
+        value = fields.get(field)
+        if not isinstance(value, str) and not (field in {"base_ref", "merge_base", "branch"} and value is None):
+            msg = f"source snapshot {field} must be a string"
+            raise ValueError(msg)
+        fields[field] = value
+    return ReviewSourceSnapshot(**{field: fields[field] for field in ReviewSourceSnapshot.__dataclass_fields__})
+
+
+@dataclass(frozen=True)
+class AuditInputIdentity:
+    """Compiler-bound ownership, inspected dependencies, and loaded instructions."""
+
+    owned_paths: tuple[str, ...]
+    inspected_paths: tuple[str, ...]
+    nearby_contract_owners: tuple[str, ...]
+    instruction_digests: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class AuditReuseTransition:
+    """A non-executable claim retaining the original artifact and source state."""
+
+    evidence_id: str
+    source_state: tuple[str, str, str]
+    target_state: tuple[str, str, str]
+    artifact_digest: str
+    artifact_path: str
+    metadata_path: str
+    instruction_digests: tuple[tuple[str, str], ...]
+
+
+def verify_reuse_inputs(origin: ReviewSourceSnapshot, target: ReviewSourceSnapshot, inputs: AuditInputIdentity, transition: AuditReuseTransition) -> None:
+    """Prove unchanged review inputs across two independently bound captures."""
+    origin.verify()
+    target.verify()
+    if origin.source_state != transition.source_state or target.source_state != transition.target_state or origin.boundary != target.boundary:
+        msg = "audit reuse changes source identity, capture boundary, or Git state"
+        raise ValueError(msg)
+    if not inputs.owned_paths or set(inputs.inspected_paths) != set(inputs.owned_paths):
+        msg = "audit reuse requires complete inspection of the owned surface"
+        raise ValueError(msg)
+    if inputs.instruction_digests != transition.instruction_digests:
+        msg = "audit reuse instruction identities changed"
+        raise ValueError(msg)
+    paths = {*inputs.owned_paths, *inputs.inspected_paths, *inputs.nearby_contract_owners}
+    root = PurePosixPath(origin.repository_root)
+    for path, _digest_value in inputs.instruction_digests:
+        instruction = PurePosixPath(path)
+        if instruction.is_relative_to(root):
+            paths.add(instruction.relative_to(root).as_posix())
+    if any(not _repository_path(path) for path in paths):
+        msg = "audit reuse dependencies must be concrete repository-relative paths"
+        raise ValueError(msg)
+    before = dict(origin.repository_path_fingerprints)
+    after = dict(target.repository_path_fingerprints)
+    if any(path not in before or path not in after or before[path] != after[path] for path in paths):
+        msg = "audit reuse inspected paths or dependencies changed or are not captured"
+        raise ValueError(msg)
+    changed_instructions = (path for path in before.keys() | after.keys() if PurePosixPath(path).name == "AGENTS.md" and before.get(path) != after.get(path))
+    if any(any(PurePosixPath(owned).is_relative_to(PurePosixPath(path).parent) for owned in inputs.owned_paths) for path in changed_instructions):
+        msg = "audit reuse applicable repository instructions changed"
+        raise ValueError(msg)

--- a/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
@@ -6,17 +6,20 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import shutil
 import stat
 import subprocess
 import sys
 import tempfile
+from collections import Counter
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any, cast
 
 from review_graph_bootstrap import bootstrap_document
 from review_graph_plan import (
+    _COMPACT_ROUTING_OVERRIDE_FIELDS,
     DEFAULT_ROUTING_CATALOG,
     DEFAULT_SKILL_ROOT,
     EVIDENCE_SCHEMA_VERSION,
@@ -38,7 +41,9 @@ from review_graph_plan import (
     ValidationEvidence,
     ValidationEvidenceExpectation,
     ValidationEvidenceMapping,
+    ValidationExclusion,
     ValidationUnit,
+    WorkerBudget,
     WorkerNode,
     _file_identity_digest,
     _native_field_values,
@@ -49,11 +54,15 @@ from review_graph_plan import (
     _native_records,
     _native_repository_path_list,
     _native_section_bodies,
+    _normalized_repository_paths,
+    _partition_execution_epochs,
     _review_native_result_blockers,
+    _schedule_nodes,
     _synthesis_reused_evidence_ids,
     _validation_environment_identity,
     _validation_ledger_expected_fields,
     _validation_native_result_blockers,
+    _validation_nodes,
     _validation_plan_expected_body,
     _validation_requirements_expected_body,
     _verified_artifact_status,
@@ -61,12 +70,17 @@ from review_graph_plan import (
     assess_review_evidence,
     assess_validation_evidence,
     build_routing_projection,
+    coalesce_validation_requirements,
     create_artifact_manifest,
+    graph_plan_digest,
     load_routing_catalog,
     plan_from_document,
     repository_review_proof_expectation,
+    review_source_state_blockers,
     validation_evidence_expectation,
+    validation_requirements_from_document,
 )
+from review_graph_reuse import SNAPSHOT_FORMAT, AuditInputIdentity, AuditReuseTransition, source_snapshot, verify_reuse_inputs
 from review_graph_schema import SchemaValidationError, require_schema, require_schema_definition
 
 _READ_ONLY_MODES = frozenset({"audit", "revalidation", "synthesis"})
@@ -80,6 +94,9 @@ _REVIEW_PAYLOAD_SCHEMA = _SCHEMA_ROOT / "review-payload-v1.schema.json"
 _VALIDATION_PAYLOAD_SCHEMA = _SCHEMA_ROOT / "validation-payload-v2.schema.json"
 _RUNTIME_OPERATION_INPUT_SCHEMA = _SCHEMA_ROOT / "runtime-operation-inputs-v1.schema.json"
 _RUNTIME_OPERATION_EXAMPLES = Path(__file__).resolve().parents[1] / "references" / "runtime-operation-examples-v1.json"
+_INITIAL_JOURNAL_HELP = (
+    "execution JSONL path; a missing or zero-byte file is an empty journal, while any nonempty file must contain canonical records without blank lines"
+)
 _COMPILER_BY_MODE = {
     "audit": "compile-review",
     "fix": "compile-review",
@@ -465,6 +482,7 @@ def _review_normalized_record(payload: dict[str, Any], expectation: ReviewEviden
         "findings": [{"finding_id": finding_id, **finding} for finding_id, finding in findings],
         "handoffs": [{"handoff_id": handoff_id, **handoff} for handoff_id, handoff in handoffs],
         "limitations": list(_text_list(payload, "limitations")),
+        "scope_limitations": [{"path": path, "reason": reason} for path, reason in _scope_limitation_records(payload)],
         "mode": evidence.mode,
         "node_id": evidence.node_id,
         "nearby_contract_owners": list(_text_list(payload, "nearby_contract_owners")),
@@ -503,6 +521,64 @@ def _review_handoff_catalog_blockers(dispatch: dict[str, Any], handoffs: tuple[t
         catalog_ids = set(_text_list(dispatch, "handoff_catalog_ids"))
     unknown = tuple(sorted({_required_text(record, "catalog_id") for _handoff_id, record in handoffs} - catalog_ids))
     return ("review payload contains unknown handoff catalog IDs: " + ", ".join(unknown),) if unknown else ()
+
+
+def _scope_limitation_records(payload: dict[str, Any]) -> tuple[tuple[str, str], ...]:
+    records: list[tuple[str, str]] = []
+    for ordinal, record in enumerate(_records(payload, "scope_limitations"), start=1):
+        if set(record) != {"path", "reason"}:
+            msg = f"scope limitation {ordinal} must contain only path and reason"
+            raise ValueError(msg)
+        records.append((_required_text(record, "path"), _required_text(record, "reason")))
+    return tuple(records)
+
+
+def _review_scope_coverage_blockers(dispatch: dict[str, Any], payload: dict[str, Any], *, status: str) -> tuple[str, ...]:
+    """Bind audit completion claims to the exact paths owned by the dispatch."""
+    mode = _required_text(dispatch, "mode")
+    limitations = _scope_limitation_records(payload)
+    if mode != "audit":
+        return ("scope_limitations apply only to audit payloads",) if limitations else ()
+    owned_paths = _text_list(dispatch, "owned_paths", required=True)
+    inspected_paths = _text_list(payload, "files_inspected")
+    blockers: list[str] = []
+    if len(owned_paths) != len(set(owned_paths)):
+        blockers.append("audit dispatch owned_paths must be unique")
+    if len(inspected_paths) != len(set(inspected_paths)):
+        blockers.append("audit files_inspected must be unique")
+    owned = set(owned_paths)
+    inspected = set(inspected_paths)
+    outside = tuple(path for path in inspected_paths if path not in owned)
+    if outside:
+        blockers.append("audit files_inspected contains paths outside dispatch ownership: " + ", ".join(outside))
+    limitation_paths = tuple(path for path, _reason in limitations)
+    if len(limitation_paths) != len(set(limitation_paths)):
+        blockers.append("audit scope_limitations paths must be unique")
+    invalid_limitations = tuple(path for path in limitation_paths if path not in owned or path in inspected)
+    if invalid_limitations:
+        blockers.append("audit scope_limitations must name omitted owned paths: " + ", ".join(invalid_limitations))
+    omitted = tuple(path for path in owned_paths if path not in inspected)
+    if status == "no-findings" and omitted:
+        blockers.append("audit no-findings requires inspection of every owned path; omitted: " + ", ".join(omitted))
+    elif status == "completed" and set(limitation_paths) != set(omitted):
+        missing = tuple(path for path in omitted if path not in set(limitation_paths))
+        extra = tuple(path for path in limitation_paths if path not in set(omitted))
+        detail = ", ".join((*missing, *extra)) or "scope limitation mismatch"
+        blockers.append("completed audit must provide one structured scope limitation for every omitted owned path: " + detail)
+    return tuple(blockers)
+
+
+def _compiled_audit_inputs(dispatch: dict[str, Any], payload: dict[str, Any]) -> AuditInputIdentity | None:
+    if dispatch["mode"] != "audit":
+        return None
+    instruction_paths = _text_list(dispatch, "instruction_paths")
+    instruction_digests = tuple((path, _file_identity_digest(path)) for path in instruction_paths)
+    if "instruction_digests" in dispatch and instruction_digests != _string_pairs(dispatch, "instruction_digests"):
+        msg = "audit instructions changed since materialization"
+        raise ValueError(msg)
+    return AuditInputIdentity(
+        _text_list(dispatch, "owned_paths"), _text_list(payload, "files_inspected"), _text_list(payload, "nearby_contract_owners"), instruction_digests
+    )
 
 
 def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  # noqa: C901, PLR0915
@@ -561,6 +637,7 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
     handoffs = _handoff_records(payload, node_id)
     policy_blockers = _review_command_policy_blockers(dispatch, payload)
     handoff_blockers = _review_handoff_catalog_blockers(dispatch, handoffs)
+    scope_blockers = _review_scope_coverage_blockers(dispatch, payload, status=status)
     limitations = _text_list(payload, "limitations")
     if status == "no-findings" and findings:
         msg = "no-findings payload cannot contain findings"
@@ -568,8 +645,9 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
     if status == "blocked" and not limitations:
         msg = "blocked payload requires a limitation"
         raise ValueError(msg)
-    files_inspected = _text_list(payload, "files_inspected", required=status != "blocked")
+    files_inspected = _text_list(payload, "files_inspected", required=status != "blocked" and mode != "synthesis")
     nearby_contract_owners = _text_list(payload, "nearby_contract_owners")
+    audit_inputs = _compiled_audit_inputs(dispatch, payload)
     requirement_ids = _text_list(dispatch, "requirement_ids")
     predecessor_evidence_ids = _text_list(dispatch, "predecessor_evidence_ids")
     evidence_id = _required_text(dispatch, "evidence_id")
@@ -591,6 +669,7 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
         source_mutation_allowed=source_mutated,
         predecessor_evidence_ids=predecessor_evidence_ids,
         planned_paths=planned_paths,
+        audit_input_identity=audit_inputs,
     )
     evidence = ReviewEvidence(
         schema_version=EVIDENCE_SCHEMA_VERSION,
@@ -665,10 +744,11 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
         "## State Verification": _state_verification(dispatch, evidence, changed_paths),
         "## Scope Inspected": "\n".join(
             (
-                f"- Files: {', '.join(files_inspected) or 'blocked-before-inspection'}",
+                f"- Files: {', '.join(files_inspected) or ('bundle-only synthesis' if mode == 'synthesis' else 'blocked-before-inspection')}",
                 f"- Nearby contract owners: {', '.join(nearby_contract_owners) or 'none'}",
                 f"- Worker payload digest: {_sha256_bytes(canonical_payload.encode())}",
                 f"- Canonical worker payload: {canonical_payload}",
+                *((f"- Audit input identity: {_canonical_json(asdict(audit_inputs))}",) if audit_inputs is not None else ()),
             )
         ),
         "## Findings": _findings_body(findings),
@@ -677,7 +757,12 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
         "## Predecessor Coverage": _predecessor_body(dispatch, evidence),
         "## Changes": _changes_body(payload, evidence, changed_paths),
         "## Handoffs": _handoffs_body(handoffs),
-        "## Limitations": "; ".join(limitations) or "none",
+        "## Limitations": "\n".join(
+            (
+                f"- General: {'; '.join(limitations) or 'none'}",
+                "- Owned-path omissions: " + ("; ".join(f"{path}: {reason}" for path, reason in _scope_limitation_records(payload)) or "none"),
+            )
+        ),
     }
     sections = (
         "## Skill Loading",
@@ -700,7 +785,7 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
     evidence = replace(evidence, raw_result_digest=_sha256_bytes(content))
     envelope_assessment = assess_review_evidence(expectation, evidence)
     native_blockers = _review_native_result_blockers(content, expectation, evidence)
-    blockers = (*policy_blockers, *handoff_blockers, *envelope_assessment.blockers, *native_blockers)
+    blockers = (*policy_blockers, *handoff_blockers, *scope_blockers, *envelope_assessment.blockers, *native_blockers)
     if blockers:
         msg = "compiled review artifact failed verification: " + "; ".join(blockers)
         raise ValueError(msg)
@@ -1219,6 +1304,20 @@ def _fingerprint_evidence(raw: dict[str, Any]) -> FingerprintEvidence:
     return FingerprintEvidence(expected=_state(raw, "expected"), before=_state(raw, "before"), after=_state(raw, "after"))
 
 
+def _audit_input_identity(raw: object) -> AuditInputIdentity | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        msg = "audit input identity must be an object"
+        raise TypeError(msg)
+    return AuditInputIdentity(
+        _string_tuple(raw, "owned_paths"),
+        _string_tuple(raw, "inspected_paths"),
+        _string_tuple(raw, "nearby_contract_owners"),
+        _string_pairs(raw, "instruction_digests"),
+    )
+
+
 def _review_expectation(raw: dict[str, Any]) -> ReviewEvidenceExpectation:
     expected_after = tuple(raw["expected_after_state"]) if raw.get("expected_after_state") is not None else None
     return ReviewEvidenceExpectation(
@@ -1239,6 +1338,7 @@ def _review_expectation(raw: dict[str, Any]) -> ReviewEvidenceExpectation:
         change_target=raw.get("change_target"),
         planned_paths=_string_tuple(raw, "planned_paths"),
         planned_path_line_bounds=_path_line_bounds(raw, "planned_path_line_bounds"),
+        audit_input_identity=_audit_input_identity(raw.get("audit_input_identity")),
     )
 
 
@@ -2052,6 +2152,28 @@ def _graph_plan(raw: dict[str, Any]) -> GraphPlan:
         routing_completion_blockers=_string_tuple(raw, "routing_completion_blockers"),
         dispatch_allowed=_required_bool(raw, "dispatch_allowed"),
         blockers=_string_tuple(raw, "blockers"),
+        audit_reuse_transitions=tuple(
+            AuditReuseTransition(
+                evidence_id=_required_text(item, "evidence_id"),
+                source_state=_state(item, "source_state"),
+                target_state=_state(item, "target_state"),
+                artifact_digest=_required_text(item, "artifact_digest"),
+                artifact_path=_required_text(item, "artifact_path"),
+                metadata_path=_required_text(item, "metadata_path"),
+                instruction_digests=_string_pairs(item, "instruction_digests"),
+            )
+            for item in _records(raw, "audit_reuse_transitions")
+        ),
+        reuse_source_snapshots=tuple(source_snapshot(item) for item in _records(raw, "reuse_source_snapshots")),
+        validation_exclusions=tuple(
+            ValidationExclusion(
+                originating_evidence_id=_required_text(item, "originating_evidence_id"),
+                requirement_id=_required_text(item, "requirement_id"),
+                requirement_digest=_sha256_digest(item.get("requirement_digest"), "requirement_digest"),
+                reason=_required_text(item, "reason"),
+            )
+            for item in _records(raw, "validation_exclusions")
+        ),
     )
 
 
@@ -2175,22 +2297,94 @@ def _load_evidence_source(  # noqa: C901, PLR0912, PLR0915
     return kind, expectation, evidence, content, normalized
 
 
-def build_synthesis_bundle(document: dict[str, Any]) -> dict[str, Any]:
+def _validation_reconciliation(plan: GraphPlan, records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Bind discovered needs to exact command plans, never to a generic CI pass."""
+    units = {requirement: unit for unit in plan.coalesced_validation_units for requirement in unit.requirement_ids}
+    exclusions = {(item.originating_evidence_id, item.requirement_id, item.requirement_digest): item for item in plan.validation_exclusions}
+    results: list[dict[str, Any]] = []
+    blockers: list[str] = []
+    for record in records:
+        if record.get("status") not in {"completed", "no-findings"}:
+            continue
+        for requirement_id, requirement in _validation_records(record):
+            digest = _sha256_bytes(_canonical_json(requirement).encode())
+            origin = _required_text(record, "evidence_id")
+            unit = units.get(requirement_id)
+            exclusion = exclusions.get((origin, requirement_id, digest))
+            matches = unit is not None and (
+                unit.commands == _text_list(requirement, "commands")
+                and unit.working_directories == (requirement["working_directory"],) * len(unit.commands)
+                and unit.environment == requirement["environment"]
+                and unit.dependency_policy == requirement["dependency_policy"]
+                and unit.required
+            )
+            resolution = "planned" if matches else "user-excluded" if exclusion else "identity-conflict" if unit else "requires-expansion"
+            if resolution in {"identity-conflict", "requires-expansion"}:
+                blockers.append(f"validation requirement {requirement_id} from {origin} needs exact validation reconciliation ({resolution})")
+            results.append(
+                {
+                    "originating_evidence_id": origin,
+                    "requirement": requirement,
+                    "requirement_digest": digest,
+                    "requirement_id": requirement_id,
+                    "resolution": resolution,
+                    "reason": exclusion.reason if exclusion and not matches else None,
+                    "validation_unit_id": unit.node_id if matches and unit else None,
+                }
+            )
+    return {"blockers": blockers, "requirements": sorted(results, key=lambda item: (item["requirement_id"], item["originating_evidence_id"]))}
+
+
+def _synthesis_plan_context(plan: GraphPlan, records: list[dict[str, Any]]) -> dict[str, Any]:
+    by_evidence = {str(record["evidence_id"]): record for record in records}
+    review_ids = tuple(str(record["evidence_id"]) for record in records if record.get("result_type") != "validation-result")
+    handoffs, unresolved, blockers = _reconciled_handoffs(plan, by_evidence, review_ids)
+    return {
+        "plan_digest": _plan_digest(plan),
+        "consulted_routers": list(plan.consulted_routers),
+        "routing_catalog_closed": plan.routing_catalog_closed,
+        "routing_completion_blockers": list(plan.routing_completion_blockers),
+        "routing_counts": dict(sorted(Counter(item.disposition for item in plan.routing_decisions).items())),
+        "routing_exceptions": [
+            {"catalog_id": item.catalog_id, "disposition": item.disposition, "reason": item.reason, "evidence_id": item.evidence_id}
+            for item in plan.routing_decisions
+            if item.disposition not in {"selected", "not-applicable"}
+        ],
+        "user_excluded_catalog_ids": list(plan.user_excluded_catalog_ids),
+        "exact_reused_review_evidence": [list(item) for item in plan.exact_reused_review_evidence],
+        "requirement_to_node": [list(item) for item in plan.requirement_to_node],
+        "validation_evidence_mapping": [asdict(item) for item in plan.validation_evidence_mapping],
+        "validation_exclusions": [asdict(item) for item in plan.validation_exclusions],
+        "validation_reconciliation": _validation_reconciliation(plan, records),
+        "handoff_reconciliation": {"handoffs": handoffs, "unresolved_handoff_ids": list(unresolved), "blockers": list(blockers)},
+    }
+
+
+def build_synthesis_bundle(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901
     """Create a compact, hashed synthesis view from accepted compiler artifacts."""
     source_state = _state(document, "source_state")
-    raw_sources = _records(document, "sources")
+    plan = _graph_plan(document["plan"]) if isinstance(document.get("plan"), dict) else None
+    raw_sources = _evidence_sources(document, plan)
     if not raw_sources:
         msg = "synthesis requires compiler evidence sources"
         raise ValueError(msg)
     derived: list[dict[str, Any]] = []
     for source in raw_sources:
         _kind, expectation, evidence, _content, normalized = _load_evidence_source(source, require_normalized=True)
-        if expectation.source_state != source_state or evidence.fingerprints.expected != source_state:
-            msg = f"synthesis evidence has a different source state: {evidence.evidence_id}"
-            raise ValueError(msg)
+        if expectation.source_state != source_state:
+            blockers = (
+                review_source_state_blockers(plan, expectation, evidence, source_state)
+                if plan is not None and isinstance(expectation, ReviewEvidenceExpectation) and isinstance(evidence, ReviewEvidence)
+                else ("different source state without a planner-bound reuse transition",)
+            )
+            if blockers:
+                msg = f"synthesis evidence has a different source state: {evidence.evidence_id}: " + "; ".join(blockers)
+                raise ValueError(msg)
         if normalized is None:  # Defensive for type narrowing after require_normalized.
             msg = f"synthesis evidence has no normalized record: {evidence.evidence_id}"
             raise ValueError(msg)
+        if expectation.source_state != source_state:
+            normalized = {**normalized, "reuse": {"original_source_state": list(expectation.source_state), "verified_source_state": list(source_state)}}
         derived.append(normalized)
     records: list[dict[str, Any]] = []
     evidence_ids: set[str] = set()
@@ -2213,8 +2407,64 @@ def build_synthesis_bundle(document: dict[str, Any]) -> dict[str, Any]:
         record["record_digest"] = _sha256_bytes(_canonical_json(record).encode())
         records.append(record)
     bundle: dict[str, Any] = {"schema_version": 1, "source_state": list(source_state), "records": sorted(records, key=lambda item: item["evidence_id"])}
+    if plan is not None:
+        bundle["plan_context"] = _synthesis_plan_context(plan, bundle["records"])
     bundle["bundle_digest"] = _sha256_bytes(_canonical_json(bundle).encode())
     return bundle
+
+
+def _verified_reused_sources(plan: GraphPlan, source_state: tuple[str, str, str], *, check_current_inputs: bool = True) -> tuple[dict[str, str], ...]:
+    """Reload immutable reused artifacts and recheck their current instructions."""
+    sources: list[dict[str, str]] = []
+    snapshots = {item.source_state: item for item in plan.reuse_source_snapshots}
+    for transition in plan.audit_reuse_transitions:
+        source = {"artifact_path": transition.artifact_path, "metadata_path": transition.metadata_path}
+        _kind, expectation, evidence, _content, _record = _load_evidence_source(source, require_normalized=True)
+        if not isinstance(expectation, ReviewEvidenceExpectation) or not isinstance(evidence, ReviewEvidence):
+            msg = "audit reuse source must contain review evidence"
+            raise TypeError(msg)
+        if evidence.evidence_id != transition.evidence_id or evidence.raw_result_digest != transition.artifact_digest:
+            msg = "audit reuse source differs from its bound evidence identity"
+            raise ValueError(msg)
+        blockers = review_source_state_blockers(plan, expectation, evidence, source_state)
+        if blockers:
+            msg = f"audit reuse failed verification: {transition.evidence_id}: " + "; ".join(blockers)
+            raise ValueError(msg)
+        if not check_current_inputs:
+            # Mutation planning loads historical evidence before checking the new capture.
+            sources.append(source)
+            continue
+        inputs = expectation.audit_input_identity
+        if inputs is None:  # Narrowed by the reuse gate.
+            msg = "audit reuse lacks compiler-bound inputs"
+            raise ValueError(msg)
+        explicit = tuple(path for decision in plan.routing_decisions if decision.evidence_id == evidence.evidence_id for path in decision.instruction_paths)
+        paths = _applicable_instruction_paths(Path(snapshots[source_state].repository_root), inputs.owned_paths, explicit)
+        if tuple((path, _file_identity_digest(path)) for path in paths) != transition.instruction_digests:
+            msg = "audit reuse instructions changed; recapture and replan"
+            raise ValueError(msg)
+        if _file_identity_digest(evidence.skill_path) != evidence.skill_digest or any(
+            _file_identity_digest(path) != digest for path, digest in evidence.reference_digests
+        ):
+            msg = "audit reuse skill or references changed; recapture and replan"
+            raise ValueError(msg)
+        sources.append(source)
+    return tuple(sources)
+
+
+def _evidence_sources(document: dict[str, Any], plan: GraphPlan | None, *, check_current_inputs: bool = True) -> tuple[dict[str, Any], ...]:
+    sources = _records(document, "sources")
+    if plan is None:
+        return sources
+    supplied = {(str(Path(_required_text(item, "artifact_path")).resolve()), str(Path(_required_text(item, "metadata_path")).resolve())) for item in sources}
+    return (
+        *sources,
+        *(
+            item
+            for item in _verified_reused_sources(plan, _state(document, "source_state"), check_current_inputs=check_current_inputs)
+            if (item["artifact_path"], item["metadata_path"]) not in supplied
+        ),
+    )
 
 
 def build_routing_projection_document(
@@ -2401,9 +2651,10 @@ def _worker_prompt(contract: str, dispatch: dict[str, Any]) -> str:
         raise ValueError(msg)
     persistence_input = _required_text(persistence, "input_path")
     persistence_candidate = _required_text(persistence, "candidate_path")
+    persistence_command = _text_list(persistence, "command", required=True)
     persistence_text = (
         f" Before returning, write the exact result bytes to temporary sibling {persistence_candidate}, then invoke the runtime-owned "
-        f"persist-worker-payload operation with --input {persistence_input} and --payload {persistence_candidate}. "
+        f"persistence command unchanged: {shlex.join(persistence_command)}. Its bound input is {persistence_input} and candidate is {persistence_candidate}. "
         f"Only after it atomically publishes {worker_payload_path} may you return those same bytes."
     )
     if contract == "native-independent-review":
@@ -2424,8 +2675,9 @@ def _worker_prompt(contract: str, dispatch: dict[str, Any]) -> str:
     )
 
 
-def _validate_worker_payload_bytes(contract: str, payload_bytes: bytes) -> None:
+def _validate_worker_payload_bytes(contract_document: dict[str, Any], payload_bytes: bytes) -> None:
     """Reject incomplete worker output before it can replace a persisted payload."""
+    contract = _required_text(contract_document, "result_contract")
     if contract in {"compact-review", "compact-validation"}:
         payload = json.loads(payload_bytes)
         if not isinstance(payload, dict):
@@ -2433,6 +2685,11 @@ def _validate_worker_payload_bytes(contract: str, payload_bytes: bytes) -> None:
             raise TypeError(msg)
         schema = _REVIEW_PAYLOAD_SCHEMA if contract == "compact-review" else _VALIDATION_PAYLOAD_SCHEMA
         require_schema(payload, schema)
+        if contract == "compact-review":
+            blockers = _review_scope_coverage_blockers(contract_document, payload, status=_required_text(payload, "status"))
+            if blockers:
+                msg = "worker payload failed owned-scope validation: " + "; ".join(blockers)
+                raise ValueError(msg)
         return
     if contract == "native-independent-review":
         _independent_input_sections(payload_bytes)
@@ -2463,7 +2720,7 @@ def persist_worker_payload(contract_document: dict[str, Any], candidate_path: Pa
 
     with candidate.open("rb+") as stream:
         payload_bytes = stream.read()
-        _validate_worker_payload_bytes(result_contract, payload_bytes)
+        _validate_worker_payload_bytes(contract_document, payload_bytes)
         stream.flush()
         os.fsync(stream.fileno())
     candidate.replace(target_path)
@@ -2480,7 +2737,9 @@ def persist_worker_payload(contract_document: dict[str, Any], candidate_path: Pa
     }
 
 
-def materialize_dispatches(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, PLR0912, PLR0915
+def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
+    document: dict[str, Any], *, preserved_entries: dict[str, dict[str, Any]] | None = None
+) -> dict[str, Any]:
     """Derive exact per-node dispatch bases from one accepted graph plan."""
     raw_plan = document.get("plan")
     if not isinstance(raw_plan, dict):
@@ -2491,6 +2750,7 @@ def materialize_dispatches(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
         msg = "cannot materialize dispatches from a blocked graph plan"
         raise ValueError(msg)
     source_state = _state(document, "source_state")
+    _verified_reused_sources(plan, source_state)
     repository_root_path = Path(_required_text(document, "repository_root"))
     if not repository_root_path.is_absolute() or not repository_root_path.is_dir():
         msg = "repository_root must be an existing absolute directory"
@@ -2553,6 +2813,9 @@ def materialize_dispatches(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
     validator_commands = {command for unit in plan.coalesced_validation_units for command in unit.commands}
     dispatches: list[dict[str, Any]] = []
     for node in plan.actual_worker_nodes:
+        if preserved_entries is not None and node.node_id in preserved_entries:
+            dispatches.append(preserved_entries[node.node_id])
+            continue
         compiler_operation = _COMPILER_BY_MODE.get(node.mode)
         if compiler_operation is None:
             msg = f"no deterministic compiler is registered for planned node mode {node.mode}: {node.node_id}"
@@ -2565,6 +2828,15 @@ def materialize_dispatches(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
         worker_payload_path = artifact_store / f"{node.node_id}.worker-payload.{worker_payload_suffix}"
         worker_payload_candidate_path = artifact_store / f"{node.node_id}.worker-payload.candidate.{worker_payload_suffix}"
         worker_payload_contract_path = artifact_store / f"{node.node_id}.worker-payload-contract.json"
+        worker_payload_persistence_command = [
+            str(Path(sys.executable).resolve()),
+            str(Path(__file__).resolve()),
+            "persist-worker-payload",
+            "--input",
+            str(worker_payload_contract_path),
+            "--payload",
+            str(worker_payload_candidate_path),
+        ]
         instruction_paths = _applicable_instruction_paths(repository_root_path.resolve(), node.coverage, node.instruction_paths)
         authorized_duplicates = tuple(sorted(set(raw_duplicate_authorizations.get(node.node_id, ()))))
         if node.mode == "validation" and authorized_duplicates:
@@ -2598,6 +2870,7 @@ def materialize_dispatches(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
             "worker_payload_path": str(worker_payload_path),
             "worker_payload_persistence": {
                 "candidate_path": str(worker_payload_candidate_path),
+                "command": worker_payload_persistence_command,
                 "input_path": str(worker_payload_contract_path),
                 "operation": "persist-worker-payload",
             },
@@ -2650,27 +2923,31 @@ def materialize_dispatches(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
                 contract = "compact-review"
         persistence_contract = {
             "candidate_path": str(worker_payload_candidate_path),
+            "mode": node.mode,
             "node_id": node.node_id,
+            "owned_paths": list(node.coverage),
             "result_contract": contract,
             "schema_version": 1,
             "worker_payload_path": str(worker_payload_path),
         }
         _write_text_once(worker_payload_contract_path, json.dumps(persistence_contract, indent=2, sort_keys=True) + "\n")
-        dispatches.append(
-            {
-                "artifact_path": str(artifact_path),
-                "compiler_operation": compiler_operation,
-                "dispatch": common,
-                "journal_operation": "journal-append",
-                "metadata_path": str(metadata_path),
-                "node_id": node.node_id,
-                "result_contract": contract,
-                "worker_payload_candidate_path": str(worker_payload_candidate_path),
-                "worker_payload_contract_path": str(worker_payload_contract_path),
-                "worker_payload_path": str(worker_payload_path),
-                "worker_prompt": _worker_prompt(contract, common),
-            }
-        )
+        worker_input_path = artifact_store / f"{node.node_id}.worker-input.json"
+        entry = {
+            "artifact_path": str(artifact_path),
+            "compiler_operation": compiler_operation,
+            "dispatch": common,
+            "journal_operation": "journal-append",
+            "metadata_path": str(metadata_path),
+            "node_id": node.node_id,
+            "result_contract": contract,
+            "worker_input_path": str(worker_input_path),
+            "worker_payload_candidate_path": str(worker_payload_candidate_path),
+            "worker_payload_contract_path": str(worker_payload_contract_path),
+            "worker_payload_path": str(worker_payload_path),
+            "worker_prompt": _worker_prompt(contract, common),
+        }
+        _write_bytes_atomically_once(worker_input_path, (json.dumps(entry, indent=2, sort_keys=True) + "\n").encode(), mode=0o444)
+        dispatches.append(entry)
     output: dict[str, Any] = {"dispatches": dispatches, "plan_digest": _plan_digest(plan), "schema_version": 1, "source_state": list(source_state)}
     output["dispatch_set_digest"] = _sha256_bytes(_canonical_json(output).encode())
     return output
@@ -2710,16 +2987,257 @@ def _epoch_scoped_plan(plan: GraphPlan, epoch: int) -> GraphPlan:
     )
 
 
+def _capture_path_fingerprints(capture: dict[str, Any], *, label: str) -> dict[str, str]:
+    raw = capture.get("repository_path_fingerprints")
+    if not isinstance(raw, dict) or any(not isinstance(path, str) for path in raw):
+        msg = f"{label} requires repository_path_fingerprints; capture before repairing with the current capture_scope.py"
+        raise ValueError(msg)
+    paths = _normalized_repository_paths(tuple(raw), label=f"{label}.repository_path_fingerprints")
+    if tuple(raw) != paths:
+        msg = f"{label}.repository_path_fingerprints requires canonical repository paths"
+        raise ValueError(msg)
+    if any(not isinstance(value, str) or re.fullmatch(r"[0-9a-f]{64}", value) is None for value in raw.values()):
+        msg = f"{label}.repository_path_fingerprints must contain SHA-256 identities"
+        raise ValueError(msg)
+    if not set(_text_list(capture, "captured_scope_paths")) <= set(paths):
+        msg = f"{label} path fingerprints do not cover captured_scope_paths"
+        raise ValueError(msg)
+    if capture.get("repository_state_format") == SNAPSHOT_FORMAT:
+        source_snapshot(capture).verify()
+    return cast("dict[str, str]", raw)
+
+
+def _mutation_path_delta(document: dict[str, Any], previous: dict[str, Any], current: dict[str, Any]) -> tuple[str, ...]:
+    previous_state = tuple(_required_text(previous, field) for field in ("scope_fingerprint", "captured_worktree_fingerprint", "repository_state_fingerprint"))
+    if previous_state != _state(document, "source_state"):
+        msg = "previous_capture must match the immediately prior plan source_state"
+        raise ValueError(msg)
+    for field in ("repository_root", "capture_mode", "base_ref", "merge_base", "requested_paths", "head", "branch"):
+        if previous.get(field) != current.get(field):
+            msg = f"mutation captures differ in {field}; repair epochs cannot change capture boundaries or Git state"
+            raise ValueError(msg)
+    old_index = _required_text(previous, "index_fingerprint")
+    new_index = _required_text(current, "index_fingerprint")
+    if any(re.fullmatch(r"[0-9a-f]{64}", value) is None for value in (old_index, new_index)):
+        msg = "mutation captures require SHA-256 index_fingerprint identities"
+        raise ValueError(msg)
+    if old_index != new_index:
+        msg = "repair epoch mutated the Git index"
+        raise ValueError(msg)
+    before = _capture_path_fingerprints(previous, label="previous_capture")
+    after = _capture_path_fingerprints(current, label="new_capture")
+    changed = tuple(sorted(path for path in before.keys() | after.keys() if before.get(path) != after.get(path)))
+    declared = _normalized_repository_paths(_text_list(document, "changed_paths", required=True), label="changed_paths")
+    if set(declared) != set(changed):
+        msg = "changed_paths differs from the immediately prior capture delta: " + ", ".join(changed)
+        raise ValueError(msg)
+    captured = set(_text_list(previous, "captured_scope_paths")) | set(_text_list(current, "captured_scope_paths"))
+    if not set(changed) <= captured:
+        msg = "repair changed paths outside both captured scopes: " + ", ".join(sorted(set(changed) - captured))
+        raise ValueError(msg)
+    return changed
+
+
+def _mutation_evidence_sources(document: dict[str, Any], plan: GraphPlan) -> dict[str, tuple[dict[str, Any], dict[str, Any]]]:
+    """Verify historical evidence without relabeling it as final-state evidence."""
+    by_id = {node.node_id: node for node in plan.actual_worker_nodes}
+    result: dict[str, tuple[dict[str, Any], dict[str, Any]]] = {}
+    reused_ids = {evidence_id for _, evidence_id in plan.exact_reused_review_evidence}
+    for source in _evidence_sources(document, plan, check_current_inputs=False):
+        _kind, expectation, evidence, _content, normalized = _load_evidence_source(source, require_normalized=True)
+        node = by_id.get(evidence.node_id)
+        if (node is None and evidence.evidence_id not in reused_ids) or evidence.node_id in result:
+            msg = f"mutation sources contain an unknown or duplicate node: {evidence.node_id}"
+            raise ValueError(msg)
+        if node is not None:
+            _verified_journal_evidence(source, plan=plan, node=node, source_state=_state(document, "source_state"))
+        elif isinstance(expectation, ReviewEvidenceExpectation) and isinstance(evidence, ReviewEvidence):
+            blockers = review_source_state_blockers(plan, expectation, evidence, _state(document, "source_state"))
+            if blockers:
+                msg = "prior reused audit is not valid for the preceding capture: " + "; ".join(blockers)
+                raise ValueError(msg)
+        if normalized is None:
+            msg = f"mutation source lacks normalized evidence: {evidence.node_id}"
+            raise ValueError(msg)
+        result[evidence.node_id] = (source, normalized)
+    return result
+
+
+def _mutation_invalidated_nodes(
+    plan: GraphPlan, replacement: GraphPlan, changed_paths: tuple[str, ...], repository_root: Path, sources: dict[str, tuple[dict[str, Any], dict[str, Any]]]
+) -> tuple[str, ...]:
+    """Invalidate path owners, inspected dependencies, and their downstream nodes."""
+    changed = set(changed_paths)
+    units = {unit.node_id: unit for unit in plan.coalesced_validation_units}
+    roots: set[str] = set()
+    for node in plan.actual_worker_nodes:
+        paths = set(units[node.node_id].captured_paths if node.node_id in units else node.coverage)
+        for raw in (node.skill_path, *node.instruction_paths, *node.static_references):
+            path = Path(raw)
+            if not path.is_absolute():
+                paths.add(raw)
+            elif path.is_relative_to(repository_root):
+                paths.add(path.relative_to(repository_root).as_posix())
+        if node.node_id in sources:
+            _source, record = sources[node.node_id]
+            for raw in (*_text_list(record, "files_inspected"), *_text_list(record, "nearby_contract_owners")):
+                path = Path(raw)
+                paths.add(path.relative_to(repository_root).as_posix() if path.is_absolute() and path.is_relative_to(repository_root) else raw)
+        replacements = tuple(
+            candidate
+            for candidate in replacement.actual_worker_nodes
+            if candidate.skill_id == node.skill_id and candidate.mode == node.mode and set(candidate.requirement_ids).intersection(node.requirement_ids)
+        )
+        routing_changed = node.mode == "audit" and not any(
+            (candidate.coverage, candidate.skill_digest, candidate.reference_digests, candidate.instruction_paths)
+            == (node.coverage, node.skill_digest, node.reference_digests, node.instruction_paths)
+            for candidate in replacements
+        )
+        instruction_changed = any(
+            Path(path).name == "AGENTS.md" and any(Path(owned).is_relative_to(Path(path).parent) for owned in node.coverage) for path in changed
+        )
+        if changed & paths or instruction_changed or routing_changed or node.mode in {"fix", "revalidation"}:
+            roots.add(node.node_id)
+    affected = set(roots)
+    while True:
+        expanded = affected | {node.node_id for node in plan.actual_worker_nodes if affected.intersection(node.predecessors)}
+        if expanded == affected:
+            break
+        affected = expanded
+    return tuple(node.node_id for node in plan.actual_worker_nodes if node.node_id in affected)
+
+
+def _expire_mutation_reuse(planning_input: dict[str, Any]) -> None:
+    """A new global source triple cannot inherit old exact-reuse assertions."""
+    for field in ("routing_overrides", "routing_decisions"):
+        records = []
+        for record in _records(planning_input, field):
+            updated = dict(record)
+            if updated.get("disposition") == "exact-evidence-reused":
+                updated.update({"disposition": "selected", "reason": "recaptured source state requires fresh verification"})
+                updated.pop("evidence_id", None)
+            records.append(updated)
+        if field in planning_input:
+            planning_input[field] = records
+    planning_input["validation_requirements"] = [{**record, "evidence_id": None} for record in _records(planning_input, "validation_requirements")]
+
+
+def _compact_reuse_overrides(plan: GraphPlan, reused_requirements: dict[str, str]) -> list[dict[str, Any]]:
+    """Preserve routing choices in schema-valid JSON while replacing audited leaves."""
+    overrides = []
+    for decision in plan.routing_decisions:
+        if decision.requirement_id in reused_requirements:
+            decision = replace(decision, disposition="exact-evidence-reused", evidence_id=reused_requirements[decision.requirement_id])
+        overrides.append({key: value for key, value in asdict(decision).items() if key in _COMPACT_ROUTING_OVERRIDE_FIELDS and value is not None})
+    return json.loads(_canonical_json(overrides))
+
+
+def _carry_forward_audits(  # noqa: C901, PLR0913
+    document: dict[str, Any],
+    old_plan: GraphPlan,
+    candidate_plan: GraphPlan,
+    planning_input: dict[str, Any],
+    *,
+    invalidated: tuple[str, ...],
+    sources: dict[str, tuple[dict[str, Any], dict[str, Any]]],
+) -> GraphPlan:
+    """Convert only proven unchanged leaves into non-executable routed reuse."""
+    previous, current = document["previous_capture"], document["new_capture"]
+    if current.get("repository_state_format") != SNAPSHOT_FORMAT:
+        return candidate_plan
+    target = source_snapshot(current)
+    target.verify()
+    snapshots = {item.source_state: item for item in old_plan.reuse_source_snapshots}
+    if previous.get("repository_state_format") == SNAPSHOT_FORMAT:
+        origin = source_snapshot(previous)
+        origin.verify()
+        snapshots[origin.source_state] = origin
+    snapshots[target.source_state] = target
+    root = Path(target.repository_root)
+    transitions: list[AuditReuseTransition] = []
+    records: list[tuple[ReviewEvidenceExpectation, ReviewEvidence]] = []
+    reused_requirements: dict[str, str] = {}
+    for node_id, (source, record) in sources.items():
+        if node_id in invalidated or record.get("mode") != "audit" or record.get("status") not in {"completed", "no-findings"}:
+            continue
+        if record.get("scope_limitations") or record.get("limitations"):
+            continue
+        _kind, expectation, evidence, _content, _normalized = _load_evidence_source(source, require_normalized=True)
+        if not isinstance(expectation, ReviewEvidenceExpectation) or not isinstance(evidence, ReviewEvidence):
+            continue
+        inputs = expectation.audit_input_identity
+        origin = snapshots.get(expectation.source_state)
+        if inputs is None or origin is None or evidence.predecessor_evidence_ids or expectation.execution_profile != candidate_plan.execution_profile:
+            continue
+        candidates = tuple(
+            node
+            for node in candidate_plan.actual_worker_nodes
+            if node.mode == "audit"
+            and not node.predecessors
+            and node.requirement_ids == evidence.requirement_ids
+            and (node.skill_id, node.skill_path, node.skill_digest, node.reference_digests, node.coverage)
+            == (evidence.skill_id, evidence.skill_path, evidence.skill_digest, evidence.reference_digests, inputs.owned_paths)
+        )
+        if len(candidates) != 1:
+            continue
+        candidate = candidates[0]
+        instructions = _applicable_instruction_paths(root, candidate.coverage, candidate.instruction_paths)
+        transition = AuditReuseTransition(
+            evidence_id=evidence.evidence_id,
+            source_state=expectation.source_state,
+            target_state=target.source_state,
+            artifact_digest=evidence.raw_result_digest,
+            artifact_path=str(Path(_required_text(source, "artifact_path")).resolve()),
+            metadata_path=str(Path(_required_text(source, "metadata_path")).resolve()),
+            instruction_digests=tuple((path, _file_identity_digest(path)) for path in instructions),
+        )
+        try:
+            verify_reuse_inputs(origin, target, inputs, transition)
+        except ValueError:
+            # Incomplete/changed inputs are ordinary fresh review work, not reuse.
+            continue
+        transitions.append(transition)
+        records.append((expectation, evidence))
+        reused_requirements.update(dict.fromkeys(evidence.requirement_ids, evidence.evidence_id))
+    if not transitions:
+        return candidate_plan
+    planning_input.pop("routing_decisions", None)
+    planning_input["routing_overrides"] = _compact_reuse_overrides(candidate_plan, reused_requirements)
+    require_schema(planning_input, _PLANNING_INPUT_SCHEMA)
+    routed = plan_from_document(
+        planning_input,
+        catalog_path=Path(document.get("routing_catalog_path", DEFAULT_ROUTING_CATALOG)),
+        skill_roots=(DEFAULT_SKILL_ROOT,),
+        repository_root=root,
+    )
+    needed_states = {state for transition in transitions for state in (transition.source_state, transition.target_state)}
+    routed = replace(
+        routed,
+        audit_reuse_transitions=tuple(sorted(transitions, key=lambda item: item.evidence_id)),
+        reuse_source_snapshots=tuple(snapshots[state] for state in sorted(needed_states)),
+    )
+    for expectation, evidence in records:
+        blockers = review_source_state_blockers(routed, expectation, evidence, target.source_state)
+        if blockers:
+            msg = "rerouted audit reuse is inconsistent: " + "; ".join(blockers)
+            raise ValueError(msg)
+    return routed
+
+
 def advance_after_mutation(document: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     """Close one repair epoch, recapture once, and emit a fresh final-state graph."""
     raw_plan = document.get("plan")
+    previous_capture = document.get("previous_capture")
     new_capture = document.get("new_capture")
     planning_template = document.get("planning_template")
-    if not isinstance(raw_plan, dict) or not isinstance(new_capture, dict) or not isinstance(planning_template, dict):
-        msg = "advance-after-mutation requires plan, new_capture, and planning_template objects"
+    if not isinstance(raw_plan, dict) or not isinstance(previous_capture, dict) or not isinstance(new_capture, dict) or not isinstance(planning_template, dict):
+        msg = "advance-after-mutation requires plan, previous_capture, new_capture, and planning_template objects"
         raise TypeError(msg)
     old_plan = _graph_plan(raw_plan)
     old_source_state = _state(document, "source_state")
+    if any(unit.source_state != old_source_state for unit in old_plan.coalesced_validation_units):
+        msg = "prior plan validation units differ from source_state"
+        raise ValueError(msg)
     new_source_state = (new_capture.get("scope_fingerprint"), new_capture.get("captured_worktree_fingerprint"), new_capture.get("repository_state_fingerprint"))
     if any(not isinstance(value, str) or not value.strip() for value in new_source_state):
         msg = "advance-after-mutation new_capture lacks the complete source fingerprint triple"
@@ -2737,17 +3255,12 @@ def advance_after_mutation(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
     if epoch < 1:
         msg = "repair_epoch must be positive"
         raise ValueError(msg)
-    changed_paths = _text_list(document, "changed_paths", required=True)
-    captured_paths = new_capture.get("captured_scope_paths")
-    if not isinstance(captured_paths, list) or any(not isinstance(path, str) for path in captured_paths):
-        msg = "new_capture captured_scope_paths must be a string array"
-        raise ValueError(msg)
-    missing_changed = tuple(sorted(set(changed_paths) - set(captured_paths)))
-    if missing_changed:
-        msg = "changed paths are absent from the new capture: " + ", ".join(missing_changed)
-        raise ValueError(msg)
+    changed_paths = _mutation_path_delta(document, previous_capture, new_capture)
+    captured_paths = _text_list(new_capture, "captured_scope_paths")
+    sources = _mutation_evidence_sources(document, old_plan)
     planning_input = bootstrap_document(new_capture, planning_template)
     planning_input["authorization"] = authorization_after
+    _expire_mutation_reuse(planning_input)
     require_schema(planning_input, _PLANNING_INPUT_SCHEMA)
     repository_root = Path(_required_text(planning_input, "repository_root")).resolve()
     catalog_path = Path(document.get("routing_catalog_path", DEFAULT_ROUTING_CATALOG)).resolve()
@@ -2755,7 +3268,10 @@ def advance_after_mutation(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
     if not new_plan.dispatch_allowed:
         msg = "recaptured repair epoch produced a blocked final-state plan: " + "; ".join(new_plan.blockers)
         raise ValueError(msg)
+    invalidated = _mutation_invalidated_nodes(old_plan, new_plan, changed_paths, repository_root, sources)
+    new_plan = _carry_forward_audits(document, old_plan, new_plan, planning_input, invalidated=invalidated, sources=sources)
     new_plan = _epoch_scoped_plan(new_plan, epoch)
+    reused_ids = {item.evidence_id for item in new_plan.audit_reuse_transitions}
     artifact_store = Path(_required_text(document, "artifact_store")).resolve() / f"repair-epoch-{epoch:03d}"
     dispatch_set = materialize_dispatches(
         {
@@ -2768,26 +3284,38 @@ def advance_after_mutation(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
             "state_verification_command": _required_text(document, "state_verification_command"),
         }
     )
-    old_paths = {path for node in old_plan.actual_worker_nodes for path in node.coverage}
+    old_paths = set(_text_list(previous_capture, "captured_scope_paths"))
     newly_touched_paths = tuple(sorted(set(captured_paths) - old_paths))
-    old_nodes = tuple(node.node_id for node in old_plan.actual_worker_nodes)
+    unaffected = tuple(node for node in old_plan.actual_worker_nodes if node.node_id not in invalidated)
     replacement_lineage: list[dict[str, object]] = []
     for node in new_plan.actual_worker_nodes:
         predecessors = tuple(
             old.node_id
             for old in old_plan.actual_worker_nodes
-            if old.skill_id == node.skill_id and old.mode == node.mode and bool(set(old.coverage) & set(node.coverage))
+            if old.skill_id == node.skill_id
+            and old.mode == node.mode
+            and (set(old.requirement_ids).intersection(node.requirement_ids) or node.mode == "synthesis")
         )
         replacement_lineage.append({"node_id": node.node_id, "replaces_node_ids": list(predecessors)})
     fix_node_id = f"fix-epoch-{epoch:03d}"
     return {
         "authorization_transition": {"after": authorization_after, "before": authorization_before},
         "dispatch_set": dispatch_set,
-        "invalidated_nodes": [{"node_id": node_id, "state": "awaiting-replan"} for node_id in old_nodes],
+        "invalidated_nodes": [{"node_id": node_id, "state": "awaiting-replan"} for node_id in invalidated],
+        "capture": new_capture,
+        "lifecycle_input": {"plan": asdict(new_plan), "source_state": list(new_state)},
         "new_plan": asdict(new_plan),
         "new_source_state": list(new_state),
         "newly_touched_paths": list(newly_touched_paths),
         "old_source_state": list(old_source_state),
+        "preserved_evidence": [
+            {"node_id": node.node_id, "source": sources[node.node_id][0], "evidence_id": sources[node.node_id][1]["evidence_id"]}
+            for node in unaffected
+            if node.mode == "audit" and node.node_id in sources and sources[node.node_id][1]["status"] in {"completed", "no-findings"}
+        ],
+        "preservation_policy": "verified-unchanged-audit-inputs",
+        "reused_evidence_ids": sorted(reused_ids),
+        "unaffected_node_ids": [node.node_id for node in unaffected],
         "repair_epoch": {
             "changed_paths": list(changed_paths),
             "fix_nodes": [{"mode": "fix", "node_id": fix_node_id, "serialized": True}],
@@ -2796,13 +3324,16 @@ def advance_after_mutation(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
         },
         "replacement_lineage": replacement_lineage,
         "schema_version": 1,
-        "stale_evidence_ids": [_expected_evidence_id(node) for node in old_plan.actual_worker_nodes],
+        "stale_evidence_ids": [
+            *(_expected_evidence_id(node) for node in old_plan.actual_worker_nodes if _expected_evidence_id(node) not in reused_ids),
+            *dict.fromkeys(evidence_id for _requirement_id, evidence_id in old_plan.exact_reused_review_evidence if evidence_id not in reused_ids),
+        ],
         "status": "advanced",
     }
 
 
 def _plan_digest(plan: GraphPlan) -> str:
-    return _sha256_bytes(_canonical_json(asdict(plan)).encode())
+    return graph_plan_digest(plan)
 
 
 def _expected_evidence_id(node: WorkerNode) -> str:
@@ -3154,12 +3685,45 @@ def _dispatches_by_node(dispatch_set: dict[str, Any], *, plan: GraphPlan, source
         if node_id in entries or not isinstance(dispatch, dict) or dispatch.get("node_id") != node_id:
             msg = f"dispatch set has an invalid or duplicate node entry: {node_id}"
             raise ValueError(msg)
+        if "worker_input_path" in entry:
+            worker_input = Path(_required_text(entry, "worker_input_path"))
+            expected_input = (json.dumps(entry, indent=2, sort_keys=True) + "\n").encode()
+            if _read_regular_file_no_follow(worker_input) != expected_input:
+                msg = f"worker input differs from its materialized dispatch: {node_id} ({worker_input})"
+                raise ValueError(msg)
         entries[node_id] = entry
     expected_node_ids = {node.node_id for node in plan.actual_worker_nodes}
     if set(entries) != expected_node_ids:
         msg = "dispatch set does not contain exactly the planned nodes"
         raise ValueError(msg)
     return entries
+
+
+def _accepted_journal_sources(
+    plan: GraphPlan, source_state: tuple[str, str, str], events: tuple[dict[str, Any], ...], entries: dict[str, dict[str, Any]]
+) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
+    state, _head = _fold_execution_journal(plan, source_state, events)
+    latest = {str(event["node_id"]): event for event in events}
+    sources: dict[str, dict[str, Any]] = {}
+    records: list[dict[str, Any]] = []
+    for node in plan.actual_worker_nodes:
+        if state.get(node.node_id) != "accepted":
+            continue
+        entry = entries[node.node_id]
+        source = {"artifact_path": entry["artifact_path"], "metadata_path": entry["metadata_path"]}
+        verified, _limitations = _verified_journal_evidence(source, plan=plan, node=node, source_state=source_state)
+        if verified != latest[node.node_id]["evidence"]:
+            msg = f"accepted artifact differs from journal: {node.node_id}"
+            raise ValueError(msg)
+        _kind, _expectation, _evidence, _content, record = _load_evidence_source(source, require_normalized=True)
+        if record is not None:
+            records.append(record)
+        sources[node.node_id] = source
+    for source in _verified_reused_sources(plan, source_state):
+        _kind, _expectation, _evidence, _content, record = _load_evidence_source(source, require_normalized=True)
+        if record is not None:
+            records.append(record)
+    return sources, records
 
 
 def next_ready_nodes(document: dict[str, Any], *, journal_events: tuple[dict[str, Any], ...], dispatch_set: dict[str, Any]) -> dict[str, Any]:
@@ -3174,20 +3738,30 @@ def next_ready_nodes(document: dict[str, Any], *, journal_events: tuple[dict[str
     if current_source_state != source_state:
         msg = "next-ready current recapture differs from the plan-bound source state"
         raise ValueError(msg)
+    reused_sources = _verified_reused_sources(plan, source_state)
     state, head_digest = _fold_execution_journal(plan, source_state, journal_events)
     dispatches = _dispatches_by_node(dispatch_set, plan=plan, source_state=source_state)
+    _sources, records = _accepted_journal_sources(plan, source_state, journal_events, dispatches)
+    validation_reconciliation = _validation_reconciliation(plan, records)
     accepted = {node_id for node_id, lifecycle in state.items() if lifecycle == "accepted"}
     blocked = {node_id for node_id, lifecycle in state.items() if lifecycle == "blocked"}
     invalidated = {node_id for node_id, lifecycle in state.items() if lifecycle == "invalidated"}
     awaiting_replan = {node_id for node_id, lifecycle in state.items() if lifecycle == "awaiting-replan"}
     in_flight = {node_id for node_id, lifecycle in state.items() if lifecycle == "in-flight"}
     blockers = ["blocked nodes prevent completion: " + ", ".join(sorted(blocked))] if blocked else []
+    blockers.extend(validation_reconciliation["blockers"])
+    pending_validation = sorted(
+        {item["validation_unit_id"] for item in validation_reconciliation["requirements"] if item["resolution"] == "planned"} - accepted
+    )
     if awaiting_replan:
         blockers.append("source mutation requires a fresh plan: " + ", ".join(sorted(awaiting_replan)))
     ready: list[str] = []
     waiting: list[dict[str, Any]] = []
     for node in plan.actual_worker_nodes:
         if node.node_id in accepted | awaiting_replan | blocked | in_flight:
+            continue
+        if node.mode == "synthesis" and (validation_reconciliation["blockers"] or pending_validation):
+            waiting.append({"node_id": node.node_id, "validation_blockers": validation_reconciliation["blockers"], "missing_validators": pending_validation})
             continue
         missing = tuple(predecessor for predecessor in node.predecessors if predecessor not in accepted)
         if missing:
@@ -3209,8 +3783,151 @@ def next_ready_nodes(document: dict[str, Any], *, journal_events: tuple[dict[str
         },
         "ready_dispatches": [dispatches[node_id] for node_id in ready],
         "ready_node_ids": ready,
+        "reused_evidence_ids": [item.evidence_id for item in plan.audit_reuse_transitions],
+        "reused_sources": list(reused_sources),
         "schema_version": 1,
+        "validation_reconciliation": validation_reconciliation,
         "waiting": waiting,
+    }
+
+
+def _expanded_validation_plan(document: dict[str, Any], plan: GraphPlan, records: list[dict[str, Any]], repository_root: Path) -> GraphPlan:
+    reconciliation = _validation_reconciliation(plan, records)
+    pending = {item["requirement_id"] for item in reconciliation["requirements"] if item["resolution"] != "planned"}
+    raw_requirements = _records(document, "validation_requirements")
+    for raw in raw_requirements:
+        require_schema_definition(raw, _PLANNING_INPUT_SCHEMA, "validationRequirement")
+    additions = validation_requirements_from_document({"validation_requirements": list(raw_requirements)}, repository_root)
+    existing = {requirement for unit in plan.coalesced_validation_units for requirement in unit.requirement_ids}
+    source_state = _state(document, "source_state")
+    for item in additions:
+        if item.requirement_id not in pending or item.requirement_id in existing or item.source_state != source_state or not item.required:
+            msg = f"late validation must be a new, required, source-matching discovered identity: {item.requirement_id}"
+            raise ValueError(msg)
+    units, mappings = coalesce_validation_requirements(additions, reserved_node_ids=tuple(node.node_id for node in plan.actual_worker_nodes))
+    exclusions = list(plan.validation_exclusions)
+    discoveries = {(item["originating_evidence_id"], item["requirement_id"], item["requirement_digest"]): item for item in reconciliation["requirements"]}
+    for raw in _records(document, "user_exclusions"):
+        exclusion = ValidationExclusion(
+            _required_text(raw, "originating_evidence_id"),
+            _required_text(raw, "requirement_id"),
+            _sha256_digest(raw.get("requirement_digest"), "requirement_digest"),
+            _required_text(raw, "reason"),
+        )
+        if (exclusion.originating_evidence_id, exclusion.requirement_id, exclusion.requirement_digest) not in discoveries:
+            msg = "user exclusion does not name an exact accepted validation requirement"
+            raise ValueError(msg)
+        if exclusion not in exclusions:
+            exclusions.append(exclusion)
+    validator = next((node for node in plan.actual_worker_nodes if node.mode == "validation"), None)
+    if validator is None:
+        msg = "validation expansion requires the existing baseline validator"
+        raise ValueError(msg)
+    added_nodes = _validation_nodes(units, skill_path=validator.skill_path, skill_digest=validator.skill_digest, reference_digests=validator.reference_digests)
+    nodes = _schedule_nodes(
+        (
+            *(
+                replace(node, predecessors=(*node.predecessors, *(unit.node_id for unit in units))) if node.mode == "synthesis" else node
+                for node in plan.actual_worker_nodes
+            ),
+            *added_nodes,
+        )
+    )
+    epochs = _partition_execution_epochs(nodes, WorkerBudget(plan.worker_budget, plan.recovery_finalization_reserve)) if plan.execution_epochs else ()
+    expanded = replace(
+        plan,
+        actual_worker_nodes=nodes,
+        complete_node_count=len(nodes),
+        coalesced_validation_units=(*plan.coalesced_validation_units, *units),
+        selected_validation_units=(*plan.selected_validation_units, *(unit.node_id for unit in units)),
+        validation_evidence_mapping=(*plan.validation_evidence_mapping, *mappings),
+        validation_exclusions=tuple(exclusions),
+        execution_epochs=epochs,
+        current_epoch_node_ids=epochs[0].node_ids if epochs else tuple(node.node_id for node in nodes),
+        requires_continuation=len(epochs) > 1,
+    )
+    remaining = _validation_reconciliation(expanded, records)
+    if remaining["blockers"]:
+        msg = "validation expansion leaves unresolved identities: " + "; ".join(remaining["blockers"])
+        raise ValueError(msg)
+    return expanded
+
+
+def reconcile_validation_requirements(document: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    """Inspect late requirements or publish a source-preserving plan revision."""
+    plan = _graph_plan(document["plan"])
+    source_state = _state(document, "source_state")
+    if _capture_source_state(args.current_capture) != source_state:
+        msg = "validation reconciliation current capture differs from plan-bound source state"
+        raise ValueError(msg)
+    events, state, head = read_execution_journal(args.journal, plan=plan, source_state=source_state)
+    entries = _dispatches_by_node(_read_json_object(args.dispatches), plan=plan, source_state=source_state)
+    sources, records = _accepted_journal_sources(plan, source_state, events, entries)
+    reconciliation = _validation_reconciliation(plan, records)
+    if not document.get("validation_requirements") and not document.get("user_exclusions"):
+        return {"schema_version": 1, "status": "requires-expansion" if reconciliation["blockers"] else "resolved", **reconciliation}
+    if any(status in {"in-flight", "blocked", "awaiting-replan"} for status in state.values()):
+        msg = "validation expansion requires quiescent execution without blocked or source-mutated nodes; preserve the current dispatches and journal"
+        raise ValueError(msg)
+    first_entry = next(iter(entries.values()), None)
+    if first_entry is None:
+        msg = "validation expansion requires an existing dispatch"
+        raise ValueError(msg)
+    sample = first_entry["dispatch"]
+    expanded = _expanded_validation_plan(document, plan, records, Path(sample["repository_root"]))
+    if expanded == plan:
+        return {"schema_version": 1, "status": "resolved", **reconciliation}
+    store = Path(_required_text(document, "artifact_store")).resolve() / f"validation-expansion-{_plan_digest(expanded)[7:23]}"
+    retained = {node.node_id: entries[node.node_id] for node in plan.actual_worker_nodes if node.node_id in sources and node.mode != "synthesis"}
+    dispatches = materialize_dispatches(
+        {
+            "artifact_store": str(store / "artifacts"),
+            "authorization": sample["authorization"],
+            "plan": json.loads(_canonical_json(asdict(expanded))),
+            "repository_root": sample["repository_root"],
+            "source_state": list(source_state),
+            "state_verification_command": sample["state_verification_command"],
+        },
+        preserved_entries=retained,
+    )
+    lifecycle = {"plan": json.loads(_canonical_json(asdict(expanded))), "source_state": list(source_state)}
+    # Rebind verified acceptance to the new plan, preserving every original artifact.
+    # Publish this journal once; never append to or rewrite the historical journal.
+    migrated: list[dict[str, Any]] = []
+    migrated_state: dict[str, str] = {}
+    for node in expanded.actual_worker_nodes:
+        if node.node_id not in retained:
+            continue
+        evidence, _limitations = _verified_journal_evidence(sources[node.node_id], plan=expanded, node=node, source_state=source_state)
+        affected = _apply_journal_transition(expanded, migrated_state, node_id=node.node_id, status="accepted")
+        event: dict[str, Any] = {
+            "affected_node_ids": list(affected),
+            "evidence": evidence,
+            "node_id": node.node_id,
+            "plan_digest": _plan_digest(expanded),
+            "previous_event_digest": migrated[-1]["event_digest"] if migrated else None,
+            "reason": None,
+            "schema_version": 1,
+            "sequence": len(migrated) + 1,
+            "source_state": list(source_state),
+            "status": "accepted",
+        }
+        event["event_digest"] = _sha256_bytes(_canonical_json(event).encode())
+        migrated.append(event)
+    paths = {"dispatches_path": store / "dispatches.json", "lifecycle_input_path": store / "lifecycle.json", "journal_path": store / "execution.jsonl"}
+    _write_text_once(paths["dispatches_path"], json.dumps(dispatches, indent=2, sort_keys=True) + "\n")
+    _write_text_once(paths["lifecycle_input_path"], json.dumps(lifecycle, indent=2, sort_keys=True) + "\n")
+    _write_text_once(paths["journal_path"], "".join(_canonical_json(event) + "\n" for event in migrated))
+    return {
+        "schema_version": 1,
+        "status": "expanded",
+        "source_state": list(source_state),
+        "lifecycle_input": lifecycle,
+        **{key: str(path) for key, path in paths.items()},
+        "retained_node_ids": sorted(retained),
+        "superseded_synthesis_node_ids": [node.node_id for node in plan.actual_worker_nodes if node.mode == "synthesis"],
+        "lineage": {"previous_plan_digest": _plan_digest(plan), "previous_journal_head": head, "previous_journal_path": str(args.journal.resolve())},
+        "validation_reconciliation": _validation_reconciliation(expanded, records),
     }
 
 
@@ -3269,11 +3986,11 @@ def reconcile_handoffs(document: dict[str, Any]) -> dict[str, Any]:
     exact_reuse_ids = {evidence_id for _requirement_id, evidence_id in plan.exact_reused_review_evidence}
     normalized: dict[str, dict[str, Any]] = {}
     accepted: list[str] = []
-    for source in _records(document, "sources"):
+    for source in _evidence_sources(document, plan):
         kind, expectation, evidence, _content, record = _load_evidence_source(source, require_normalized=True)
         if kind != "review" or not isinstance(expectation, ReviewEvidenceExpectation) or not isinstance(evidence, ReviewEvidence):
             continue
-        if expectation.source_state != source_state or not assess_review_evidence(expectation, evidence).satisfies_requirements:
+        if review_source_state_blockers(plan, expectation, evidence, source_state) or not assess_review_evidence(expectation, evidence).satisfies_requirements:
             continue
         if evidence.node_id not in planned_node_ids and evidence.evidence_id not in exact_reuse_ids:
             continue
@@ -3305,7 +4022,7 @@ def finalize_proof(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, P
         raise ValueError(msg)
     expectation = repository_review_proof_expectation(plan, source_state=source_state)
     stale_ids = set(_text_list(document, "stale_evidence_ids"))
-    sources = _records(document, "sources")
+    sources = _evidence_sources(document, plan)
     if not sources:
         msg = "finalize-proof requires persisted evidence sources"
         raise ValueError(msg)
@@ -3410,6 +4127,14 @@ def finalize_proof(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, P
         )
     )
     preblockers.extend(handoff_blockers)
+    validation_reconciliation = _validation_reconciliation(
+        plan, [normalized_by_evidence[evidence_id] for evidence_id in accepted_review_ids if evidence_id in normalized_by_evidence]
+    )
+    preblockers.extend(validation_reconciliation["blockers"])
+    for evidence_id in accepted_review_ids:
+        evidence = loaded[evidence_id][2]
+        if isinstance(evidence, ReviewEvidence) and evidence.validation_requirement_ids and evidence_id not in normalized_by_evidence:
+            preblockers.append(f"validation requirements lack compiler-bound normalized context: {evidence_id}")
 
     verifier_id = _defaulted_text(document, "verifier_id", "review-graph-runtime")
     manifest_id = _defaulted_text(document, "manifest_id", f"manifest:{expectation.plan_digest.removeprefix('sha256:')[:16]}")
@@ -3473,7 +4198,7 @@ def finalize_proof(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, P
         repository_validation_status = "failed"
     elif "blocked" in validation_statuses or "not-applicable" in validation_statuses:
         repository_validation_status = "blocked"
-    elif len(accepted_validation_ids) != len(validation_node_ids):
+    elif len(accepted_validation_ids) != len(validation_node_ids) or validation_reconciliation["blockers"]:
         repository_validation_status = "incomplete"
     else:
         repository_validation_status = "passed"
@@ -3497,6 +4222,7 @@ def finalize_proof(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, P
         },
         "proof": asdict(proof),
         "repository_validation_status": repository_validation_status,
+        "validation_reconciliation": validation_reconciliation,
         "schema_version": 1,
         "status": graph_proof_status,
         "summary": {
@@ -3508,16 +4234,13 @@ def finalize_proof(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, P
     }
 
 
-def _runtime_subparser(subparsers: Any, operation: str, help_text: str) -> argparse.ArgumentParser:
+def _runtime_subparser(subparsers: Any, operation: str, help_text: str, *, contract_text: str | None = None) -> argparse.ArgumentParser:
     schema_reference = f"{_RUNTIME_OPERATION_INPUT_SCHEMA}#/$defs/{operation}"
     example_reference = f"{_RUNTIME_OPERATION_EXAMPLES}#/{operation}"
-    parser = subparsers.add_parser(
-        operation,
-        description=help_text,
-        epilog=f"Input schema: {schema_reference}\nValid example: {example_reference}",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        help=help_text,
-    )
+    epilog = f"Input schema: {schema_reference}\nValid example: {example_reference}"
+    if contract_text is not None:
+        epilog += "\n\n" + contract_text
+    parser = subparsers.add_parser(operation, description=help_text, epilog=epilog, formatter_class=argparse.RawDescriptionHelpFormatter, help=help_text)
     if not isinstance(parser, argparse.ArgumentParser):
         msg = f"runtime parser factory returned an invalid parser for {operation}"
         raise TypeError(msg)
@@ -3549,7 +4272,7 @@ def _argument_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     node_parser.add_argument("--after-capture", type=Path, required=True)
     node_parser.add_argument("--workspace-before", type=Path)
     node_parser.add_argument("--workspace-after", type=Path)
-    node_parser.add_argument("--journal", type=Path, required=True)
+    node_parser.add_argument("--journal", type=Path, required=True, help=_INITIAL_JOURNAL_HELP)
     node_parser.add_argument("--status", choices=sorted(_REVIEW_STATUSES))
     node_parser.add_argument("--limitation", action="append")
     node_parser.add_argument("--output", type=Path, required=True)
@@ -3579,28 +4302,48 @@ def _argument_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     handoff_parser = _runtime_subparser(subparsers, "reconcile-handoffs", "resolve covered handoffs and return new routing triggers")
     handoff_parser.add_argument("--input", type=Path, required=True)
     handoff_parser.add_argument("--output", type=Path, required=True)
-    journal_parser = _runtime_subparser(subparsers, "journal-append", "append one verified graph lifecycle event")
+    validation_parser = _runtime_subparser(subparsers, "reconcile-validation-requirements", "inspect or expand late validation without changing source state")
+    validation_parser.add_argument("--input", type=Path, required=True)
+    validation_parser.add_argument("--journal", type=Path, required=True)
+    validation_parser.add_argument("--dispatches", type=Path, required=True)
+    validation_parser.add_argument("--current-capture", type=Path, required=True)
+    validation_parser.add_argument("--output", type=Path, required=True)
+    journal_parser = _runtime_subparser(
+        subparsers,
+        "journal-append",
+        "append one verified graph lifecycle event",
+        contract_text=(
+            "Status field contract:\n"
+            "  in-flight       artifact/metadata/kind/reason forbidden\n"
+            "  accepted        artifact and metadata required; kind optional; reason forbidden\n"
+            "  blocked         artifact and metadata optional as a pair; kind optional with evidence; reason required\n"
+            "  invalidated     artifact/metadata/kind forbidden; reason required\n"
+            "  awaiting-replan artifact/metadata/kind forbidden; reason required"
+        ),
+    )
     journal_parser.add_argument("--input", type=Path, required=True)
-    journal_parser.add_argument("--journal", type=Path, required=True)
+    journal_parser.add_argument("--journal", type=Path, required=True, help=_INITIAL_JOURNAL_HELP)
     journal_parser.add_argument("--node-id", required=True)
-    journal_parser.add_argument("--status", choices=sorted(_JOURNAL_STATUSES), required=True)
-    journal_parser.add_argument("--artifact", type=Path)
-    journal_parser.add_argument("--metadata", type=Path)
-    journal_parser.add_argument("--kind", choices=("review", "validation"))
-    journal_parser.add_argument("--reason")
+    journal_parser.add_argument("--status", choices=sorted(_JOURNAL_STATUSES), required=True, help="lifecycle status; see the status field contract below")
+    journal_parser.add_argument("--artifact", type=Path, help="compiled evidence artifact; paired with --metadata")
+    journal_parser.add_argument("--metadata", type=Path, help="compiled evidence metadata; paired with --artifact")
+    journal_parser.add_argument("--kind", choices=("review", "validation"), help="optional evidence kind; requires artifact and metadata")
+    journal_parser.add_argument("--reason", help="required for blocked, invalidated, and awaiting-replan; forbidden otherwise")
     ready_parser = _runtime_subparser(subparsers, "next-ready", "compute dependency-ready graph nodes")
     ready_parser.add_argument("--dispatches", type=Path, required=True)
     ready_parser.add_argument("--current-capture", type=Path, required=True)
     ready_parser.add_argument("--input", type=Path, required=True)
-    ready_parser.add_argument("--journal", type=Path, required=True)
+    ready_parser.add_argument("--journal", type=Path, required=True, help=_INITIAL_JOURNAL_HELP)
     ready_output = ready_parser.add_mutually_exclusive_group(required=True)
     ready_output.add_argument("--output", type=Path)
-    ready_output.add_argument("--output-dir", type=Path, help="runtime-managed immutable next-ready generations")
+    ready_output.add_argument(
+        "--output-dir", type=Path, help="runtime-managed immutable next-ready generations; prints output_path and output_generation as JSON"
+    )
     final_parser = _runtime_subparser(subparsers, "finalize-proof", "derive and verify the repository proof")
     final_parser.add_argument("--current-capture", type=Path, required=True)
     final_parser.add_argument("--dispatches", type=Path)
     final_parser.add_argument("--input", type=Path, required=True)
-    final_parser.add_argument("--journal", type=Path)
+    final_parser.add_argument("--journal", type=Path, help=_INITIAL_JOURNAL_HELP)
     final_parser.add_argument("--output", type=Path, required=True)
     return parser
 
@@ -3616,6 +4359,19 @@ def _journal_request_from_args(args: argparse.Namespace) -> JournalEventRequest:
             source["kind"] = args.kind
     elif args.kind is not None:
         msg = "--kind requires --artifact and --metadata"
+        raise ValueError(msg)
+    has_evidence = source is not None
+    if args.status == "accepted" and not has_evidence:
+        msg = "accepted journal event requires --artifact and --metadata"
+        raise ValueError(msg)
+    if args.status in {"in-flight", "invalidated", "awaiting-replan"} and has_evidence:
+        msg = f"{args.status} journal event forbids --artifact, --metadata, and --kind"
+        raise ValueError(msg)
+    if args.status in {"blocked", "invalidated", "awaiting-replan"} and args.reason is None:
+        msg = f"{args.status} journal event requires --reason"
+        raise ValueError(msg)
+    if args.status in {"in-flight", "accepted"} and args.reason is not None:
+        msg = f"{args.status} journal event forbids --reason"
         raise ValueError(msg)
     return JournalEventRequest(args.node_id, args.status, source=source, reason=args.reason)
 
@@ -3826,6 +4582,8 @@ def _json_operation_output(document: dict[str, Any], args: argparse.Namespace) -
         return advance_after_mutation(document)
     if args.operation == "reconcile-handoffs":
         return reconcile_handoffs(document)
+    if args.operation == "reconcile-validation-requirements":
+        return reconcile_validation_requirements(document, args)
     if args.operation == "next-ready":
         return _next_ready_from_files(document, args)
     return finalize_proof(_finalize_document_from_files(document, args))
@@ -3866,6 +4624,8 @@ def _run_operation(document: dict[str, Any], args: argparse.Namespace) -> int:
         output["output_generation"] = generation
         output["output_path"] = str(output_path)
     _write_text_once(output_path, json.dumps(output, indent=2, sort_keys=True) + "\n")
+    if args.operation == "next-ready" and args.output_dir is not None:
+        print(_canonical_json({"output_generation": output["output_generation"], "output_path": str(output_path)}))
     return 2 if args.operation == "finalize-proof" and output["status"] != "complete" else 0
 
 

--- a/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
@@ -73,6 +73,7 @@ from review_graph_plan import (
     coalesce_validation_requirements,
     create_artifact_manifest,
     graph_plan_digest,
+    graph_plan_digest_matches,
     load_routing_catalog,
     plan_from_document,
     repository_review_proof_expectation,
@@ -1742,6 +1743,8 @@ def capture_workspace_snapshot(dispatch: dict[str, Any]) -> dict[str, Any]:
         raise TypeError(msg)
     unit = _validation_unit(raw_unit)
     repository_root = Path(_required_text(dispatch, "repository_root")).resolve()
+    if unit.requires_isolation:
+        _validate_isolated_workspace_paths(dispatch, unit, ())
     approved = {artifact.path: artifact for artifact in unit.allowed_artifacts}
     paths = tuple(dict.fromkeys((*unit.expected_workspace_effects, *approved)))
     records: list[dict[str, object]] = []
@@ -2337,7 +2340,7 @@ def _validation_reconciliation(plan: GraphPlan, records: list[dict[str, Any]]) -
 
 def _synthesis_plan_context(plan: GraphPlan, records: list[dict[str, Any]]) -> dict[str, Any]:
     by_evidence = {str(record["evidence_id"]): record for record in records}
-    review_ids = tuple(str(record["evidence_id"]) for record in records if record.get("result_type") != "validation-result")
+    review_ids = tuple(str(record["evidence_id"]) for record in records if record.get("record_type") == "review")
     handoffs, unresolved, blockers = _reconciled_handoffs(plan, by_evidence, review_ids)
     return {
         "plan_digest": _plan_digest(plan),
@@ -2437,6 +2440,9 @@ def _verified_reused_sources(plan: GraphPlan, source_state: tuple[str, str, str]
         inputs = expectation.audit_input_identity
         if inputs is None:  # Narrowed by the reuse gate.
             msg = "audit reuse lacks compiler-bound inputs"
+            raise ValueError(msg)
+        if source_state not in snapshots:
+            msg = "audit reuse lacks a source snapshot for current source_state"
             raise ValueError(msg)
         explicit = tuple(path for decision in plan.routing_decisions if decision.evidence_id == evidence.evidence_id for path in decision.instruction_paths)
         paths = _applicable_instruction_paths(Path(snapshots[source_state].repository_root), inputs.owned_paths, explicit)
@@ -2756,6 +2762,9 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
         msg = "repository_root must be an existing absolute directory"
         raise ValueError(msg)
     repository_root = str(repository_root_path.resolve())
+    for unit in plan.coalesced_validation_units:
+        if unit.requires_isolation:
+            _validate_isolated_workspace_paths({"repository_root": repository_root}, unit, ())
     authorization = _required_text(document, "authorization")
     if authorization not in {"review-only", "review-and-fix"}:
         msg = "authorization must be review-only or review-and-fix"
@@ -3132,7 +3141,19 @@ def _compact_reuse_overrides(plan: GraphPlan, reused_requirements: dict[str, str
     return json.loads(_canonical_json(overrides))
 
 
-def _carry_forward_audits(  # noqa: C901, PLR0913
+def _audit_reuse_blocker(record: dict[str, Any], *, invalidated: bool) -> tuple[str, str] | None:
+    if invalidated:
+        return "invalidated-inputs", "Owned inputs, routing, or a predecessor changed."
+    if record.get("mode") != "audit" or record.get("status") not in {"completed", "no-findings"}:
+        return "ineligible-evidence", "Only completed audit leaves can be reused across captures."
+    if record.get("scope_limitations"):
+        return "coverage-limitations", "The audit declares incomplete owned-path coverage."
+    if record.get("limitations"):
+        return "unclassified-limitations", "Free-text caveats cannot prove independence from changed inputs or prior validation."
+    return None
+
+
+def _carry_forward_audits(  # noqa: C901, PLR0913, PLR0915 - preserve provenance and report every reuse rejection.
     document: dict[str, Any],
     old_plan: GraphPlan,
     candidate_plan: GraphPlan,
@@ -3140,11 +3161,21 @@ def _carry_forward_audits(  # noqa: C901, PLR0913
     *,
     invalidated: tuple[str, ...],
     sources: dict[str, tuple[dict[str, Any], dict[str, Any]]],
-) -> GraphPlan:
+) -> tuple[GraphPlan, list[dict[str, str]]]:
     """Convert only proven unchanged leaves into non-executable routed reuse."""
+    decisions = {
+        node.node_id: {"node_id": node.node_id, "disposition": "not-reused", "reason_code": "missing-evidence", "reason": "No accepted source was supplied."}
+        for node in old_plan.actual_worker_nodes
+    }
+
+    def decision(node_id: str, code: str, reason: str) -> None:
+        decisions[node_id] = {"node_id": node_id, "disposition": "reused" if code == "verified" else "not-reused", "reason_code": code, "reason": reason}
+
     previous, current = document["previous_capture"], document["new_capture"]
     if current.get("repository_state_format") != SNAPSHOT_FORMAT:
-        return candidate_plan
+        for node_id in sources:
+            decision(node_id, "unsupported-snapshot", "The current capture lacks content-bound path identities.")
+        return candidate_plan, list(decisions.values())
     target = source_snapshot(current)
     target.verify()
     snapshots = {item.source_state: item for item in old_plan.reuse_source_snapshots}
@@ -3158,16 +3189,18 @@ def _carry_forward_audits(  # noqa: C901, PLR0913
     records: list[tuple[ReviewEvidenceExpectation, ReviewEvidence]] = []
     reused_requirements: dict[str, str] = {}
     for node_id, (source, record) in sources.items():
-        if node_id in invalidated or record.get("mode") != "audit" or record.get("status") not in {"completed", "no-findings"}:
-            continue
-        if record.get("scope_limitations") or record.get("limitations"):
+        blocker = _audit_reuse_blocker(record, invalidated=node_id in invalidated)
+        if blocker is not None:
+            decision(node_id, *blocker)
             continue
         _kind, expectation, evidence, _content, _normalized = _load_evidence_source(source, require_normalized=True)
         if not isinstance(expectation, ReviewEvidenceExpectation) or not isinstance(evidence, ReviewEvidence):
+            decision(node_id, "ineligible-evidence", "The source is not typed review evidence.")
             continue
         inputs = expectation.audit_input_identity
         origin = snapshots.get(expectation.source_state)
         if inputs is None or origin is None or evidence.predecessor_evidence_ids or expectation.execution_profile != candidate_plan.execution_profile:
+            decision(node_id, "unproven-inputs", "Bound origin/inputs, predecessor independence, or the execution profile do not permit reuse.")
             continue
         candidates = tuple(
             node
@@ -3179,6 +3212,7 @@ def _carry_forward_audits(  # noqa: C901, PLR0913
             == (evidence.skill_id, evidence.skill_path, evidence.skill_digest, evidence.reference_digests, inputs.owned_paths)
         )
         if len(candidates) != 1:
+            decision(node_id, "routing-identity-changed", "No unique unchanged audit leaf owns the same requirements and inputs.")
             continue
         candidate = candidates[0]
         instructions = _applicable_instruction_paths(root, candidate.coverage, candidate.instruction_paths)
@@ -3193,14 +3227,16 @@ def _carry_forward_audits(  # noqa: C901, PLR0913
         )
         try:
             verify_reuse_inputs(origin, target, inputs, transition)
-        except ValueError:
+        except ValueError as error:
             # Incomplete/changed inputs are ordinary fresh review work, not reuse.
+            decision(node_id, "input-proof-failed", str(error))
             continue
+        decision(node_id, "verified", "Complete audit inputs and dependencies are unchanged.")
         transitions.append(transition)
         records.append((expectation, evidence))
         reused_requirements.update(dict.fromkeys(evidence.requirement_ids, evidence.evidence_id))
     if not transitions:
-        return candidate_plan
+        return candidate_plan, list(decisions.values())
     planning_input.pop("routing_decisions", None)
     planning_input["routing_overrides"] = _compact_reuse_overrides(candidate_plan, reused_requirements)
     require_schema(planning_input, _PLANNING_INPUT_SCHEMA)
@@ -3221,7 +3257,7 @@ def _carry_forward_audits(  # noqa: C901, PLR0913
         if blockers:
             msg = "rerouted audit reuse is inconsistent: " + "; ".join(blockers)
             raise ValueError(msg)
-    return routed
+    return routed, list(decisions.values())
 
 
 def advance_after_mutation(document: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
@@ -3269,7 +3305,7 @@ def advance_after_mutation(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
         msg = "recaptured repair epoch produced a blocked final-state plan: " + "; ".join(new_plan.blockers)
         raise ValueError(msg)
     invalidated = _mutation_invalidated_nodes(old_plan, new_plan, changed_paths, repository_root, sources)
-    new_plan = _carry_forward_audits(document, old_plan, new_plan, planning_input, invalidated=invalidated, sources=sources)
+    new_plan, reuse_decisions = _carry_forward_audits(document, old_plan, new_plan, planning_input, invalidated=invalidated, sources=sources)
     new_plan = _epoch_scoped_plan(new_plan, epoch)
     reused_ids = {item.evidence_id for item in new_plan.audit_reuse_transitions}
     artifact_store = Path(_required_text(document, "artifact_store")).resolve() / f"repair-epoch-{epoch:03d}"
@@ -3284,6 +3320,16 @@ def advance_after_mutation(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
             "state_verification_command": _required_text(document, "state_verification_command"),
         }
     )
+    lifecycle = {"plan": asdict(new_plan), "source_state": list(new_state)}
+    continuation = {
+        "lifecycle_input_path": artifact_store / "lifecycle.json",
+        "dispatches_path": artifact_store / "dispatches.json",
+        "capture_path": artifact_store / "capture.json",
+        "journal_path": artifact_store / "execution.jsonl",
+    }
+    for key, value in (("lifecycle_input_path", lifecycle), ("dispatches_path", dispatch_set), ("capture_path", new_capture)):
+        _write_text_once(continuation[key], json.dumps(value, indent=2, sort_keys=True) + "\n")
+    _write_text_once(continuation["journal_path"], "")
     old_paths = set(_text_list(previous_capture, "captured_scope_paths"))
     newly_touched_paths = tuple(sorted(set(captured_paths) - old_paths))
     unaffected = tuple(node for node in old_plan.actual_worker_nodes if node.node_id not in invalidated)
@@ -3303,18 +3349,20 @@ def advance_after_mutation(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
         "dispatch_set": dispatch_set,
         "invalidated_nodes": [{"node_id": node_id, "state": "awaiting-replan"} for node_id in invalidated],
         "capture": new_capture,
-        "lifecycle_input": {"plan": asdict(new_plan), "source_state": list(new_state)},
+        "lifecycle_input": lifecycle,
+        **{key: str(path) for key, path in continuation.items()},
         "new_plan": asdict(new_plan),
         "new_source_state": list(new_state),
         "newly_touched_paths": list(newly_touched_paths),
         "old_source_state": list(old_source_state),
         "preserved_evidence": [
-            {"node_id": node.node_id, "source": sources[node.node_id][0], "evidence_id": sources[node.node_id][1]["evidence_id"]}
-            for node in unaffected
-            if node.mode == "audit" and node.node_id in sources and sources[node.node_id][1]["status"] in {"completed", "no-findings"}
+            {"node_id": node_id, "source": source, "evidence_id": record["evidence_id"]}
+            for node_id, (source, record) in sources.items()
+            if record["evidence_id"] in reused_ids
         ],
         "preservation_policy": "verified-unchanged-audit-inputs",
         "reused_evidence_ids": sorted(reused_ids),
+        "reuse_decisions": sorted(reuse_decisions, key=lambda item: item["node_id"]),
         "unaffected_node_ids": [node.node_id for node in unaffected],
         "repair_epoch": {
             "changed_paths": list(changed_paths),
@@ -3492,7 +3540,7 @@ def _validated_journal_record(
     if _required_int(event, "schema_version") != 1 or _required_int(event, "sequence") != expected_sequence:
         msg = f"journal event sequence is invalid at record {expected_sequence}"
         raise ValueError(msg)
-    if _required_text(event, "plan_digest") != _plan_digest(plan) or _state(event, "source_state") != source_state:
+    if not graph_plan_digest_matches(plan, _required_text(event, "plan_digest")) or _state(event, "source_state") != source_state:
         msg = f"journal event {expected_sequence} belongs to a different plan or source state"
         raise ValueError(msg)
     if event.get("previous_event_digest") != previous_digest:
@@ -3649,7 +3697,7 @@ def append_journal_event(path: Path, document: dict[str, Any], request: JournalE
                 "affected_node_ids": list(affected),
                 "evidence": evidence,
                 "node_id": request.node_id,
-                "plan_digest": _plan_digest(plan),
+                "plan_digest": events[0]["plan_digest"] if events else _plan_digest(plan),
                 "previous_event_digest": head_digest,
                 "reason": _new_journal_reason(request, limitations),
                 "schema_version": 1,
@@ -3669,7 +3717,7 @@ def _dispatches_by_node(dispatch_set: dict[str, Any], *, plan: GraphPlan, source
     if _required_int(dispatch_set, "schema_version") != 1:
         msg = "dispatch set has an unsupported schema version"
         raise ValueError(msg)
-    if _required_text(dispatch_set, "plan_digest") != _plan_digest(plan) or _state(dispatch_set, "source_state") != source_state:
+    if not graph_plan_digest_matches(plan, _required_text(dispatch_set, "plan_digest")) or _state(dispatch_set, "source_state") != source_state:
         msg = "dispatch set belongs to a different plan or source state"
         raise ValueError(msg)
     expected_digest = _required_text(dispatch_set, "dispatch_set_digest")
@@ -3700,20 +3748,26 @@ def _dispatches_by_node(dispatch_set: dict[str, Any], *, plan: GraphPlan, source
 
 
 def _accepted_journal_sources(
-    plan: GraphPlan, source_state: tuple[str, str, str], events: tuple[dict[str, Any], ...], entries: dict[str, dict[str, Any]]
+    plan: GraphPlan,
+    source_state: tuple[str, str, str],
+    events: tuple[dict[str, Any], ...],
+    entries: dict[str, dict[str, Any]],
+    *,
+    include_blocked: bool = False,
 ) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]]]:
     state, _head = _fold_execution_journal(plan, source_state, events)
     latest = {str(event["node_id"]): event for event in events}
     sources: dict[str, dict[str, Any]] = {}
     records: list[dict[str, Any]] = []
     for node in plan.actual_worker_nodes:
-        if state.get(node.node_id) != "accepted":
+        status = state.get(node.node_id)
+        if status != "accepted" and not (include_blocked and status == "blocked" and latest[node.node_id]["evidence"] is not None):
             continue
         entry = entries[node.node_id]
         source = {"artifact_path": entry["artifact_path"], "metadata_path": entry["metadata_path"]}
         verified, _limitations = _verified_journal_evidence(source, plan=plan, node=node, source_state=source_state)
         if verified != latest[node.node_id]["evidence"]:
-            msg = f"accepted artifact differs from journal: {node.node_id}"
+            msg = f"{status} artifact differs from journal: {node.node_id}"
             raise ValueError(msg)
         _kind, _expectation, _evidence, _content, record = _load_evidence_source(source, require_normalized=True)
         if record is not None:
@@ -3788,6 +3842,77 @@ def next_ready_nodes(document: dict[str, Any], *, journal_events: tuple[dict[str
         "schema_version": 1,
         "validation_reconciliation": validation_reconciliation,
         "waiting": waiting,
+    }
+
+
+def fallback_to_coordinator(document: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    """Publish one unstarted adaptive fallback while preserving the current journal."""
+    lock_path = args.journal.with_name(args.journal.name + ".lock")
+    with lock_path.open("a+b") as lock_stream:
+        fcntl.flock(lock_stream.fileno(), fcntl.LOCK_EX)
+        try:
+            return _fallback_to_coordinator_locked(document, args)
+        finally:
+            fcntl.flock(lock_stream.fileno(), fcntl.LOCK_UN)
+
+
+def _fallback_to_coordinator_locked(document: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    plan = _graph_plan(document["plan"])
+    source_state = _state(document, "source_state")
+    if _capture_source_state(args.current_capture) != source_state:
+        msg = "fallback current capture differs from plan-bound source state"
+        raise ValueError(msg)
+    if plan.execution_profile not in {"grouped", "mixed"} or document.get("worker_created") is not False:
+        msg = "coordinator fallback requires an adaptive profile and worker_created=false"
+        raise ValueError(msg)
+    reason = _required_text(document, "reason")
+    node_id = _required_text(document, "node_id")
+    events, state, head = read_execution_journal(args.journal, plan=plan, source_state=source_state)
+    dispatch_set = _read_json_object(args.dispatches)
+    entries = _dispatches_by_node(dispatch_set, plan=plan, source_state=source_state)
+    if node_id not in entries or node_id in state:
+        msg = "fallback requires a planned node with no prior execution or lifecycle event"
+        raise ValueError(msg)
+    ready = next_ready_nodes({**document, "current_source_state": list(source_state)}, journal_events=events, dispatch_set=dispatch_set)
+    if node_id not in ready["ready_node_ids"]:
+        msg = f"fallback node is not dependency-ready: {node_id}"
+        raise ValueError(msg)
+    original = entries[node_id]
+    if original["dispatch"]["execution_location"] != "worker":
+        msg = f"fallback node is not assigned to a worker: {node_id}"
+        raise ValueError(msg)
+    if any(Path(original[field]).exists() for field in ("artifact_path", "metadata_path", "worker_payload_path", "worker_payload_candidate_path")):
+        msg = f"fallback node already has execution output: {node_id}"
+        raise ValueError(msg)
+    identity = _sha256_bytes(_canonical_json({"dispatch_set_digest": dispatch_set["dispatch_set_digest"], "node_id": node_id, "journal_head": head}).encode())
+    store = Path(_required_text(document, "artifact_store")).resolve() / f"fallback-{identity[7:23]}"
+    entry = json.loads(_canonical_json(original))
+    entry["dispatch"].update({"execution_location": "coordinator", "worker_created": False, "fresh_context": False})
+    entry["worker_prompt"] = _worker_prompt(entry["result_contract"], entry["dispatch"])
+    entry["worker_input_path"] = str(store / f"{node_id}.worker-input.json")
+    updated = {**dispatch_set, "dispatches": [entry if item["node_id"] == node_id else item for item in dispatch_set["dispatches"]]}
+    updated.pop("dispatch_set_digest")
+    updated["dispatch_set_digest"] = _sha256_bytes(_canonical_json(updated).encode())
+    lifecycle = {"plan": document["plan"], "source_state": list(source_state)}
+    store.mkdir(parents=True, exist_ok=True)
+    _write_bytes_atomically_once(Path(entry["worker_input_path"]), (json.dumps(entry, indent=2, sort_keys=True) + "\n").encode(), mode=0o444)
+    dispatches_path = store / "dispatches.json"
+    lifecycle_path = store / "lifecycle.json"
+    _write_text_once(dispatches_path, json.dumps(updated, indent=2, sort_keys=True) + "\n")
+    _write_text_once(lifecycle_path, json.dumps(lifecycle, indent=2, sort_keys=True) + "\n")
+    return {
+        "schema_version": 1,
+        "status": "transitioned",
+        "node_id": node_id,
+        "execution_location": "coordinator",
+        "worker_created": False,
+        "reason": reason,
+        "source_state": list(source_state),
+        "dispatches_path": str(dispatches_path),
+        "lifecycle_input_path": str(lifecycle_path),
+        "journal_path": str(args.journal.resolve()),
+        "worker_input_path": entry["worker_input_path"],
+        "lineage": {"previous_dispatch_set_digest": dispatch_set["dispatch_set_digest"], "journal_head": head},
     }
 
 
@@ -4023,9 +4148,6 @@ def finalize_proof(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, P
     expectation = repository_review_proof_expectation(plan, source_state=source_state)
     stale_ids = set(_text_list(document, "stale_evidence_ids"))
     sources = _evidence_sources(document, plan)
-    if not sources:
-        msg = "finalize-proof requires persisted evidence sources"
-        raise ValueError(msg)
 
     loaded: dict[
         str, tuple[str, ReviewEvidenceExpectation | ValidationEvidenceExpectation, ReviewEvidence | ValidationEvidence, bytes, dict[str, Any] | None]
@@ -4036,7 +4158,7 @@ def finalize_proof(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, P
         if evidence.evidence_id in loaded:
             duplicate_evidence.add(evidence.evidence_id)
         loaded[evidence.evidence_id] = (kind, record_expectation, evidence, content, normalized)
-    preblockers: list[str] = []
+    preblockers = list(_text_list(document, "lifecycle_blockers"))
     if duplicate_evidence:
         preblockers.append("duplicate evidence sources: " + ", ".join(sorted(duplicate_evidence)))
 
@@ -4308,6 +4430,12 @@ def _argument_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     validation_parser.add_argument("--dispatches", type=Path, required=True)
     validation_parser.add_argument("--current-capture", type=Path, required=True)
     validation_parser.add_argument("--output", type=Path, required=True)
+    fallback_parser = _runtime_subparser(subparsers, "fallback-to-coordinator", "transition one unstarted adaptive node without rebinding accepted evidence")
+    fallback_parser.add_argument("--input", type=Path, required=True)
+    fallback_parser.add_argument("--journal", type=Path, required=True)
+    fallback_parser.add_argument("--dispatches", type=Path, required=True)
+    fallback_parser.add_argument("--current-capture", type=Path, required=True)
+    fallback_parser.add_argument("--output", type=Path, required=True)
     journal_parser = _runtime_subparser(
         subparsers,
         "journal-append",
@@ -4418,12 +4546,15 @@ def _finalize_document_from_files(document: dict[str, Any], args: argparse.Names
         raise TypeError(msg)
     plan = _graph_plan(raw_plan)
     source_state = _state(output, "source_state")
-    _events, lifecycle, _head = read_execution_journal(args.journal, plan=plan, source_state=source_state)
+    events, lifecycle, _head = read_execution_journal(args.journal, plan=plan, source_state=source_state)
     entries = _dispatches_by_node(_read_json_object(args.dispatches), plan=plan, source_state=source_state)
-    output["sources"] = [
-        {"artifact_path": _required_text(entries[node.node_id], "artifact_path"), "metadata_path": _required_text(entries[node.node_id], "metadata_path")}
-        for node in plan.actual_worker_nodes
-        if lifecycle.get(node.node_id) in {"accepted", "blocked"}
+    sources, _records = _accepted_journal_sources(plan, source_state, events, entries, include_blocked=True)
+    output["sources"] = list(sources.values())
+    latest = {str(event["node_id"]): event for event in events}
+    output["lifecycle_blockers"] = [
+        f"{status} node {node_id}: {latest[node_id].get('reason') or 'execution has not completed'}"
+        for node_id, status in lifecycle.items()
+        if status in {"blocked", "in-flight", "awaiting-replan", "invalidated"}
     ]
     return output
 
@@ -4582,8 +4713,9 @@ def _json_operation_output(document: dict[str, Any], args: argparse.Namespace) -
         return advance_after_mutation(document)
     if args.operation == "reconcile-handoffs":
         return reconcile_handoffs(document)
-    if args.operation == "reconcile-validation-requirements":
-        return reconcile_validation_requirements(document, args)
+    if args.operation in {"reconcile-validation-requirements", "fallback-to-coordinator"}:
+        operation = {"reconcile-validation-requirements": reconcile_validation_requirements, "fallback-to-coordinator": fallback_to_coordinator}[args.operation]
+        return operation(document, args)
     if args.operation == "next-ready":
         return _next_ready_from_files(document, args)
     return finalize_proof(_finalize_document_from_files(document, args))

--- a/agents/.agents/skills/review-graph/scripts/test_capture_scope.py
+++ b/agents/.agents/skills/review-graph/scripts/test_capture_scope.py
@@ -10,6 +10,7 @@ from typing import cast
 
 import pytest
 from capture_scope import _scope_data
+from review_graph_reuse import source_snapshot
 
 _TIMEOUT_SECONDS = 30
 
@@ -153,6 +154,63 @@ def test_baseline_includes_untracked_files(tmp_path: Path) -> None:
     assert manifest["untracked_paths"] == ["new.txt"]
 
 
+def test_baseline_path_identities_detect_repeated_dirty_edits_without_inventing_untouched_paths(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "edited.txt").write_text("initial\n", encoding="utf-8")
+    (repo / "LICENSE").write_text("unchanged\n", encoding="utf-8")
+    _commit_all(repo)
+    (repo / "edited.txt").write_text("first\n", encoding="utf-8")
+    first = _capture(repo, "baseline")
+    (repo / "edited.txt").write_text("later\n", encoding="utf-8")
+
+    second = _capture(repo, "baseline")
+
+    assert first["status"] == second["status"]
+    before = cast("dict[str, str]", first["repository_path_fingerprints"])
+    after = cast("dict[str, str]", second["repository_path_fingerprints"])
+    assert {path for path in before if before[path] != after[path]} == {"edited.txt"}
+    assert first["index_fingerprint"] == second["index_fingerprint"]
+
+
+@pytest.mark.parametrize("field", ["repository_path_fingerprints", "captured_scope_paths", "requested_paths", "index_fingerprint"])
+def test_capture_fingerprint_binds_path_identity_and_context(tmp_path: Path, field: str) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "source.txt").write_text("original\n", encoding="utf-8")
+    _commit_all(repo)
+    capture = _capture(repo, "baseline")
+    source_snapshot(capture).verify()
+    if field == "repository_path_fingerprints":
+        capture[field] = {"source.txt": "f" * 64}
+    elif field == "index_fingerprint":
+        capture[field] = "f" * 64
+    else:
+        capture[field] = ["substituted.txt"]
+
+    with pytest.raises(ValueError, match="do not match its repository fingerprint"):
+        source_snapshot(capture).verify()
+
+
+def test_baseline_path_identities_cover_rename_deletion_and_executable_mode(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    for name in ("old.txt", "deleted.txt", "script.sh"):
+        (repo / name).write_text("content\n", encoding="utf-8")
+    _commit_all(repo)
+    first = _capture(repo, "baseline")
+    (repo / "old.txt").rename(repo / "new.txt")
+    (repo / "deleted.txt").unlink()
+    (repo / "script.sh").chmod(0o755)
+
+    second = _capture(repo, "baseline")
+
+    before = cast("dict[str, str]", first["repository_path_fingerprints"])
+    after = cast("dict[str, str]", second["repository_path_fingerprints"])
+    assert {path for path in before.keys() | after.keys() if before.get(path) != after.get(path)} == {"old.txt", "new.txt", "deleted.txt", "script.sh"}
+    assert first["index_fingerprint"] == second["index_fingerprint"]
+
+
 def test_untracked_executable_mode_changes_fingerprint(tmp_path: Path) -> None:
     repo = tmp_path / "repo"
     _init_repo(repo)
@@ -244,6 +302,9 @@ def test_staged_line_bounds_use_head_and_index_not_unstaged_worktree(tmp_path: P
     manifest = _capture(repo, "staged")
 
     assert manifest["captured_path_line_bounds"] == {"added.txt": 2, "deleted.txt": 3, "linked.txt": 0, "tracked.txt": 4}
+    identities = manifest["repository_path_fingerprints"]
+    assert isinstance(identities, dict)
+    assert {"added.txt", "deleted.txt", "linked.txt", "tracked.txt"} <= identities.keys()
 
 
 def test_branch_line_bounds_use_numeric_maximum_of_base_and_head(tmp_path: Path) -> None:

--- a/agents/.agents/skills/review-graph/scripts/test_review_graph_plan.py
+++ b/agents/.agents/skills/review-graph/scripts/test_review_graph_plan.py
@@ -3438,7 +3438,7 @@ def _verified_binding(
             selection_reason=f"exact routed reuse for {reuse.requirement_id}",
             authorization="review-only",
             change_target=reuse.change_target,
-            planned_paths=reuse.planned_paths,
+            planned_paths=reuse.planned_paths if reuse.mode == "independent-review" else (),
             planned_path_line_bounds=reuse.planned_path_line_bounds,
         )
         review_records.append(
@@ -3675,6 +3675,7 @@ def test_exact_routed_reuse_satisfies_only_its_requirement_without_execution(cat
 
     assert result.feasible
     assert not ({item.requirement_id for item in expectation.reused_review_identities} & set(expectation.plan.selected_review_requirements))
+    assert all(item.planned_paths == (RUST_FIXTURE_PATH,) for item in expectation.reused_review_identities)
     if catalog_id == "repo.independent":
         (reuse,) = tuple(item for item in expectation.reused_review_identities if item.mode == "independent-review")
         assert reuse.change_target == f"git diff origin/main...HEAD -- {RUST_FIXTURE_PATH}"

--- a/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
@@ -24,6 +24,7 @@ from review_graph_plan import (
     ValidationUnit,
     expand_compact_routing,
     graph_plan_digest,
+    graph_plan_digest_matches,
     load_routing_catalog,
     main as plan_main,
     plan_from_document,
@@ -35,6 +36,7 @@ from review_graph_runtime import (
     _argument_parser,
     _git_path_status,
     _graph_plan,
+    _reconciled_handoffs,
     _schema_reference,
     _validation_workspace_audit,
     _workspace_content_digest,
@@ -772,7 +774,9 @@ def test_mutation_delta_uses_immediately_prior_capture_for_already_dirty_files(t
         advance_after_mutation({**next_request, "previous_capture": request["previous_capture"]})
 
 
-def _mutation_with_audit_source(tmp_path: Path, *, nearby_contract_owners: tuple[str, ...] = ()) -> tuple[dict[str, Any], dict[str, Any], dict[str, str]]:
+def _mutation_with_audit_source(
+    tmp_path: Path, *, nearby_contract_owners: tuple[str, ...] = (), limitations: tuple[str, ...] = ()
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, str]]:
     request = _mutation_request(tmp_path)
     materialized = materialize_dispatches(
         {
@@ -793,7 +797,7 @@ def _mutation_with_audit_source(tmp_path: Path, *, nearby_contract_owners: tuple
         "files_inspected": ["tool.py"],
         "findings": [],
         "handoffs": [],
-        "limitations": [],
+        "limitations": list(limitations),
         "scope_limitations": [],
         "nearby_contract_owners": list(nearby_contract_owners),
         "status": "no-findings",
@@ -902,6 +906,20 @@ def test_mutation_reuse_rejects_tampered_provenance_before_synthesis(tmp_path: P
 
     with pytest.raises(ValueError, match=r"digest|fingerprint|identity|identities|source state|scope|instructions"):
         build_synthesis_bundle(document)
+
+
+def test_synthesis_reports_missing_current_reuse_snapshot_without_key_error(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    request, _entry, source = _mutation_with_audit_source(tmp_path)
+    result = advance_after_mutation(request)
+    document: dict[str, Any] = {**result["lifecycle_input"], "source_state": request["source_state"], "sources": [source]}
+    document["plan"]["reuse_source_snapshots"] = []
+    input_path = tmp_path / "synthesis.json"
+    output_path = tmp_path / "bundle.json"
+    input_path.write_text(json.dumps(document), encoding="utf-8")
+
+    assert main(["synthesis-bundle", "--input", str(input_path), "--output", str(output_path)]) == 2
+    assert "review_graph_runtime: audit reuse lacks a source snapshot for current source_state" in capsys.readouterr().err
+    assert not output_path.exists()
 
 
 def test_legacy_unbound_capture_falls_back_to_executable_audit(tmp_path: Path) -> None:
@@ -2591,7 +2609,17 @@ def test_create_once_writers_reject_nonregular_targets(tmp_path: Path, writer: s
     assert not tuple(tmp_path.glob(f".{destination.name}.*.tmp"))
 
 
-def test_compile_node_survives_context_compaction_by_reading_bound_worker_payload(tmp_path: Path) -> None:
+def _legacy_plan_digest(plan: GraphPlan) -> str:
+    document = asdict(plan)
+    if not plan.validation_exclusions:
+        document.pop("validation_exclusions")
+    return "sha256:" + hashlib.sha256(json.dumps(document, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+@pytest.mark.parametrize("legacy_digest", [False, True])
+def test_compile_node_survives_context_compaction_by_reading_bound_worker_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, legacy_digest: bool) -> None:  # noqa: PLR0915
+    if legacy_digest:
+        monkeypatch.setattr("review_graph_runtime.graph_plan_digest", _legacy_plan_digest)
     plan = _sparse_plan()
     source_state = ["scope", "worktree", "repository"]
     artifact_store = tmp_path / "nested" / "artifacts"
@@ -2638,6 +2666,10 @@ def test_compile_node_survives_context_compaction_by_reading_bound_worker_payloa
     capture_path.write_text(json.dumps(capture), encoding="utf-8")
     payload_candidate_path.write_bytes(payload_bytes)
     assert main(["persist-worker-payload", "--input", entry["worker_payload_contract_path"], "--payload", str(payload_candidate_path)]) == 0
+    journal_path.parent.mkdir()
+    append_journal_event(journal_path, lifecycle, JournalEventRequest(entry["node_id"], "in-flight"))
+    original_journal = journal_path.read_bytes()
+    monkeypatch.undo()
 
     result = main(
         [
@@ -2670,8 +2702,12 @@ def test_compile_node_survives_context_compaction_by_reading_bound_worker_payloa
     assert metadata["worker_payload_path"] == str(sealed_payload_path)
     assert metadata["worker_payload_staging_path"] == str(payload_path)
     events, lifecycle_state, _head = read_execution_journal(journal_path, plan=plan, source_state=cast("tuple[str, str, str]", tuple(source_state)))
-    assert len(events) == 1
+    assert len(events) == 2
+    assert journal_path.read_bytes().startswith(original_journal)
+    assert all(event["plan_digest"] == dispatch_set["plan_digest"] for event in events)
     assert lifecycle_state[entry["node_id"]] == "accepted"
+    ready = next_ready_nodes({**lifecycle, "current_source_state": source_state}, journal_events=events, dispatch_set=dispatch_set)
+    assert entry["node_id"] in ready["lifecycle"]["accepted_node_ids"]
     source = {"artifact_path": output["artifact_path"], "metadata_path": output["metadata_path"]}
     build_synthesis_bundle({"source_state": source_state, "sources": [source]})
 
@@ -3373,9 +3409,20 @@ def test_bundle_only_synthesis_persists_and_compiles_without_reading_source(tmp_
     assert b"bundle-only synthesis" in content
 
 
-def test_synthesis_bundle_binds_compact_routing_and_validation_closure(tmp_path: Path) -> None:
+def test_synthesis_bundle_binds_compact_routing_and_validation_closure(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     plan, sources = _compile_materialized_evidence(tmp_path)
+    reconciled_review_ids: list[str] = []
+
+    def reconcile_reviews(
+        plan: GraphPlan, records: dict[str, dict[str, Any]], review_ids: tuple[str, ...]
+    ) -> tuple[list[dict[str, Any]], tuple[str, ...], tuple[str, ...]]:
+        reconciled_review_ids.extend(review_ids)
+        return _reconciled_handoffs(plan, records, review_ids)
+
+    monkeypatch.setattr("review_graph_runtime._reconciled_handoffs", reconcile_reviews)
     bundle = build_synthesis_bundle({"plan": _json_plan(plan), "source_state": ["scope", "worktree", "repository"], "sources": sources})
+    assert {record["record_type"] for record in bundle["records"]} == {"review", "validation"}
+    assert reconciled_review_ids == [record["evidence_id"] for record in bundle["records"] if record["record_type"] == "review"]
     context = bundle["plan_context"]
     assert context["consulted_routers"] == list(plan.consulted_routers)
     assert context["routing_catalog_closed"]
@@ -3390,13 +3437,269 @@ def test_synthesis_bundle_binds_compact_routing_and_validation_closure(tmp_path:
     assert changed_bundle["bundle_digest"] != bundle["bundle_digest"]
 
 
-def test_plan_digest_keeps_existing_journals_compatible_without_validation_exclusions() -> None:
+def test_plan_digest_keeps_existing_journals_compatible_without_optional_reuse_fields() -> None:
     plan = _sparse_plan()
     legacy = _json_plan(plan)
     legacy.pop("validation_exclusions")
+    legacy.pop("audit_reuse_transitions")
+    legacy.pop("reuse_source_snapshots")
     expected = "sha256:" + hashlib.sha256(json.dumps(legacy, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
     assert graph_plan_digest(plan) == expected
     assert graph_plan_digest(_graph_plan(legacy)) == expected
+
+
+def test_plan_digest_retains_nonempty_reuse_fields(tmp_path: Path) -> None:
+    request, _entry, _source = _mutation_with_audit_source(tmp_path)
+    result = advance_after_mutation(request)
+    plan = _graph_plan(json.loads(json.dumps(result["new_plan"])))
+    document = _json_plan(plan)
+    document.pop("validation_exclusions")
+    expected = "sha256:" + hashlib.sha256(json.dumps(document, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+    assert plan.audit_reuse_transitions
+    assert plan.reuse_source_snapshots
+    assert graph_plan_digest(plan) == expected
+    assert graph_plan_digest(replace(plan, audit_reuse_transitions=())) != expected
+    assert graph_plan_digest(replace(plan, reuse_source_snapshots=())) != expected
+
+
+def test_repair_explains_conservative_nonreuse_and_emits_continuation_files(tmp_path: Path) -> None:
+    request, entry, source = _mutation_with_audit_source(tmp_path, limitations=("Validation was limited to the current platform.",))
+    original = {Path(path): Path(path).read_bytes() for path in source.values()}
+    result = advance_after_mutation(request)
+    decision = next(item for item in result["reuse_decisions"] if item["node_id"] == entry["node_id"])
+    assert decision["disposition"] == "not-reused"
+    assert decision["reason_code"] == "unclassified-limitations"
+    assert result["preserved_evidence"] == []
+    assert result["reused_evidence_ids"] == []
+    assert entry["dispatch"]["evidence_id"] in result["stale_evidence_ids"]
+    assert all(path.read_bytes() == content for path, content in original.items())
+    assert json.loads(Path(result["lifecycle_input_path"]).read_text())["source_state"] == result["new_source_state"]
+    ready_path = tmp_path / "ready-after-repair.json"
+    assert (
+        main(
+            [
+                "next-ready",
+                "--input",
+                result["lifecycle_input_path"],
+                "--dispatches",
+                result["dispatches_path"],
+                "--journal",
+                result["journal_path"],
+                "--current-capture",
+                result["capture_path"],
+                "--output",
+                str(ready_path),
+            ]
+        )
+        == 0
+    )
+    assert json.loads(ready_path.read_text())["ready_node_ids"]
+
+
+def test_legacy_digest_compatibility_does_not_accept_a_different_plan(tmp_path: Path) -> None:
+    plan = _sparse_plan()
+    legacy = _legacy_plan_digest(plan)
+    assert legacy != graph_plan_digest(plan)
+    assert graph_plan_digest_matches(plan, legacy)
+    assert not graph_plan_digest_matches(replace(plan, routing_completion_blockers=("new blocker",)), legacy)
+    request, _entry, _source = _mutation_with_audit_source(tmp_path)
+    reused = _graph_plan(json.loads(json.dumps(advance_after_mutation(request)["new_plan"])))
+    assert not graph_plan_digest_matches(reused, legacy)
+    assert not graph_plan_digest_matches(replace(reused, audit_reuse_transitions=()), graph_plan_digest(reused))
+
+
+def _continuation_fixture(tmp_path: Path) -> tuple[dict[str, Any], dict[str, Any], dict[str, Path]]:
+    document, dispatches = _worker_input_fixture(tmp_path)
+    lifecycle = {"plan": document["plan"], "source_state": document["source_state"]}
+    paths = {key: tmp_path / f"{key}.json" for key in ("input", "dispatches", "current-capture", "journal")}
+    paths["input"].write_text(json.dumps(lifecycle), encoding="utf-8")
+    paths["dispatches"].write_text(json.dumps(dispatches), encoding="utf-8")
+    paths["current-capture"].write_text(
+        json.dumps({"scope_fingerprint": "scope", "captured_worktree_fingerprint": "worktree", "repository_state_fingerprint": "repository"}), encoding="utf-8"
+    )
+    return lifecycle, dispatches, paths
+
+
+@pytest.mark.parametrize("accepted_ci", [False, True])
+def test_finalization_reports_blocked_without_evidence_instead_of_loading_missing_files(tmp_path: Path, accepted_ci: bool) -> None:
+    lifecycle, dispatches, paths = _continuation_fixture(tmp_path)
+    audit = next(entry for entry in dispatches["dispatches"] if entry["dispatch"].get("mode") == "audit")
+    if accepted_ci:
+        validation = next(entry for entry in dispatches["dispatches"] if entry["result_contract"] == "compact-validation")
+        _compile_repair_fixture_entry(validation, lifecycle, paths["journal"])
+    append_journal_event(paths["journal"], lifecycle, JournalEventRequest(audit["node_id"], "blocked", reason="worker creation failed"))
+    original = paths["journal"].read_bytes()
+    output = tmp_path / "final.json"
+    assert main(["finalize-proof", *(arg for key, path in paths.items() for arg in (f"--{key}", str(path))), "--output", str(output)]) == 2
+    result = json.loads(output.read_text())
+    assert result["status"] == "incomplete"
+    assert result["repository_validation_status"] == ("passed" if accepted_ci else "incomplete")
+    assert any("worker creation failed" in blocker for blocker in result["blockers"])
+    assert not Path(audit["metadata_path"]).exists()
+    assert paths["journal"].read_bytes() == original
+
+
+def test_fallback_preserves_accepted_bindings_and_finishes_without_replaying_ci(tmp_path: Path) -> None:
+    lifecycle, dispatches, paths = _continuation_fixture(tmp_path)
+    audit = next(entry for entry in dispatches["dispatches"] if entry["dispatch"].get("mode") == "audit")
+    validation = next(entry for entry in dispatches["dispatches"] if entry["result_contract"] == "compact-validation")
+    source = _compile_repair_fixture_entry(validation, lifecycle, paths["journal"])
+    original_files = {path: path.read_bytes() for path in (*paths.values(), *(Path(path) for path in source.values()))}
+    request = {
+        **lifecycle,
+        "node_id": audit["node_id"],
+        "worker_created": False,
+        "reason": "capacity retry exhausted",
+        "artifact_store": str(tmp_path / "fallback"),
+    }
+    request_path = tmp_path / "fallback-request.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+    output = tmp_path / "fallback.json"
+    assert (
+        main(
+            [
+                "fallback-to-coordinator",
+                "--input",
+                str(request_path),
+                "--dispatches",
+                str(paths["dispatches"]),
+                "--journal",
+                str(paths["journal"]),
+                "--current-capture",
+                str(paths["current-capture"]),
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+    result = json.loads(output.read_text())
+    updated = json.loads(Path(result["dispatches_path"]).read_text())
+    assert all(path.read_bytes() == content for path, content in original_files.items())
+    for old, new in zip(dispatches["dispatches"], updated["dispatches"], strict=True):
+        if old["node_id"] != audit["node_id"]:
+            assert new == old
+        else:
+            assert new["dispatch"]["execution_location"] == "coordinator"
+            assert new["dispatch"]["worker_created"] is False
+            assert new["dispatch"]["fresh_context"] is False
+    plan = _graph_plan(lifecycle["plan"])
+    events, _state, _head = read_execution_journal(paths["journal"], plan=plan, source_state=("scope", "worktree", "repository"))
+    ready = next_ready_nodes({**lifecycle, "current_source_state": lifecycle["source_state"]}, journal_events=events, dispatch_set=updated)
+    assert audit["node_id"] in ready["ready_node_ids"]
+    assert validation["node_id"] not in ready["ready_node_ids"]
+    for entry in updated["dispatches"]:
+        if entry["node_id"] != validation["node_id"]:
+            _compile_repair_fixture_entry(entry, lifecycle, paths["journal"])
+    final_path = tmp_path / "final-fallback.json"
+    assert (
+        main(
+            [
+                "finalize-proof",
+                "--input",
+                result["lifecycle_input_path"],
+                "--dispatches",
+                result["dispatches_path"],
+                "--journal",
+                result["journal_path"],
+                "--current-capture",
+                str(paths["current-capture"]),
+                "--output",
+                str(final_path),
+            ]
+        )
+        == 0
+    )
+    assert json.loads(final_path.read_text())["status"] == "complete"
+    assert all(Path(path).read_bytes() == original_files[Path(path)] for path in source.values())
+
+
+@pytest.mark.parametrize("case", ["started", "isolated", "worker-created", "output-present", "stale-capture"])
+def test_fallback_rejects_unsafe_transitions_without_publishing(tmp_path: Path, capsys: pytest.CaptureFixture[str], case: str) -> None:
+    lifecycle, dispatches, paths = _continuation_fixture(tmp_path)
+    audit = next(entry for entry in dispatches["dispatches"] if entry["dispatch"].get("mode") == "audit")
+    request = {
+        **lifecycle,
+        "node_id": audit["node_id"],
+        "worker_created": False,
+        "reason": "capacity retry exhausted",
+        "artifact_store": str(tmp_path / "fallback"),
+    }
+    if case == "started":
+        append_journal_event(paths["journal"], lifecycle, JournalEventRequest(audit["node_id"], "in-flight"))
+    elif case == "isolated":
+        request["plan"] = {**lifecycle["plan"], "execution_profile": "isolated-only"}
+    elif case == "worker-created":
+        request["worker_created"] = True
+    elif case == "output-present":
+        Path(audit["worker_payload_path"]).write_text("pending worker result", encoding="utf-8")
+    else:
+        paths["current-capture"].write_text(
+            json.dumps({"scope_fingerprint": "other", "captured_worktree_fingerprint": "other", "repository_state_fingerprint": "other"}), encoding="utf-8"
+        )
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+    output = tmp_path / "fallback.json"
+    assert (
+        main(
+            [
+                "fallback-to-coordinator",
+                "--input",
+                str(request_path),
+                "--dispatches",
+                str(paths["dispatches"]),
+                "--journal",
+                str(paths["journal"]),
+                "--current-capture",
+                str(paths["current-capture"]),
+                "--output",
+                str(output),
+            ]
+        )
+        == 2
+    )
+    assert capsys.readouterr().err
+    assert not output.exists()
+    assert not (tmp_path / "fallback").exists()
+
+
+@pytest.mark.parametrize("location", ["inside", "ancestor", "symlink", "external"])
+def test_isolation_boundary_is_checked_before_planning_materialization_and_snapshots(tmp_path: Path, location: str) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    inside = repository / "target" / "copied-tree"
+    root = inside if location == "inside" else tmp_path if location == "ancestor" else tmp_path / "external"
+    if location == "symlink":
+        inside.mkdir(parents=True)
+        root.symlink_to(inside, target_is_directory=True)
+    document = _sparse_plan_document()
+    requirement = document["validation_requirements"][0]
+    requirement.update({"requires_isolation": True, "isolation_root": str(root), "working_directories": [str(root / "work")]})
+    if location == "external":
+        plan = plan_from_document(document, repository_root=repository)
+        assert plan.coalesced_validation_units[0].isolation_root == str(root)
+        return
+    with pytest.raises(ValueError, match="validation root overlaps"):
+        plan_from_document(document, repository_root=repository)
+    plan = _sparse_plan()
+    unit = replace(plan.coalesced_validation_units[0], requires_isolation=True, isolation_root=str(root), working_directories=(str(root / "work"),))
+    old_plan = replace(plan, coalesced_validation_units=(unit,))
+    store = tmp_path / "unpublished"
+    with pytest.raises(ValueError, match=r"outside the captured repository|validation root overlaps"):
+        materialize_dispatches(
+            {
+                "plan": _json_plan(old_plan),
+                "source_state": ["scope", "worktree", "repository"],
+                "repository_root": str(repository),
+                "authorization": "review-only",
+                "artifact_store": str(store),
+                "state_verification_command": "capture",
+            }
+        )
+    assert not store.exists()
+    with pytest.raises(ValueError, match=r"outside the captured repository|validation root overlaps"):
+        capture_workspace_snapshot({"validation_unit": json.loads(json.dumps(asdict(unit))), "repository_root": str(repository)})
 
 
 def test_journal_append_cli_supports_each_status_field_contract(tmp_path: Path) -> None:

--- a/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
@@ -1,10 +1,12 @@
 """Tests for compact review-graph runtime compilation."""
 
+import hashlib
 import json
 import os
 import shlex
 import shutil
 import subprocess
+import sys
 from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from dataclasses import asdict, replace
@@ -21,6 +23,7 @@ from review_graph_plan import (
     ValidationArtifact,
     ValidationUnit,
     expand_compact_routing,
+    graph_plan_digest,
     load_routing_catalog,
     main as plan_main,
     plan_from_document,
@@ -49,6 +52,7 @@ from review_graph_runtime import (
     main,
     materialize_dispatches,
     next_ready_nodes,
+    persist_worker_payload,
     read_execution_journal,
     reconcile_handoffs,
 )
@@ -172,6 +176,25 @@ def _assert_compact_dispatches(entries: list[dict[str, Any]]) -> None:
         assert not present_references, f"dispatch {entry['node_id']} contains maintainer specifications: {present_references}"
 
 
+def _baseline_capture() -> dict[str, Any]:
+    return {
+        "base_ref": None,
+        "branch": "main",
+        "capture_mode": "baseline",
+        "captured_path_line_bounds": {STATE_FIXTURE: 3},
+        "captured_scope_paths": [STATE_FIXTURE],
+        "captured_worktree_fingerprint": "captured-worktree",
+        "head": "head",
+        "merge_base": None,
+        "repository_root": str(SKILL_ROOT.parents[2]),
+        "repository_state_fingerprint": "captured-repository",
+        "requested_paths": [],
+        "scope_fingerprint": "captured-scope",
+        "status": [],
+        "untracked_paths": [],
+    }
+
+
 def _sparse_plan_document() -> dict[str, Any]:
     return {
         "captured_paths": [STATE_FIXTURE],
@@ -288,6 +311,7 @@ def _dispatch(*, mode: str = "audit") -> dict[str, object]:
         "fresh_context": mode != "fix",
         "mode": mode,
         "node_id": "audit-errors" if mode != "fix" else "fix-errors",
+        "owned_paths": ["src/error.rs"],
         "predecessor_evidence_ids": [],
         "reference_paths": [],
         "requirement_ids": ["rust.errors"],
@@ -317,6 +341,7 @@ def test_compile_review_builds_verified_artifact_from_compact_payload() -> None:
                 ],
                 "handoffs": [],
                 "limitations": [],
+                "scope_limitations": [],
                 "nearby_contract_owners": ["src/lib.rs"],
                 "status": "completed",
                 "validation_requirements": [],
@@ -359,6 +384,7 @@ def test_compile_fix_binds_changed_paths_and_transition_state() -> None:
                 "findings": [],
                 "handoffs": [],
                 "limitations": [],
+                "scope_limitations": [],
                 "nearby_contract_owners": ["src/lib.rs"],
                 "status": "completed",
                 "validation_requirements": [],
@@ -385,6 +411,7 @@ def test_compile_review_rejects_inherited_worker_context() -> None:
                     "findings": [],
                     "handoffs": [],
                     "limitations": [],
+                    "scope_limitations": [],
                     "nearby_contract_owners": [],
                     "status": "no-findings",
                     "validation_requirements": [],
@@ -416,6 +443,27 @@ def test_planning_schema_aggregates_enum_and_required_field_diagnostics() -> Non
     assert strategy["accepted_values"] == ["sequential", "parallel-independent"]
 
 
+def test_bootstrap_reports_invalid_requested_scope_at_its_field_path(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    document = _sparse_plan_document()
+    validation = cast("list[dict[str, Any]]", document["validation_requirements"])[0]
+    validation["requested_scope"] = "baseline-current-host-ci"
+    capture_path = tmp_path / "capture.json"
+    template_path = tmp_path / "template.json"
+    output_path = tmp_path / "bootstrap.json"
+    capture_path.write_text(json.dumps(_baseline_capture()), encoding="utf-8")
+    template_path.write_text(json.dumps(document), encoding="utf-8")
+
+    result = bootstrap_main(["--capture", str(capture_path), "--input", str(template_path), "--output", str(output_path)])
+
+    error = json.loads(capsys.readouterr().err)
+    diagnostics = cast("list[dict[str, Any]]", error["diagnostics"])
+    diagnostic = next(item for item in diagnostics if item["path"] == "$.validation_requirements[0].requested_scope")
+    assert result == 2
+    assert not output_path.exists()
+    assert diagnostic["message"] == "unknown value 'baseline-current-host-ci'"
+    assert diagnostic["accepted_values"] == ["branch", "staged", "worktree", "baseline", "release"]
+
+
 def test_runtime_operations_publish_schema_valid_examples_and_help_links(capsys: pytest.CaptureFixture[str]) -> None:
     examples_path = SCHEMA_ROOT.parent / "runtime-operation-examples-v1.json"
     schema_path = SCHEMA_ROOT / "runtime-operation-inputs-v1.schema.json"
@@ -429,6 +477,9 @@ def test_runtime_operations_publish_schema_valid_examples_and_help_links(capsys:
         help_text = capsys.readouterr().out
         assert f"#/$defs/{operation}" in help_text
         assert f"runtime-operation-examples-v1.json#/{operation}" in help_text
+        if operation == "next-ready":
+            assert "missing or zero-byte file is" in help_text
+            assert "an empty journal" in help_text
 
 
 @pytest.mark.parametrize("value", [1, 1.0])
@@ -598,22 +649,7 @@ def test_compile_cli_allows_at_most_one_schema_retry(tmp_path: Path, capsys: pyt
 
 
 def test_bootstrap_binds_capture_and_validation_fingerprints_without_field_renaming(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    capture = {
-        "base_ref": None,
-        "branch": "main",
-        "capture_mode": "baseline",
-        "captured_path_line_bounds": {STATE_FIXTURE: 3},
-        "captured_scope_paths": [STATE_FIXTURE],
-        "captured_worktree_fingerprint": "captured-worktree",
-        "head": "head",
-        "merge_base": None,
-        "repository_root": str(SKILL_ROOT.parents[2]),
-        "repository_state_fingerprint": "captured-repository",
-        "requested_paths": [],
-        "scope_fingerprint": "captured-scope",
-        "status": [],
-        "untracked_paths": [],
-    }
+    capture = _baseline_capture()
 
     document = bootstrap_document(capture, _sparse_plan_document())
     require_schema(document, SCHEMA_ROOT / "planning-input-v1.schema.json")
@@ -641,7 +677,7 @@ def test_bootstrap_binds_capture_and_validation_fingerprints_without_field_renam
     assert json.loads(capsys.readouterr().out) == bundle["plan"]
 
 
-def test_advance_after_mutation_emits_one_recaptured_repair_epoch(tmp_path: Path) -> None:
+def _baseline_mutation_fixture(tmp_path: Path) -> tuple[str, Path, dict[str, Any], dict[str, Any], GraphPlan]:
     git = shutil.which("git")
     assert git is not None
     repository = tmp_path / "repository"
@@ -651,34 +687,55 @@ def test_advance_after_mutation_emits_one_recaptured_repair_epoch(tmp_path: Path
     _run_test_git(git, "-C", str(repository), "config", "user.name", "Review Test")
     state_path = repository / "state.rs"
     state_path.write_text("pub fn state() {}\n", encoding="utf-8")
-    _run_test_git(git, "-C", str(repository), "add", "state.rs")
+    (repository / "tool.py").write_text("value = 1\n", encoding="utf-8")
+    for name in ("LICENSE", "cliff.toml", ".codecov.yml"):
+        (repository / name).write_text("unchanged baseline fixture\n", encoding="utf-8")
+    _run_test_git(git, "-C", str(repository), "add", ".")
     _run_test_git(git, "-C", str(repository), "commit", "-m", "initial")
-    state_path.write_text("pub fn state() { assert!(true); }\n", encoding="utf-8")
-    new_capture = _scope_data(git, repository, "baseline", None, ())
     template = _sparse_plan_document()
-    template["captured_paths"] = ["state.rs"]
+    template["consulted_routers"] = ["review-graph", "rust-review-orchestrator", "python-review-orchestrator"]
     template["routing_overrides"][0]["review_surface"] = ["state.rs"]
+    template["validation_requirements"][0]["working_directories"] = [str(repository)]
+    capture = _scope_data(git, repository, "baseline", None, ())
+    plan = plan_from_document(bootstrap_document(capture, template), catalog_path=ROUTING_CATALOG, skill_roots=(SKILL_ROOT,), repository_root=repository)
+    return git, repository, template, capture, plan
 
-    result = advance_after_mutation(
-        {
-            "artifact_store": str(tmp_path / "proof-store"),
-            "authorization_after": "review-and-fix",
-            "authorization_before": "review-only",
-            "changed_paths": ["state.rs"],
-            "new_capture": new_capture,
-            "plan": _json_plan(_sparse_plan()),
-            "planning_template": template,
-            "repair_epoch": 1,
-            "source_state": ["old-scope", "old-worktree", "old-repository"],
-            "state_verification_command": "capture_scope.py --mode baseline",
-        }
-    )
+
+def _mutation_request(tmp_path: Path) -> dict[str, Any]:
+    git, repository, template, previous_capture, plan = _baseline_mutation_fixture(tmp_path)
+    (repository / "state.rs").write_text("pub fn state() { assert!(true); }\n", encoding="utf-8")
+    return {
+        "artifact_store": str(tmp_path / "proof-store"),
+        "authorization_after": "review-and-fix",
+        "authorization_before": "review-only",
+        "changed_paths": ["state.rs"],
+        "new_capture": _scope_data(git, repository, "baseline", None, ()),
+        "plan": _json_plan(plan),
+        "planning_template": template,
+        "previous_capture": previous_capture,
+        "repair_epoch": 1,
+        "source_state": [previous_capture[field] for field in ("scope_fingerprint", "captured_worktree_fingerprint", "repository_state_fingerprint")],
+        "state_verification_command": "capture_scope.py --mode baseline",
+    }
+
+
+def test_advance_after_mutation_invalidates_only_baseline_owners_and_dependents(tmp_path: Path) -> None:
+    request = _mutation_request(tmp_path)
+    old_plan = _graph_plan(request["plan"])
+
+    result = advance_after_mutation(request)
 
     assert result["status"] == "advanced"
     assert result["repair_epoch"]["recapture_count"] == 1
     assert result["repair_epoch"]["fix_nodes"] == [{"mode": "fix", "node_id": "fix-epoch-001", "serialized": True}]
     assert {item["state"] for item in result["invalidated_nodes"]} == {"awaiting-replan"}
-    assert result["newly_touched_paths"] == ["state.rs"]
+    assert result["newly_touched_paths"] == []
+    assert result["repair_epoch"]["changed_paths"] == ["state.rs"]
+    assert result["capture"] == request["new_capture"]
+    expected_affected = {node.node_id for node in old_plan.actual_worker_nodes if "state.rs" in node.coverage or node.mode in {"validation", "synthesis"}}
+    assert {record["node_id"] for record in result["invalidated_nodes"]} == expected_affected
+    assert set(result["unaffected_node_ids"]) == {node.node_id for node in old_plan.actual_worker_nodes} - expected_affected
+    assert result["unaffected_node_ids"]
     assert result["dispatch_set"]["source_state"] == result["new_source_state"]
     new_node_ids = {node["node_id"] for node in result["new_plan"]["actual_worker_nodes"]}
     new_evidence_ids = {entry["dispatch"]["evidence_id"] for entry in result["dispatch_set"]["dispatches"]}
@@ -686,6 +743,386 @@ def test_advance_after_mutation_emits_one_recaptured_repair_epoch(tmp_path: Path
     assert set(result["stale_evidence_ids"]).isdisjoint(new_evidence_ids)
     expectation = repository_review_proof_expectation(_graph_plan(json.loads(json.dumps(result["new_plan"]))), source_state=tuple(result["new_source_state"]))
     assert expectation.final_synthesis_identity == ("repair-epoch-001-repository-synthesis", "repository-production-review", "synthesis")
+
+
+def test_mutation_delta_uses_immediately_prior_capture_for_already_dirty_files(tmp_path: Path) -> None:
+    request = _mutation_request(tmp_path)
+    first = advance_after_mutation(request)
+    repository = Path(request["new_capture"]["repository_root"])
+    (repository / "state.rs").write_text("pub fn state() { assert!(false); }\n", encoding="utf-8")
+    git = shutil.which("git")
+    assert git is not None
+    next_capture = _scope_data(git, repository, "baseline", None, ())
+    assert next_capture["status"] == first["capture"]["status"]
+    next_request = {
+        **request,
+        "authorization_before": "review-and-fix",
+        "new_capture": next_capture,
+        "plan": json.loads(json.dumps(first["new_plan"])),
+        "previous_capture": first["capture"],
+        "repair_epoch": 2,
+        "source_state": first["new_source_state"],
+    }
+
+    result = advance_after_mutation(next_request)
+
+    assert result["repair_epoch"]["changed_paths"] == ["state.rs"]
+    assert result["newly_touched_paths"] == []
+    with pytest.raises(ValueError, match="immediately prior plan source_state"):
+        advance_after_mutation({**next_request, "previous_capture": request["previous_capture"]})
+
+
+def _mutation_with_audit_source(tmp_path: Path, *, nearby_contract_owners: tuple[str, ...] = ()) -> tuple[dict[str, Any], dict[str, Any], dict[str, str]]:
+    request = _mutation_request(tmp_path)
+    materialized = materialize_dispatches(
+        {
+            "artifact_store": str(tmp_path / "old-evidence"),
+            "authorization": "review-only",
+            "plan": request["plan"],
+            "repository_root": request["previous_capture"]["repository_root"],
+            "source_state": request["source_state"],
+            "state_verification_command": request["state_verification_command"],
+        }
+    )
+    entry = next(item for item in materialized["dispatches"] if item["dispatch"].get("mode") == "audit" and item["dispatch"]["owned_paths"] == ["tool.py"])
+    dispatch = {**entry["dispatch"], "before_state": request["source_state"], "after_state": request["source_state"]}
+    payload = {
+        "changes": [],
+        "command_policy_attested": True,
+        "commands_executed": [],
+        "files_inspected": ["tool.py"],
+        "findings": [],
+        "handoffs": [],
+        "limitations": [],
+        "scope_limitations": [],
+        "nearby_contract_owners": list(nearby_contract_owners),
+        "status": "no-findings",
+        "validation_requirements": [],
+    }
+    content, metadata = compile_review({"dispatch": dispatch, "payload": payload})
+    artifact_path = Path(entry["artifact_path"])
+    metadata_path = Path(entry["metadata_path"])
+    artifact_path.write_bytes(content)
+    metadata_bytes = json.dumps(metadata).encode()
+    metadata_path.write_bytes(metadata_bytes)
+    source = {"artifact_path": str(artifact_path), "metadata_path": str(metadata_path)}
+    request["sources"] = [source]
+    return request, entry, source
+
+
+@pytest.mark.parametrize("nearby_contract_owners", [(), ("state.rs",)], ids=["unaffected", "inspected-dependency-changed"])
+def test_mutation_reuses_only_unaffected_raw_evidence_without_relabeling_its_source_state(tmp_path: Path, nearby_contract_owners: tuple[str, ...]) -> None:
+    request, entry, source = _mutation_with_audit_source(tmp_path, nearby_contract_owners=nearby_contract_owners)
+    artifact_path, metadata_path = Path(source["artifact_path"]), Path(source["metadata_path"])
+    content, metadata_bytes = artifact_path.read_bytes(), metadata_path.read_bytes()
+    dispatch = entry["dispatch"]
+
+    result = advance_after_mutation(request)
+
+    expected_preserved = [] if nearby_contract_owners else [{"node_id": entry["node_id"], "source": source, "evidence_id": dispatch["evidence_id"]}]
+    assert result["preserved_evidence"] == expected_preserved
+    assert result["preservation_policy"] == "verified-unchanged-audit-inputs"
+    assert artifact_path.read_bytes() == content
+    assert metadata_path.read_bytes() == metadata_bytes
+    assert (entry["node_id"] in {record["node_id"] for record in result["invalidated_nodes"]}) == bool(nearby_contract_owners)
+    with pytest.raises(ValueError, match="different source state"):
+        build_synthesis_bundle({"source_state": result["new_source_state"], "sources": [source]})
+    if nearby_contract_owners:
+        assert result["reused_evidence_ids"] == []
+    else:
+        assert result["reused_evidence_ids"] == [dispatch["evidence_id"]]
+        assert dispatch["evidence_id"] not in result["stale_evidence_ids"]
+        plan = _graph_plan(json.loads(json.dumps(result["new_plan"])))
+        assert not any(node.skill_id == dispatch["skill_id"] and node.coverage == ("tool.py",) for node in plan.actual_worker_nodes)
+        bundle = build_synthesis_bundle({"plan": _json_plan(plan), "source_state": result["new_source_state"], "sources": []})
+        assert bundle["records"][0]["evidence_id"] == dispatch["evidence_id"]
+        assert bundle["records"][0]["reuse"] == {"original_source_state": request["source_state"], "verified_source_state": result["new_source_state"]}
+
+
+@pytest.mark.parametrize("changed_path", ["state.rs", "tool.py", "AGENTS.md"])
+def test_repeated_mutation_retains_or_expires_prior_nonexecutable_reuse(tmp_path: Path, changed_path: str) -> None:
+    request, entry, source = _mutation_with_audit_source(tmp_path)
+    first = advance_after_mutation(request)
+    artifact_bytes = Path(source["artifact_path"]).read_bytes()
+    repository = Path(request["new_capture"]["repository_root"])
+    (repository / changed_path).write_text("// another source change\n", encoding="utf-8")
+    git = shutil.which("git")
+    assert git is not None
+    next_request = {
+        **request,
+        **json.loads(json.dumps(first["lifecycle_input"])),
+        "changed_paths": [changed_path],
+        "previous_capture": first["capture"],
+        "new_capture": _scope_data(git, repository, "baseline", None, ()),
+        "repair_epoch": 2,
+    }
+    next_request.pop("sources")  # The prior plan owns immutable reused-source locations.
+    if changed_path == "AGENTS.md":
+        # New instructions also expand documentation routing in the repaired scope.
+        next_request["planning_template"] = {
+            **request["planning_template"],
+            "consulted_routers": [*request["planning_template"]["consulted_routers"], "docs-review-orchestrator"],
+        }
+
+    second = advance_after_mutation(next_request)
+
+    evidence_id = entry["dispatch"]["evidence_id"]
+    assert (evidence_id in second["reused_evidence_ids"]) == (changed_path == "state.rs")
+    assert (evidence_id in second["stale_evidence_ids"]) == (changed_path != "state.rs")
+    fresh_audit = any(
+        node["skill_id"] == entry["dispatch"]["skill_id"] and node["coverage"] == ("tool.py",) for node in second["new_plan"]["actual_worker_nodes"]
+    )
+    assert fresh_audit == (changed_path != "state.rs")
+    assert Path(source["artifact_path"]).read_bytes() == artifact_bytes
+    if changed_path == "state.rs":
+        transition = second["new_plan"]["audit_reuse_transitions"][0]
+        assert transition["source_state"] == tuple(request["source_state"])
+        assert transition["target_state"] == tuple(second["new_source_state"])
+
+
+@pytest.mark.parametrize("case", ["artifact", "snapshot", "instructions", "scope", "target", "missing-transition"])
+def test_mutation_reuse_rejects_tampered_provenance_before_synthesis(tmp_path: Path, case: str) -> None:
+    request, _entry, source = _mutation_with_audit_source(tmp_path)
+    result = advance_after_mutation(request)
+    document: dict[str, Any] = {**json.loads(json.dumps(result["lifecycle_input"])), "sources": [source]}
+    plan = document["plan"]
+    if case == "artifact":
+        Path(source["artifact_path"]).write_bytes(b"tampered")
+    elif case == "snapshot":
+        origin = next(item for item in plan["reuse_source_snapshots"] if item["repository_state_fingerprint"] == request["source_state"][2])
+        origin["repository_path_fingerprints"] = [[path, "f" * 64 if path == "tool.py" else digest] for path, digest in origin["repository_path_fingerprints"]]
+    elif case == "instructions":
+        (Path(request["new_capture"]["repository_root"]) / "AGENTS.md").write_text("New mandatory audit instructions.\n", encoding="utf-8")
+    elif case == "scope":
+        plan["reused_review_identities"][0]["planned_paths"] = ["state.rs"]
+    elif case == "target":
+        plan["audit_reuse_transitions"][0]["target_state"] = request["source_state"]
+    else:
+        plan["audit_reuse_transitions"] = []
+
+    with pytest.raises(ValueError, match=r"digest|fingerprint|identity|identities|source state|scope|instructions"):
+        build_synthesis_bundle(document)
+
+
+def test_legacy_unbound_capture_falls_back_to_executable_audit(tmp_path: Path) -> None:
+    request, entry, _source = _mutation_with_audit_source(tmp_path)
+    request["previous_capture"].pop("repository_state_format")
+
+    result = advance_after_mutation(request)
+
+    assert result["reused_evidence_ids"] == []
+    assert any(node["skill_id"] == entry["dispatch"]["skill_id"] and node["coverage"] == ("tool.py",) for node in result["new_plan"]["actual_worker_nodes"])
+
+
+def _compile_repair_fixture_entry(entry: dict[str, Any], lifecycle: dict[str, Any], journal: Path) -> dict[str, str]:
+    dispatch = {**entry["dispatch"], "before_state": lifecycle["source_state"], "after_state": lifecycle["source_state"]}
+    if entry["result_contract"] == "compact-validation":
+        unit = dispatch["validation_unit"]
+        payload = {
+            "artifacts": [],
+            "executions": [
+                {
+                    "artifact_paths": [],
+                    "command": command,
+                    "elapsed": "0s",
+                    "evidence": "fixture command passed",
+                    "executor": dispatch["node_id"],
+                    "exit_code": 0,
+                    "result": "passed",
+                    "working_directory": directory,
+                }
+                for command, directory in zip(unit["commands"], unit["working_directories"], strict=True)
+            ],
+            "limitations": [],
+            "status": "passed",
+        }
+        content, metadata = compile_validation({"dispatch": dispatch, "payload": payload})
+    else:
+        payload = {
+            "changes": [],
+            "command_policy_attested": True,
+            "commands_executed": [],
+            "files_inspected": list(dispatch["owned_paths"]) or ["state.rs", "tool.py"],
+            "findings": [],
+            "handoffs": [],
+            "limitations": [],
+            "nearby_contract_owners": [],
+            "scope_limitations": [],
+            "status": "no-findings",
+            "validation_requirements": [],
+        }
+        content, metadata = compile_review({"dispatch": dispatch, "payload": payload})
+    Path(entry["artifact_path"]).write_bytes(content)
+    Path(entry["metadata_path"]).write_text(json.dumps(metadata), encoding="utf-8")
+    source: dict[str, str] = {"artifact_path": entry["artifact_path"], "metadata_path": entry["metadata_path"]}
+    append_journal_event(journal, lifecycle, JournalEventRequest(entry["node_id"], "accepted", source=source))
+    return source
+
+
+def test_repair_skips_unchanged_audit_through_scheduling_synthesis_and_final_proof(tmp_path: Path) -> None:
+    request, old_entry, old_source = _mutation_with_audit_source(tmp_path)
+    original_artifact = Path(old_source["artifact_path"]).read_bytes()
+    original_metadata = Path(old_source["metadata_path"]).read_bytes()
+    result = advance_after_mutation(request)
+    lifecycle = json.loads(json.dumps(result["lifecycle_input"]))
+    plan = _graph_plan(lifecycle["plan"])
+    dispatches = result["dispatch_set"]
+    evidence_id = old_entry["dispatch"]["evidence_id"]
+    assert result["reused_evidence_ids"] == [evidence_id]
+    assert plan.complete_node_count == len(request["plan"]["actual_worker_nodes"]) - 1
+    assert not any(item["dispatch"].get("skill_id") == old_entry["dispatch"]["skill_id"] for item in dispatches["dispatches"])
+    journal = tmp_path / "repair.jsonl"
+    sources: list[dict[str, str]] = []
+    executed: list[str] = []
+    for _ in range(plan.complete_node_count + 1):
+        events, _states, _head = read_execution_journal(journal, plan=plan, source_state=tuple(lifecycle["source_state"]))
+        ready = next_ready_nodes({**lifecycle, "current_source_state": lifecycle["source_state"]}, journal_events=events, dispatch_set=dispatches)
+        assert ready["reused_evidence_ids"] == [evidence_id]
+        if ready["complete"]:
+            break
+        assert ready["ready_dispatches"], ready
+        for entry in ready["ready_dispatches"]:
+            if entry["dispatch"].get("mode") == "synthesis":
+                bundle = build_synthesis_bundle({**lifecycle, "sources": sources})
+                reused = next(item for item in bundle["records"] if item["evidence_id"] == evidence_id)
+                assert reused["reuse"]["original_source_state"] == request["source_state"]
+            sources.append(_compile_repair_fixture_entry(entry, lifecycle, journal))
+            executed.append(entry["node_id"])
+    else:
+        pytest.fail("repair graph did not reach completion within its node bound")
+    assert len(executed) == plan.complete_node_count
+    assert old_entry["node_id"] not in executed
+
+    lifecycle_path, dispatch_path, capture_path, proof_path = (tmp_path / name for name in ("lifecycle.json", "dispatch.json", "capture.json", "proof.json"))
+    lifecycle_path.write_text(json.dumps(lifecycle), encoding="utf-8")
+    dispatch_path.write_text(json.dumps(dispatches), encoding="utf-8")
+    capture_path.write_text(json.dumps(result["capture"]), encoding="utf-8")
+    assert (
+        main(
+            [
+                "finalize-proof",
+                "--input",
+                str(lifecycle_path),
+                "--dispatches",
+                str(dispatch_path),
+                "--journal",
+                str(journal),
+                "--current-capture",
+                str(capture_path),
+                "--output",
+                str(proof_path),
+            ]
+        )
+        == 0
+    )
+    final = json.loads(proof_path.read_text(encoding="utf-8"))
+    assert final["graph_proof_status"] == "complete", final["blockers"]
+    assert evidence_id in final["proof"]["accepted_review_evidence_ids"]
+    assert evidence_id not in final["proof"]["stale_evidence_ids"]
+    assert {item[1] for item in final["proof"]["exact_reused_review_evidence"]} == {evidence_id}
+    assert Path(old_source["artifact_path"]).read_bytes() == original_artifact
+    assert Path(old_source["metadata_path"]).read_bytes() == original_metadata
+
+    unproven = deepcopy(lifecycle)
+    unproven["plan"]["audit_reuse_transitions"] = []
+    unproven["plan"]["reuse_source_snapshots"] = []
+    rejected = finalize_proof({**unproven, "current_source_state": lifecycle["source_state"], "sources": [*sources, old_source]})
+    assert rejected["graph_proof_status"] == "incomplete"
+    assert any("different source state" in blocker for blocker in rejected["blockers"])
+
+
+def test_new_baseline_file_invalidates_its_expanded_owners_not_unrelated_leaves(tmp_path: Path) -> None:
+    request = _mutation_request(tmp_path)
+    repository = Path(request["new_capture"]["repository_root"])
+    (repository / "state.rs").write_text("pub fn state() {}\n", encoding="utf-8")
+    (repository / "extra.py").write_text("value = 2\n", encoding="utf-8")
+    git = shutil.which("git")
+    assert git is not None
+    request.update({"changed_paths": ["extra.py"], "new_capture": _scope_data(git, repository, "baseline", None, ())})
+
+    result = advance_after_mutation(request)
+
+    assert result["newly_touched_paths"] == ["extra.py"]
+    assert result["repair_epoch"]["changed_paths"] == ["extra.py"]
+    old_plan = _graph_plan(request["plan"])
+    invalidated = {record["node_id"] for record in result["invalidated_nodes"]}
+    assert {node.node_id for node in old_plan.actual_worker_nodes if node.mode == "audit" and "tool.py" in node.coverage} <= invalidated
+    assert not {node.node_id for node in old_plan.actual_worker_nodes if node.mode == "audit" and "state.rs" in node.coverage} & invalidated
+
+
+def test_mutation_does_not_carry_stale_exact_reuse_assertions_into_new_plan(tmp_path: Path) -> None:
+    request = _mutation_request(tmp_path)
+    override = request["planning_template"]["routing_overrides"][0]
+    override.update({"disposition": "exact-evidence-reused", "evidence_id": "review:old-audit"})
+    request["planning_template"]["validation_requirements"][0]["evidence_id"] = "validation:old-validator"
+
+    result = advance_after_mutation(request)
+
+    assert not result["new_plan"]["exact_reused_review_evidence"]
+    assert all(mapping["evidence_id"] is None for mapping in result["new_plan"]["validation_evidence_mapping"])
+    assert override["disposition"] == "exact-evidence-reused"
+    assert override["evidence_id"] == "review:old-audit"
+
+
+def test_mutation_accepts_removal_from_the_previous_untracked_scope(tmp_path: Path) -> None:
+    git, repository, template, _capture, _plan = _baseline_mutation_fixture(tmp_path)
+    scratch = repository / "scratch.py"
+    scratch.write_text("value = 2\n", encoding="utf-8")
+    previous_capture = _scope_data(git, repository, "baseline", None, ())
+    plan = plan_from_document(
+        bootstrap_document(previous_capture, template), catalog_path=ROUTING_CATALOG, skill_roots=(SKILL_ROOT,), repository_root=repository
+    )
+    scratch.unlink()
+
+    result = advance_after_mutation(
+        {
+            "artifact_store": str(tmp_path / "proof-store"),
+            "authorization_after": "review-and-fix",
+            "authorization_before": "review-and-fix",
+            "changed_paths": ["scratch.py"],
+            "new_capture": _scope_data(git, repository, "baseline", None, ()),
+            "plan": _json_plan(plan),
+            "planning_template": template,
+            "previous_capture": previous_capture,
+            "repair_epoch": 1,
+            "source_state": [previous_capture[field] for field in ("scope_fingerprint", "captured_worktree_fingerprint", "repository_state_fingerprint")],
+            "state_verification_command": "capture_scope.py --mode baseline",
+        }
+    )
+
+    assert result["repair_epoch"]["changed_paths"] == ["scratch.py"]
+    assert result["newly_touched_paths"] == []
+    invalidated = {record["node_id"] for record in result["invalidated_nodes"]}
+    assert {node.node_id for node in plan.actual_worker_nodes if "scratch.py" in node.coverage} <= invalidated
+    assert not {node.node_id for node in plan.actual_worker_nodes if node.mode == "audit" and node.coverage == ("state.rs",)} & invalidated
+
+
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("missing-previous", "previous_capture"),
+        ("missing-path-identities", "repository_path_fingerprints"),
+        ("undeclared-change", "immediately prior capture delta"),
+        ("git-index-change", "mutated the Git index"),
+        ("different-boundary", "cannot change capture boundaries"),
+    ],
+)
+def test_mutation_rejects_unproven_delta_before_publishing(tmp_path: Path, case: str, message: str) -> None:
+    request = _mutation_request(tmp_path)
+    if case == "missing-previous":
+        request.pop("previous_capture")
+    elif case == "missing-path-identities":
+        request["previous_capture"].pop("repository_path_fingerprints")
+    elif case == "undeclared-change":
+        request["changed_paths"] = ["LICENSE"]
+    elif case == "git-index-change":
+        request["new_capture"]["index_fingerprint"] = "f" * 64
+    else:
+        request["new_capture"]["requested_paths"] = ["state.rs"]
+
+    with pytest.raises((ValueError, TypeError), match=message):
+        advance_after_mutation(request)
+    assert not Path(request["artifact_store"]).exists()
 
 
 def test_compile_review_enforces_validator_owned_command_policy() -> None:
@@ -706,6 +1143,7 @@ def test_compile_review_enforces_validator_owned_command_policy() -> None:
                     "findings": [],
                     "handoffs": [],
                     "limitations": [],
+                    "scope_limitations": [],
                     "nearby_contract_owners": [],
                     "status": "no-findings",
                     "validation_requirements": [],
@@ -727,6 +1165,7 @@ def test_compile_review_rejects_numeric_command_policy_attestation_without_polic
                     "findings": [],
                     "handoffs": [],
                     "limitations": [],
+                    "scope_limitations": [],
                     "nearby_contract_owners": [],
                     "status": "no-findings",
                     "validation_requirements": [],
@@ -753,6 +1192,7 @@ def test_compile_review_records_explicitly_authorized_duplicate_validation() -> 
                 "findings": [],
                 "handoffs": [],
                 "limitations": [],
+                "scope_limitations": [],
                 "nearby_contract_owners": [],
                 "status": "no-findings",
                 "validation_requirements": [],
@@ -786,6 +1226,7 @@ def test_compile_review_rejects_non_catalog_handoff_identity() -> None:
                         }
                     ],
                     "limitations": [],
+                    "scope_limitations": [],
                     "nearby_contract_owners": [],
                     "status": "no-findings",
                     "validation_requirements": [],
@@ -810,6 +1251,7 @@ def test_runtime_cli_writes_verified_review_artifacts(tmp_path: Path) -> None:
                     "findings": [],
                     "handoffs": [],
                     "limitations": [],
+                    "scope_limitations": [],
                     "nearby_contract_owners": [],
                     "status": "no-findings",
                     "validation_requirements": [],
@@ -1406,6 +1848,118 @@ def test_routing_regression_fixtures_enforce_guarded_docs_and_scripts_test_paths
             assert projected[catalog_id]["matched_paths"] == expected_matches, case["id"]
 
 
+def test_baseline_plan_assigns_references_markdown_to_citation_audit() -> None:
+    document = _sparse_plan_document()
+    document["captured_paths"] = ["REFERENCES.md"]
+    document["consulted_routers"] = ["review-graph", "docs-review-orchestrator"]
+    document["routing_overrides"] = []
+    requirement = cast("dict[str, Any]", document["validation_requirements"][0])
+    requirement["captured_paths"] = ["REFERENCES.md"]
+
+    plan = plan_from_document(document, catalog_path=ROUTING_CATALOG, skill_roots=(SKILL_ROOT,))
+
+    citation_decision = next(decision for decision in plan.routing_decisions if decision.catalog_id == "docs.citations")
+    citation_node_id = dict(plan.requirement_to_node)["docs.citations"]
+    citation_node = next(node for node in plan.actual_worker_nodes if node.node_id == citation_node_id)
+    assert citation_decision.disposition == "selected"
+    assert citation_decision.review_surface == ("REFERENCES.md",)
+    assert "REFERENCES.md" in citation_node.coverage
+
+
+def test_readme_citation_claim_can_semantically_route_to_citation_audit() -> None:
+    document = _sparse_plan_document()
+    document["captured_paths"] = ["README.md"]
+    document["consulted_routers"] = ["review-graph", "docs-review-orchestrator"]
+    document["routing_overrides"] = [
+        {
+            "applicability_evidence": ["README.md contains public DOI and citation guidance"],
+            "catalog_id": "docs.citations",
+            "disposition": "selected",
+            "owners": ["documentation"],
+            "reason": "public citation claims require bibliographic verification",
+            "review_surface": ["README.md"],
+        }
+    ]
+    requirement = cast("dict[str, Any]", document["validation_requirements"][0])
+    requirement["captured_paths"] = ["README.md"]
+
+    catalog = load_routing_catalog(ROUTING_CATALOG, skill_roots=(SKILL_ROOT,))
+    citation_entry = next(entry for entry in catalog if entry.catalog_id == "docs.citations")
+    plan = plan_from_document(document, catalog_path=ROUTING_CATALOG, skill_roots=(SKILL_ROOT,))
+
+    assert any("README citation" in trigger for trigger in citation_entry.semantic_triggers)
+    citation_decision = next(decision for decision in plan.routing_decisions if decision.catalog_id == "docs.citations")
+    assert citation_decision.disposition == "selected"
+    assert citation_decision.review_surface == ("README.md",)
+
+
+@pytest.mark.parametrize("mode", ["branch", "staged", "worktree", "baseline"])
+def test_readme_citations_are_owned_without_overrides_in_each_capture_scope(tmp_path: Path, mode: str) -> None:
+    git = shutil.which("git")
+    assert git is not None
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    _run_test_git(git, "init", str(repository))
+    _run_test_git(git, "-C", str(repository), "config", "user.email", "review@example.com")
+    _run_test_git(git, "-C", str(repository), "config", "user.name", "Review Test")
+    (repository / "docs").mkdir()
+    (repository / "README.md").write_text("Project concept DOI and citation guidance.\n", encoding="utf-8")
+    (repository / "docs/RELEASING.md").write_text("Release instructions.\n", encoding="utf-8")
+    (repository / "CITATION.cff").write_text("# Unchanged project citation metadata.\n", encoding="utf-8")
+    _run_test_git(git, "-C", str(repository), "add", ".")
+    _run_test_git(git, "-C", str(repository), "commit", "-m", "initial")
+    (repository / "README.md").write_text("Release updater preserves the concept DOI and citation guidance.\n", encoding="utf-8")
+    (repository / "docs/RELEASING.md").write_text("Updated release instructions.\n", encoding="utf-8")
+    if mode == "staged":
+        _run_test_git(git, "-C", str(repository), "add", "README.md", "docs/RELEASING.md")
+    capture = _scope_data(git, repository, mode, "HEAD" if mode == "branch" else None, ())
+    template = _sparse_plan_document()
+    template.pop("scope_mode")
+    template.update({"consulted_routers": ["review-graph", "docs-review-orchestrator"], "routing_overrides": [], "concrete_change_target": mode != "baseline"})
+    if mode != "baseline":
+        template["change_target"] = "git diff " + ("--cached " if mode == "staged" else "") + "HEAD -- README.md docs/RELEASING.md"
+    template["validation_requirements"][0].update(
+        {"baseline": True, "requested_scope": mode, "commands": ["just ci"], "canonical_recipe": "just ci", "working_directories": [str(repository)]}
+    )
+    capture_path, template_path, output_path = (tmp_path / name for name in ("capture.json", "template.json", "bootstrap.json"))
+    capture_path.write_text(json.dumps(capture), encoding="utf-8")
+    template_path.write_text(json.dumps(template), encoding="utf-8")
+
+    assert bootstrap_main(["--capture", str(capture_path), "--input", str(template_path), "--output", str(output_path)]) == 0
+
+    bundle = json.loads(output_path.read_text(encoding="utf-8"))
+    unit = bundle["plan"]["coalesced_validation_units"][0]
+    assert unit["baseline"] is True
+    assert unit["commands"] == ["just ci"]
+    assert bundle["planning_input"]["validation_requirements"][0]["requested_scope"] == mode
+    expected_paths = ["README.md", "docs/RELEASING.md"]
+    if mode == "baseline":
+        expected_paths.insert(0, "CITATION.cff")
+    assert capture["captured_scope_paths"] == expected_paths
+    projection = build_routing_projection_document(bundle["planning_input"], catalog_path=ROUTING_CATALOG, skill_roots=(SKILL_ROOT,))
+    assert next(entry for entry in projection["entries"] if entry["catalog_id"] == "docs.citations")["matched_paths"] == expected_paths
+    dispatches = materialize_dispatches(bundle["materialization_input"])
+    citation = next(entry for entry in dispatches["dispatches"] if "docs.citations" in entry["dispatch"]["requirement_ids"])
+    assert citation["dispatch"]["owned_paths"] == expected_paths
+
+
+def test_missing_baseline_validator_explains_the_field_without_changing_review_scope(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    template = _sparse_plan_document()
+    template["scope_mode"] = "branch"
+    template["validation_requirements"][0].update({"baseline": False, "requested_scope": "branch"})
+    capture_path, template_path, output_path = (tmp_path / name for name in ("capture.json", "template.json", "bootstrap.json"))
+    capture_path.write_text(json.dumps(_baseline_capture()), encoding="utf-8")
+    template_path.write_text(json.dumps(template), encoding="utf-8")
+
+    assert bootstrap_main(["--capture", str(capture_path), "--input", str(template_path), "--output", str(output_path)]) == 2
+
+    diagnostic = capsys.readouterr()
+    assert diagnostic.out == ""
+    assert "validation_requirements[i].baseline=true" in diagnostic.err
+    assert "keep requested_scope=branch" in diagnostic.err
+    assert not output_path.exists()
+
+
 def test_sparse_mixed_lockfile_fixture_selects_every_projection_match_and_coalesces_aliases() -> None:
     fixture = Path(__file__).with_name("fixtures") / "sparse_mixed_lockfiles.json"
     document = json.loads(fixture.read_text(encoding="utf-8"))
@@ -1486,6 +2040,18 @@ def test_dispatch_materialization_and_ready_nodes_are_plan_derived(tmp_path: Pat
     assert all(entry["worker_prompt"] for entry in result["dispatches"])
     assert all("persist-worker-payload" in entry["worker_prompt"] for entry in result["dispatches"])
     assert all(Path(entry["worker_payload_contract_path"]).is_file() for entry in result["dispatches"])
+    for entry in result["dispatches"]:
+        worker_input = Path(entry["worker_input_path"])
+        assert worker_input.is_absolute()
+        assert json.loads(worker_input.read_text(encoding="utf-8")) == entry
+        assert worker_input.stat().st_mode & 0o777 == 0o444
+        persistence = entry["dispatch"]["worker_payload_persistence"]
+        command = persistence["command"]
+        assert Path(command[0]).is_absolute()
+        assert Path(command[0]).is_file()
+        assert command[1] == str(Path(__file__).resolve().with_name("review_graph_runtime.py"))
+        assert command[2:] == ["persist-worker-payload", "--input", entry["worker_payload_contract_path"], "--payload", entry["worker_payload_candidate_path"]]
+        assert shlex.join(command) in entry["worker_prompt"]
 
     lifecycle_document = {
         "current_source_state": ["scope", "worktree", "repository"],
@@ -1495,6 +2061,7 @@ def test_dispatch_materialization_and_ready_nodes_are_plan_derived(tmp_path: Pat
     initial = next_ready_nodes(lifecycle_document, journal_events=(), dispatch_set=result)
     assert set(initial["ready_node_ids"]) == {node.node_id for node in plan.actual_worker_nodes if not node.predecessors}
     assert {entry["node_id"] for entry in initial["ready_dispatches"]} == set(initial["ready_node_ids"])
+    assert all(json.loads(Path(entry["worker_input_path"]).read_text(encoding="utf-8")) == entry for entry in initial["ready_dispatches"])
     stale = dict(lifecycle_document)
     stale["current_source_state"] = ["scope", "worktree", "changed-repository"]
     with pytest.raises(ValueError, match="current recapture differs"):
@@ -1507,6 +2074,89 @@ def test_dispatch_materialization_and_ready_nodes_are_plan_derived(tmp_path: Pat
     after_start = next_ready_nodes(lifecycle_document, journal_events=events, dispatch_set=result)
     assert started not in after_start["ready_node_ids"]
     assert after_start["lifecycle"]["in_flight_node_ids"] == [started]
+
+
+def _worker_input_fixture(tmp_path: Path) -> tuple[dict[str, Any], dict[str, Any]]:
+    document = {
+        "artifact_store": str(tmp_path / "proof"),
+        "authorization": "review-only",
+        "plan": _json_plan(_sparse_plan()),
+        "repository_root": str(SKILL_ROOT.parents[2]),
+        "source_state": ["scope", "worktree", "repository"],
+        "state_verification_command": "capture_scope.py --mode baseline",
+    }
+    return document, materialize_dispatches(document)
+
+
+def test_worker_publishes_payload_from_only_runtime_emitted_input(tmp_path: Path) -> None:
+    document, dispatches = _worker_input_fixture(tmp_path)
+    ready = next_ready_nodes({**document, "current_source_state": document["source_state"]}, journal_events=(), dispatch_set=dispatches)
+    entry = next(item for item in ready["ready_dispatches"] if item["dispatch"].get("mode") == "audit")
+    worker_directory = tmp_path / "empty-worker-directory"
+    worker_directory.mkdir()
+    worker = """
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+entry = json.loads(Path(sys.argv[1]).read_text())
+dispatch = entry["dispatch"]
+payload = {
+    "changes": [], "commands_executed": [], "command_policy_attested": True,
+    "files_inspected": dispatch["owned_paths"], "nearby_contract_owners": [],
+    "findings": [], "validation_requirements": [], "handoffs": [],
+    "limitations": [], "scope_limitations": [], "status": "no-findings"
+}
+persistence = dispatch["worker_payload_persistence"]
+Path(persistence["candidate_path"]).write_text(json.dumps(payload))
+subprocess.run(persistence["command"], check=True, timeout=30)
+"""
+
+    result = subprocess.run(  # noqa: S603 - isolated protocol fixture, no review/validation commands executed.
+        [sys.executable, "-I", "-c", worker, entry["worker_input_path"]], cwd=worker_directory, capture_output=True, text=True, timeout=30, check=False
+    )
+
+    assert result.returncode == 0, result.stderr
+    receipt = json.loads(result.stdout)
+    assert receipt["worker_payload_path"] == entry["worker_payload_path"]
+    payload = json.loads(Path(receipt["worker_payload_path"]).read_text(encoding="utf-8"))
+    assert payload["files_inspected"] == entry["dispatch"]["owned_paths"]
+    assert payload["status"] == "no-findings"
+    assert not list(worker_directory.iterdir())
+
+
+@pytest.mark.parametrize("tamper", ["content", "missing", "symlink"])
+def test_ready_nodes_reject_missing_or_substituted_worker_inputs(tmp_path: Path, tamper: str) -> None:
+    document, dispatches = _worker_input_fixture(tmp_path)
+    worker_input = Path(dispatches["dispatches"][0]["worker_input_path"])
+    original = worker_input.read_bytes()
+    if tamper == "content":
+        worker_input.chmod(0o600)
+        worker_input.write_bytes(b'{"dispatch": {"node_id": "substituted"}}\n')
+    else:
+        worker_input.unlink()
+        if tamper == "symlink":
+            substitute = tmp_path / "substitute.json"
+            substitute.write_bytes(original)
+            worker_input.symlink_to(substitute)
+
+    with pytest.raises(ValueError, match=r"worker input differs|regular non-symlink file"):
+        next_ready_nodes({**document, "current_source_state": document["source_state"]}, journal_events=(), dispatch_set=dispatches)
+
+
+def test_worker_input_publication_is_immutable_and_replayable(tmp_path: Path) -> None:
+    document, dispatches = _worker_input_fixture(tmp_path)
+    worker_input = Path(dispatches["dispatches"][0]["worker_input_path"])
+    original = worker_input.read_bytes()
+
+    assert materialize_dispatches(document) == dispatches
+    assert worker_input.read_bytes() == original
+    worker_input.chmod(0o600)
+    worker_input.write_bytes(b"preexisting different input\n")
+    with pytest.raises(ValueError, match="refusing to overwrite non-identical immutable artifact"):
+        materialize_dispatches(document)
+    assert worker_input.read_bytes() == b"preexisting different input\n"
 
 
 def test_validator_prompt_exposes_nested_required_shape_and_minimal_response_compiles(tmp_path: Path) -> None:
@@ -1582,7 +2232,8 @@ def test_late_handoff_replan_reserves_reused_ids_and_binds_surface_readiness(tmp
     assert f"validation:{validation.node_id}" in dispatches["python-synthesis"]["predecessor_evidence_ids"]
 
 
-def test_next_ready_creates_runtime_managed_output_directory(tmp_path: Path) -> None:
+@pytest.mark.parametrize("precreate_zero_byte_journal", [False, True])
+def test_first_next_ready_accepts_missing_or_zero_byte_journal(tmp_path: Path, capsys: pytest.CaptureFixture[str], precreate_zero_byte_journal: bool) -> None:
     plan = _sparse_plan()
     lifecycle = {"plan": _json_plan(plan), "source_state": ["scope", "worktree", "repository"]}
     dispatch_set = materialize_dispatches(
@@ -1603,6 +2254,9 @@ def test_next_ready_creates_runtime_managed_output_directory(tmp_path: Path) -> 
     dispatch_path.write_text(json.dumps(dispatch_set), encoding="utf-8")
     capture_path.write_text(json.dumps(capture), encoding="utf-8")
     output_directory = tmp_path / "missing" / "ready"
+    journal_path = tmp_path / "execution.jsonl"
+    if precreate_zero_byte_journal:
+        journal_path.touch()
 
     result = main(
         [
@@ -1610,7 +2264,7 @@ def test_next_ready_creates_runtime_managed_output_directory(tmp_path: Path) -> 
             "--input",
             str(input_path),
             "--journal",
-            str(tmp_path / "execution.jsonl"),
+            str(journal_path),
             "--dispatches",
             str(dispatch_path),
             "--current-capture",
@@ -1621,7 +2275,33 @@ def test_next_ready_creates_runtime_managed_output_directory(tmp_path: Path) -> 
     )
 
     assert result == 0
-    assert (output_directory / "next-ready.000000.json").is_file()
+    response = capsys.readouterr()
+    assert response.err == ""
+    receipt = json.loads(response.out)
+    assert receipt == {"output_generation": 0, "output_path": str(output_directory / "next-ready.000000.json")}
+    ready = json.loads(Path(receipt["output_path"]).read_text(encoding="utf-8"))
+    assert ready["ready_dispatches"]
+    for entry in ready["ready_dispatches"]:
+        worker_input = json.loads(Path(entry["worker_input_path"]).read_text(encoding="utf-8"))
+        assert worker_input == entry
+    assert journal_path.exists() is precreate_zero_byte_journal
+    if precreate_zero_byte_journal:
+        assert journal_path.read_bytes() == b""
+
+
+def test_execution_journal_rejects_blank_record_but_accepts_zero_bytes(tmp_path: Path) -> None:
+    plan = _sparse_plan()
+    journal = tmp_path / "execution.jsonl"
+    journal.touch()
+
+    events, state, head = read_execution_journal(journal, plan=plan, source_state=("scope", "worktree", "repository"))
+
+    assert events == ()
+    assert state == {}
+    assert head is None
+    journal.write_bytes(b"\n")
+    with pytest.raises(ValueError, match="blank record at line 1"):
+        read_execution_journal(journal, plan=plan, source_state=("scope", "worktree", "repository"))
 
 
 def test_dispatch_materialization_reports_validation_node_without_unit(tmp_path: Path) -> None:
@@ -1938,6 +2618,7 @@ def test_compile_node_survives_context_compaction_by_reading_bound_worker_payloa
         "findings": [],
         "handoffs": [],
         "limitations": [],
+        "scope_limitations": [],
         "nearby_contract_owners": [],
         "status": "no-findings",
         "validation_requirements": [],
@@ -2027,6 +2708,7 @@ def test_persist_worker_payload_preserves_valid_target_when_validation_or_public
         "findings": [],
         "handoffs": [],
         "limitations": [],
+        "scope_limitations": [],
         "nearby_contract_owners": [],
         "status": "no-findings",
         "validation_requirements": [],
@@ -2054,6 +2736,68 @@ def test_persist_worker_payload_preserves_valid_target_when_validation_or_public
     assert main(command) == 2
     assert target.read_bytes() == valid_bytes
     assert candidate.is_file()
+
+
+def test_baseline_audit_rejects_changed_only_no_findings_before_publication(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    target = tmp_path / "audit.worker-payload.json"
+    candidate = tmp_path / "audit.worker-payload.candidate.json"
+    contract_path = tmp_path / "audit.worker-payload-contract.json"
+    owned_paths = ["README.md", "REFERENCES.md"]
+    contract = {
+        "candidate_path": str(candidate),
+        "mode": "audit",
+        "node_id": "audit-docs",
+        "owned_paths": owned_paths,
+        "result_contract": "compact-review",
+        "schema_version": 1,
+        "worker_payload_path": str(target),
+    }
+    payload = {
+        "changes": [],
+        "command_policy_attested": True,
+        "commands_executed": [],
+        "files_inspected": ["README.md"],
+        "findings": [],
+        "handoffs": [],
+        "limitations": [],
+        "scope_limitations": [],
+        "nearby_contract_owners": [],
+        "status": "no-findings",
+        "validation_requirements": [],
+    }
+    contract_path.write_text(json.dumps(contract), encoding="utf-8")
+    candidate.write_text(json.dumps(payload), encoding="utf-8")
+
+    assert main(["persist-worker-payload", "--input", str(contract_path), "--payload", str(candidate)]) == 2
+    assert "requires inspection of every owned path" in capsys.readouterr().err
+    assert not target.exists()
+    assert candidate.exists()
+
+    accepted = {**payload, "scope_limitations": [{"path": "REFERENCES.md", "reason": "upstream bibliography was unavailable"}], "status": "completed"}
+    candidate.write_text(json.dumps(accepted), encoding="utf-8")
+    assert main(["persist-worker-payload", "--input", str(contract_path), "--payload", str(candidate)]) == 0
+    assert target.exists()
+
+
+def test_compile_review_rechecks_owned_audit_scope() -> None:
+    dispatch = _dispatch()
+    dispatch["owned_paths"] = ["src/error.rs", "src/context.rs"]
+    payload = {
+        "changes": [],
+        "command_policy_attested": True,
+        "commands_executed": [],
+        "files_inspected": ["src/error.rs"],
+        "findings": [],
+        "handoffs": [],
+        "limitations": [],
+        "scope_limitations": [],
+        "nearby_contract_owners": [],
+        "status": "no-findings",
+        "validation_requirements": [],
+    }
+
+    with pytest.raises(ValueError, match="requires inspection of every owned path"):
+        compile_review({"dispatch": dispatch, "payload": payload})
 
 
 def test_compact_branch_runs_from_bootstrap_through_journal_and_final_proof(tmp_path: Path) -> None:  # noqa: PLR0915
@@ -2179,6 +2923,7 @@ none
                 "findings": [],
                 "handoffs": [],
                 "limitations": [],
+                "scope_limitations": [],
                 "nearby_contract_owners": [],
                 "status": "no-findings",
                 "validation_requirements": [],
@@ -2305,8 +3050,14 @@ def test_journal_and_next_ready_cli_use_persisted_artifacts(tmp_path: Path) -> N
     assert generated["output_generation"] == 1
 
 
-def _compile_materialized_evidence(
-    tmp_path: Path, *, handoff_catalog_id: str | None = None, resolved_handoff: bool = False, plan: GraphPlan | None = None, skip_node_ids: tuple[str, ...] = ()
+def _compile_materialized_evidence(  # noqa: PLR0913
+    tmp_path: Path,
+    *,
+    handoff_catalog_id: str | None = None,
+    resolved_handoff: bool = False,
+    plan: GraphPlan | None = None,
+    skip_node_ids: tuple[str, ...] = (),
+    late_requirements: list[dict[str, Any]] | None = None,
 ) -> tuple[GraphPlan, list[dict[str, str]]]:
     plan = plan or _sparse_plan()
     materialized = materialize_dispatches(
@@ -2375,9 +3126,10 @@ def _compile_materialized_evidence(
                 "findings": [],
                 "handoffs": handoffs,
                 "limitations": [],
+                "scope_limitations": [],
                 "nearby_contract_owners": [],
                 "status": "no-findings",
-                "validation_requirements": [],
+                "validation_requirements": late_requirements or [] if dispatch["node_id"] == "audit-001" else [],
             }
             content, metadata = compile_review({"dispatch": dispatch, "payload": payload})
             kind = "review"
@@ -2391,6 +3143,349 @@ def _compile_materialized_evidence(
 
 def _source_by_node(sources: list[dict[str, str]]) -> dict[str, dict[str, str]]:
     return {json.loads(Path(source["metadata_path"]).read_text(encoding="utf-8"))["evidence"]["node_id"]: source for source in sources}
+
+
+def _late_validation_requirement() -> dict[str, Any]:
+    return {
+        "requirement_id": "python.build.isolated-artifacts",
+        "owner": "review-validator",
+        "reason": "clean install is not covered by CI",
+        "commands": ["uv build"],
+        "working_directory": str(SKILL_ROOT.parents[2]),
+        "environment": "isolated Python",
+        "expected_evidence": "sdist and wheel install cleanly",
+        "dependency_policy": "stop-on-failure",
+    }
+
+
+def _late_validation_plan() -> dict[str, Any]:
+    requirement = _sparse_plan_document()["validation_requirements"][0]
+    late = _late_validation_requirement()
+    requirement.update(
+        {
+            "baseline": False,
+            "canonical_recipe": None,
+            "requirement_id": late["requirement_id"],
+            "commands": late["commands"],
+            "working_directories": [late["working_directory"]],
+            "environment": late["environment"],
+            "expected_evidence": late["expected_evidence"],
+            "expected_workspace_effects": [],
+            "requires_isolation": False,
+            "isolation_root": None,
+        }
+    )
+    require_schema_definition(requirement, SCHEMA_ROOT / "planning-input-v1.schema.json", "validationRequirement")
+    return requirement
+
+
+def _late_validation_fixture(tmp_path: Path) -> tuple[GraphPlan, list[dict[str, str]], dict[str, Any], Path, Path, Path]:
+    plan, sources = _compile_materialized_evidence(tmp_path / "original", late_requirements=[_late_validation_requirement()])
+    lifecycle = {"plan": _json_plan(plan), "source_state": ["scope", "worktree", "repository"]}
+    materialized = materialize_dispatches(
+        {
+            **lifecycle,
+            "artifact_store": str(tmp_path / "original"),
+            "authorization": "review-only",
+            "repository_root": str(SKILL_ROOT.parents[2]),
+            "state_verification_command": "capture_scope.py --mode baseline",
+        }
+    )
+    dispatch_path = tmp_path / "dispatches.json"
+    dispatch_path.write_text(json.dumps(materialized), encoding="utf-8")
+    capture_path = tmp_path / "capture.json"
+    capture_path.write_text(
+        json.dumps({"scope_fingerprint": "scope", "captured_worktree_fingerprint": "worktree", "repository_state_fingerprint": "repository"}), encoding="utf-8"
+    )
+    journal = tmp_path / "execution.jsonl"
+    by_node = _source_by_node(sources)
+    for node in plan.actual_worker_nodes:
+        if node.mode != "synthesis":
+            append_journal_event(journal, lifecycle, JournalEventRequest(node.node_id, "accepted", source=by_node[node.node_id]))
+    return plan, sources, lifecycle, dispatch_path, capture_path, journal
+
+
+@pytest.mark.parametrize("exclude", [False, True])
+def test_late_validation_blocks_readiness_and_finalization_then_expands_without_replaying_ci(tmp_path: Path, exclude: bool) -> None:
+    plan, sources, lifecycle, dispatch_path, capture_path, journal = _late_validation_fixture(tmp_path)
+    events, _state, _head = read_execution_journal(journal, plan=plan, source_state=tuple(lifecycle["source_state"]))
+    ready = next_ready_nodes(
+        {**lifecycle, "current_source_state": lifecycle["source_state"]}, journal_events=events, dispatch_set=json.loads(dispatch_path.read_text())
+    )
+    assert ready["ready_node_ids"] == []
+    assert any("python.build.isolated-artifacts" in blocker for blocker in ready["blockers"])
+    # Even precompiled, otherwise complete syntheses must not conceal this gap.
+    premature = finalize_proof({**lifecycle, "current_source_state": lifecycle["source_state"], "sources": sources})
+    assert premature["status"] == "incomplete"
+    assert premature["repository_validation_status"] == "incomplete"
+    assert any("python.build.isolated-artifacts" in blocker for blocker in premature["blockers"])
+    original_bytes = {
+        path: path.read_bytes()
+        for path in [journal, dispatch_path, *(Path(source[field]) for source in sources for field in ("artifact_path", "metadata_path"))]
+    }
+    discovery = ready["validation_reconciliation"]["requirements"][0]
+    request = {**lifecycle, "artifact_store": str(tmp_path / "revision")}
+    if exclude:
+        request["user_exclusions"] = [
+            {key: discovery[key] for key in ("originating_evidence_id", "requirement_id", "requirement_digest")}
+            | {"reason": "user explicitly excludes clean-install coverage"}
+        ]
+    else:
+        request["validation_requirements"] = [_late_validation_plan()]
+    input_path = tmp_path / "expand.json"
+    input_path.write_text(json.dumps(request), encoding="utf-8")
+    output_path = tmp_path / "expanded.json"
+    assert (
+        main(
+            [
+                "reconcile-validation-requirements",
+                "--input",
+                str(input_path),
+                "--journal",
+                str(journal),
+                "--dispatches",
+                str(dispatch_path),
+                "--current-capture",
+                str(capture_path),
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+    result = json.loads(output_path.read_text())
+    assert result["status"] == "expanded"
+    assert result["source_state"] == lifecycle["source_state"]
+    revised_lifecycle = result["lifecycle_input"]
+    revised_plan = _graph_plan(revised_lifecycle["plan"])
+    revised_dispatches = json.loads(Path(result["dispatches_path"]).read_text())
+    revised_journal = Path(result["journal_path"])
+    revised_events, _state, _head = read_execution_journal(revised_journal, plan=revised_plan, source_state=tuple(lifecycle["source_state"]))
+    ready = next_ready_nodes(
+        {**revised_lifecycle, "current_source_state": lifecycle["source_state"]}, journal_events=revised_events, dispatch_set=revised_dispatches
+    )
+    old_validators = {node.node_id for node in plan.actual_worker_nodes if node.mode == "validation"}
+    assert old_validators <= set(result["retained_node_ids"])
+    assert not old_validators & set(ready["ready_node_ids"])
+    if not exclude:
+        assert len(ready["ready_node_ids"]) == 1
+        assert next(node for node in revised_plan.actual_worker_nodes if node.node_id == ready["ready_node_ids"][0]).mode == "validation"
+    for entry in revised_dispatches["dispatches"]:
+        if entry["node_id"] not in result["retained_node_ids"]:
+            _compile_repair_fixture_entry(entry, revised_lifecycle, revised_journal)
+    final_path = tmp_path / "final.json"
+    assert (
+        main(
+            [
+                "finalize-proof",
+                "--input",
+                result["lifecycle_input_path"],
+                "--dispatches",
+                result["dispatches_path"],
+                "--journal",
+                str(revised_journal),
+                "--current-capture",
+                str(capture_path),
+                "--output",
+                str(final_path),
+            ]
+        )
+        == 0
+    )
+    final = json.loads(final_path.read_text())
+    assert final["status"] == "complete"
+    assert final["validation_reconciliation"]["requirements"][0]["resolution"] == ("user-excluded" if exclude else "planned")
+    assert all(path.read_bytes() == content for path, content in original_bytes.items())
+
+
+@pytest.mark.parametrize("tamper", ["commands", "environment", "source", "exclusion", "capacity"])
+def test_late_validation_expansion_rejects_wrong_identity_or_active_workers(tmp_path: Path, tamper: str) -> None:
+    plan, _sources, lifecycle, dispatch_path, capture_path, journal = _late_validation_fixture(tmp_path)
+    requirement = _late_validation_plan()
+    late = _late_validation_requirement()
+    request = {**lifecycle, "artifact_store": str(tmp_path / "revision"), "validation_requirements": [requirement]}
+    if tamper == "commands":
+        requirement["commands"] = ["true"]
+    elif tamper == "environment":
+        requirement["environment"] = "CI environment"
+    elif tamper == "source":
+        requirement["source_state"] = ["changed", "worktree", "repository"]
+    elif tamper == "exclusion":
+        request["validation_requirements"] = []
+        request["user_exclusions"] = [
+            {
+                "originating_evidence_id": "review:audit-001",
+                "requirement_id": late["requirement_id"],
+                "requirement_digest": "sha256:" + "0" * 64,
+                "reason": "unbound exclusion",
+            }
+        ]
+    else:
+        synthesis = next(node for node in plan.actual_worker_nodes if node.mode == "synthesis")
+        append_journal_event(journal, lifecycle, JournalEventRequest(synthesis.node_id, "in-flight"))
+    input_path = tmp_path / "request.json"
+    input_path.write_text(json.dumps(request), encoding="utf-8")
+    assert (
+        main(
+            [
+                "reconcile-validation-requirements",
+                "--input",
+                str(input_path),
+                "--journal",
+                str(journal),
+                "--dispatches",
+                str(dispatch_path),
+                "--current-capture",
+                str(capture_path),
+                "--output",
+                str(tmp_path / "output.json"),
+            ]
+        )
+        == 2
+    )
+    assert not (tmp_path / "revision").exists()
+
+
+def test_bundle_only_synthesis_persists_and_compiles_without_reading_source(tmp_path: Path) -> None:
+    _document, materialized = _worker_input_fixture(tmp_path)
+    entry = next(entry for entry in materialized["dispatches"] if entry["dispatch"].get("mode") == "synthesis")
+    assert entry["dispatch"]["owned_paths"] == []
+    payload = {
+        "status": "no-findings",
+        "commands_executed": [],
+        "command_policy_attested": True,
+        "files_inspected": [],
+        "nearby_contract_owners": [],
+        "findings": [],
+        "validation_requirements": [],
+        "handoffs": [],
+        "changes": [],
+        "limitations": [],
+        "scope_limitations": [],
+    }
+    candidate = Path(entry["worker_payload_candidate_path"])
+    candidate.write_text(json.dumps(payload), encoding="utf-8")
+    persist_worker_payload(json.loads(Path(entry["worker_payload_contract_path"]).read_text()), candidate)
+    dispatch = {**entry["dispatch"], "before_state": materialized["source_state"], "after_state": materialized["source_state"]}
+    content, metadata = compile_review({"dispatch": dispatch, "payload": json.loads(Path(entry["worker_payload_path"]).read_text())})
+    assert metadata["normalized_record"]["files_inspected"] == []
+    assert metadata["evidence"]["predecessor_evidence_ids"] == tuple(dispatch["predecessor_evidence_ids"])
+    assert b"bundle-only synthesis" in content
+
+
+def test_synthesis_bundle_binds_compact_routing_and_validation_closure(tmp_path: Path) -> None:
+    plan, sources = _compile_materialized_evidence(tmp_path)
+    bundle = build_synthesis_bundle({"plan": _json_plan(plan), "source_state": ["scope", "worktree", "repository"], "sources": sources})
+    context = bundle["plan_context"]
+    assert context["consulted_routers"] == list(plan.consulted_routers)
+    assert context["routing_catalog_closed"]
+    assert context["requirement_to_node"] == [list(item) for item in plan.requirement_to_node]
+    assert context["validation_evidence_mapping"] == [asdict(item) for item in plan.validation_evidence_mapping]
+    assert context["handoff_reconciliation"]["unresolved_handoff_ids"] == []
+    assert context["routing_exceptions"] == []
+    assert sum(context["routing_counts"].values()) == len(plan.routing_decisions)
+    changed = replace(plan, routing_completion_blockers=("newly deferred coverage",))
+    changed_bundle = build_synthesis_bundle({"plan": _json_plan(changed), "source_state": bundle["source_state"], "sources": sources})
+    assert changed_bundle["records"] == bundle["records"]
+    assert changed_bundle["bundle_digest"] != bundle["bundle_digest"]
+
+
+def test_plan_digest_keeps_existing_journals_compatible_without_validation_exclusions() -> None:
+    plan = _sparse_plan()
+    legacy = _json_plan(plan)
+    legacy.pop("validation_exclusions")
+    expected = "sha256:" + hashlib.sha256(json.dumps(legacy, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+    assert graph_plan_digest(plan) == expected
+    assert graph_plan_digest(_graph_plan(legacy)) == expected
+
+
+def test_journal_append_cli_supports_each_status_field_contract(tmp_path: Path) -> None:
+    plan, sources = _compile_materialized_evidence(tmp_path / "evidence")
+    source_by_node = _source_by_node(sources)
+    root = next(node for node in plan.actual_worker_nodes if not node.predecessors)
+    lifecycle_path = tmp_path / "lifecycle.json"
+    lifecycle_path.write_text(json.dumps({"plan": _json_plan(plan), "source_state": ["scope", "worktree", "repository"]}), encoding="utf-8")
+
+    started = tmp_path / "started.jsonl"
+    base = ["journal-append", "--input", str(lifecycle_path), "--node-id", root.node_id]
+    assert main([*base, "--journal", str(started), "--status", "in-flight"]) == 0
+    source = source_by_node[root.node_id]
+    assert (
+        main(
+            [
+                *base,
+                "--journal",
+                str(started),
+                "--status",
+                "accepted",
+                "--artifact",
+                source["artifact_path"],
+                "--metadata",
+                source["metadata_path"],
+                "--kind",
+                source["kind"],
+            ]
+        )
+        == 0
+    )
+    assert main([*base, "--journal", str(started), "--status", "invalidated", "--reason", "source state changed"]) == 0
+
+    blocked = tmp_path / "blocked.jsonl"
+    assert main([*base, "--journal", str(blocked), "--status", "blocked", "--reason", "required target unavailable"]) == 0
+
+    replanning = tmp_path / "replanning.jsonl"
+    assert main([*base, "--journal", str(replanning), "--status", "in-flight"]) == 0
+    assert main([*base, "--journal", str(replanning), "--status", "awaiting-replan", "--reason", "routing expanded"]) == 0
+
+
+def test_journal_append_help_publishes_status_field_matrix(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as raised:
+        main(["journal-append", "--help"])
+
+    assert raised.value.code == 0
+    help_text = capsys.readouterr().out
+    for status in ("in-flight", "accepted", "blocked", "invalidated", "awaiting-replan"):
+        assert status in help_text
+    assert "artifact and metadata required" in help_text
+    assert "reason required" in help_text
+
+
+@pytest.mark.parametrize(
+    ("status", "extra", "message"),
+    [
+        ("in-flight", ["--reason", "not allowed"], "in-flight journal event forbids --reason"),
+        ("accepted", [], "accepted journal event requires --artifact and --metadata"),
+        ("blocked", [], "blocked journal event requires --reason"),
+        ("invalidated", [], "invalidated journal event requires --reason"),
+        ("awaiting-replan", [], "awaiting-replan journal event requires --reason"),
+    ],
+)
+def test_journal_append_cli_rejects_status_field_contract_violations(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], status: str, extra: list[str], message: str
+) -> None:
+    plan = _sparse_plan()
+    root = next(node for node in plan.actual_worker_nodes if not node.predecessors)
+    lifecycle_path = tmp_path / "lifecycle.json"
+    lifecycle_path.write_text(json.dumps({"plan": _json_plan(plan), "source_state": ["scope", "worktree", "repository"]}), encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "journal-append",
+                "--input",
+                str(lifecycle_path),
+                "--journal",
+                str(tmp_path / "execution.jsonl"),
+                "--node-id",
+                root.node_id,
+                "--status",
+                status,
+                *extra,
+            ]
+        )
+        == 2
+    )
+    assert message in capsys.readouterr().err
 
 
 def test_late_handoff_exact_reuse_replan_finalizes_complete_proof(tmp_path: Path) -> None:

--- a/agents/.agents/skills/scientific-citation-audit/references/doi-validation.md
+++ b/agents/.agents/skills/scientific-citation-audit/references/doi-validation.md
@@ -18,6 +18,12 @@ The script extracts DOI labels from Markdown, queries DOI content negotiation
 for CSL JSON metadata, and compares the resolved title with the surrounding
 bibliography entry. Use `--json` for machine-readable output.
 
+A badge-only paragraph reports `INSUFFICIENT_CONTEXT` when its DOI resolves:
+missing author/title/year context is not contradictory metadata. Compare the
+resolved identity with `CITATION.cff` or primary metadata. This outcome retains
+exit status 1 (manual verification needed), not a successful bibliographic match.
+Resolution failures remain `FAIL`; contradictory reference text remains `MISMATCH`.
+
 Network access is required. If the environment blocks network calls, request
 approval and explain that validation must query DOI, Crossref, or publisher
 metadata.

--- a/agents/.agents/skills/scientific-citation-audit/scripts/test_validate_reference_dois.py
+++ b/agents/.agents/skills/scientific-citation-audit/scripts/test_validate_reference_dois.py
@@ -4,9 +4,14 @@
 import contextlib
 import importlib.util
 import io
+import json
 import sys
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pytest
 
 SCRIPT = Path(__file__).with_name("validate_reference_dois.py")
 SPEC = importlib.util.spec_from_file_location("validate_reference_dois", SCRIPT)
@@ -110,6 +115,44 @@ def test_validation_reports_malformed_fetcher_response() -> None:
 
     assert result.status == MODULE.AuditStatus.FAIL
     assert result.message == "TypeError: DOI resolver response must be a JSON object"
+
+
+def test_resolved_badge_needs_context_instead_of_reporting_mismatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    path = tmp_path / "README.md"
+    path.write_text("# Project\n\n[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.123.svg)](https://doi.org/10.5281/zenodo.123)\n", encoding="utf-8")
+    original = MODULE.validate_entries
+    monkeypatch.setattr(
+        MODULE,
+        "validate_entries",
+        lambda entries, timeout, score: original(entries, timeout, score, lambda *_: metadata("Project", family="Author", year=2026)),
+    )
+    assert MODULE.run([str(path), "--json"]) == 1
+    result = json.loads(capsys.readouterr().out)[0]
+    assert result["status"] == "INSUFFICIENT_CONTEXT"
+    assert result["line"] == 3
+    assert result["resolved_title"] == "Project"
+    assert result["resolved_authors"] == ["Author"]
+    assert result["title_score"] is None
+    assert result["author_score"] is None
+    assert "no bibliographic context" in result["message"]
+
+
+def test_badge_does_not_hide_contradictory_bibliographic_context() -> None:
+    entry = MODULE.extract_entries("Wrong. Unrelated science. 2001.\n[![DOI](https://example.org/badge.svg)](https://doi.org/10.1234/test)")[0]
+    result = MODULE.validate_entry(entry, 1.0, 0.45, lambda *_: metadata("Actual title", year=2026))
+    assert result.status == MODULE.AuditStatus.MISMATCH
+
+
+def test_unresolved_badge_is_still_a_resolution_failure() -> None:
+    entry = MODULE.extract_entries("[![DOI](https://example.org/badge.svg)](https://doi.org/10.1234/test)")[0]
+
+    def unavailable(*_args: object) -> dict[str, object]:
+        message = "resolver unavailable"
+        raise TimeoutError(message)
+
+    assert MODULE.validate_entry(entry, 1.0, 0.45, unavailable).status == MODULE.AuditStatus.FAIL
 
 
 def test_empty_input_fails_without_allow_empty() -> None:

--- a/agents/.agents/skills/scientific-citation-audit/scripts/test_validate_reference_dois.py
+++ b/agents/.agents/skills/scientific-citation-audit/scripts/test_validate_reference_dois.py
@@ -8,10 +8,8 @@ import json
 import sys
 import tempfile
 from pathlib import Path
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    import pytest
+import pytest
 
 SCRIPT = Path(__file__).with_name("validate_reference_dois.py")
 SPEC = importlib.util.spec_from_file_location("validate_reference_dois", SCRIPT)
@@ -117,11 +115,12 @@ def test_validation_reports_malformed_fetcher_response() -> None:
     assert result.message == "TypeError: DOI resolver response must be a JSON object"
 
 
+@pytest.mark.parametrize("heading", ["# Project\n\n", "# Project\n", "### Project\n", "   ###### Project\n", "#\tProject\n", "#\n"])
 def test_resolved_badge_needs_context_instead_of_reporting_mismatch(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], heading: str
 ) -> None:
     path = tmp_path / "README.md"
-    path.write_text("# Project\n\n[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.123.svg)](https://doi.org/10.5281/zenodo.123)\n", encoding="utf-8")
+    path.write_text(f"{heading}[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.123.svg)](https://doi.org/10.5281/zenodo.123)\n", encoding="utf-8")
     original = MODULE.validate_entries
     monkeypatch.setattr(
         MODULE,
@@ -131,12 +130,19 @@ def test_resolved_badge_needs_context_instead_of_reporting_mismatch(
     assert MODULE.run([str(path), "--json"]) == 1
     result = json.loads(capsys.readouterr().out)[0]
     assert result["status"] == "INSUFFICIENT_CONTEXT"
-    assert result["line"] == 3
+    assert result["line"] == heading.count("\n") + 1
     assert result["resolved_title"] == "Project"
     assert result["resolved_authors"] == ["Author"]
     assert result["title_score"] is None
     assert result["author_score"] is None
     assert "no bibliographic context" in result["message"]
+
+
+def test_heading_after_badge_terminates_entry() -> None:
+    badge = "[![DOI](https://example.org/badge.svg)](https://doi.org/10.1234/test)"
+    entry = MODULE.extract_entries(f"{badge}\n## Unrelated section\nOther text.")[0]
+    assert entry.entry == badge
+    assert entry.badge_only
 
 
 def test_badge_does_not_hide_contradictory_bibliographic_context() -> None:

--- a/agents/.agents/skills/scientific-citation-audit/scripts/validate_reference_dois.py
+++ b/agents/.agents/skills/scientific-citation-audit/scripts/validate_reference_dois.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
 
 STOPWORDS = {"a", "an", "and", "are", "as", "by", "for", "from", "in", "into", "is", "it", "of", "on", "or", "the", "to", "using", "with"}
+_ENTRY_BOUNDARY = re.compile(r"^(?:\s*$| {0,3}#{1,6}(?:[ \t]|$))")
 
 
 class AuditStatus(StrEnum):
@@ -223,11 +224,11 @@ def trim_raw_url_doi(value: str) -> str:
 
 
 def collect_entry(lines: Sequence[str], doi_idx: int) -> str:
-    """Collect the current bibliography item around a DOI line."""
+    """Collect a bibliography item, stopping at blank lines or ATX headings."""
     start = doi_idx
     while start > 0:
         prev = lines[start - 1]
-        if not prev.strip():
+        if _ENTRY_BOUNDARY.match(prev):
             break
         if re.match(r"^\s*(?:[-*]|\d+\.)\s+", prev) and start - 1 != doi_idx:
             start -= 1
@@ -235,7 +236,7 @@ def collect_entry(lines: Sequence[str], doi_idx: int) -> str:
         start -= 1
 
     end = doi_idx + 1
-    while end < len(lines) and lines[end].strip():
+    while end < len(lines) and not _ENTRY_BOUNDARY.match(lines[end]):
         if re.match(r"^\s*(?:[-*]|\d+\.)\s+", lines[end]) and end > doi_idx + 1:
             break
         end += 1

--- a/agents/.agents/skills/scientific-citation-audit/scripts/validate_reference_dois.py
+++ b/agents/.agents/skills/scientific-citation-audit/scripts/validate_reference_dois.py
@@ -31,6 +31,7 @@ class AuditStatus(StrEnum):
 
     OK = "OK"
     MISMATCH = "MISMATCH"
+    INSUFFICIENT_CONTEXT = "INSUFFICIENT_CONTEXT"
     FAIL = "FAIL"
 
 
@@ -67,6 +68,7 @@ class DoiEntry:
     doi: Doi
     line: int
     entry: str
+    badge_only: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -158,7 +160,11 @@ def extract_entries(markdown: str) -> list[DoiEntry]:
             if key in seen:
                 continue
             seen.add(key)
-            entries.append(DoiEntry(doi=doi, line=idx + 1, entry=collect_entry(lines, idx)))
+            paragraph = collect_entry(lines, idx)
+            # Remove linked images, not ordinary citation links or their labels.
+            without_badges = re.sub(r"\[!\[[^\]]*\]\([^\n]*?\)\]\(https?://[^\s]+\)", "", paragraph)
+            badge_only = without_badges != paragraph and not re.search(r"\w", without_badges)
+            entries.append(DoiEntry(doi=doi, line=idx + 1, entry=paragraph, badge_only=badge_only))
 
     return entries
 
@@ -334,6 +340,20 @@ def validate_entry(entry: DoiEntry, timeout: float, min_title_score: float, fetc
             message=f"{type(exc).__name__}: {exc}",
         )
 
+    if entry.badge_only:
+        return DoiResult(
+            doi=entry.doi.value,
+            line=entry.line,
+            status=AuditStatus.INSUFFICIENT_CONTEXT,
+            title_score=None,
+            author_score=None,
+            resolved_title=metadata.title,
+            resolved_year=metadata.year,
+            resolved_container=metadata.container,
+            resolved_authors=metadata.author_families,
+            message="DOI resolves, but this badge supplies no bibliographic context; compare its identity with CITATION.cff or primary metadata",
+        )
+
     resolved_title_score = title_score(metadata.title, entry.entry)
     resolved_author_score = author_score(metadata.author_families, entry.entry)
     problems: list[str] = []
@@ -384,7 +404,7 @@ def print_text_report(results: Sequence[DoiResult]) -> None:
             f"{result.status.value}\tline={result.line}\t"
             f"title_score={title_score_text}\tauthor_score={author_score_text}\t"
             f"{result.doi}\t{result.resolved_year or '-'}\t"
-            f"{result.resolved_title or result.message}"
+            f"{result.resolved_title or '-'}\t{result.message}"
         )
 
 

--- a/justfile
+++ b/justfile
@@ -6,11 +6,11 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 export UV_CACHE_DIR := env_var_or_default("UV_CACHE_DIR", ".uv-cache")
 
 python_paths := "agents/.agents/skills scripts"
-dprint_version := "0.56.1"
+dprint_version := "0.57.0"
 just_version := "1.58.0"
-rumdl_version := "0.2.60"
-uv_version := "0.12.6"
-zizmor_version := "1.29.0"
+rumdl_version := "0.2.62"
+uv_version := "0.12.7"
+zizmor_version := "1.30.0"
 
 _ensure-actionlint:
     #!/usr/bin/env bash

--- a/uv.lock
+++ b/uv.lock
@@ -495,7 +495,7 @@ wheels = [
 
 [[package]]
 name = "jupyter-client"
-version = "8.9.1"
+version = "8.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-core" },
@@ -505,9 +505,9 @@ dependencies = [
     { name = "traitlets" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/dc/5512503b088997c2250b8bf18258fba9d9ce5ead641183700960d3c9d342/jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa", size = 359256, upload-time = "2026-06-09T13:15:01.033Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/2a/906772148a06e48885039e0250c340b770a55bbf37b08d6ee0449df369c3/jupyter_client-8.10.0.tar.gz", hash = "sha256:9f7116294dca55f1785be880057d44544db9b1567718d92cb33c58886afb9497", size = 360653, upload-time = "2026-08-28T12:17:10.854Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/6f/56d39bf385c5c27988aebaf0c18a2a17e960575740100973511018bd904e/jupyter_client-8.9.1-py3-none-any.whl", hash = "sha256:0b7a295bc46e8751e9adae84781f726c851c1d911bd793edc4a3bde942e3da81", size = 109828, upload-time = "2026-06-09T13:14:58.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/88/7c548de1f6c2ade7c931a3282da73f9274fa6a1531091be682f89c85efb9/jupyter_client-8.10.0-py3-none-any.whl", hash = "sha256:5f73f24f22fa25192cfff6b23c051932a2473a797b05734aff495b392103e14e", size = 110184, upload-time = "2026-08-28T12:17:09.028Z" },
 ]
 
 [[package]]
@@ -763,11 +763,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.4"
+version = "4.11.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/50/bb/ebc6636e1ae41314f796ebb7215fd28febb45f9aac72f2b04cb74b5071dc/platformdirs-4.11.4.tar.gz", hash = "sha256:f3373be828247211d0febabea97e238c3dfde8a60b3c90c32756fb52cb21556d", size = 34079, upload-time = "2026-08-24T14:53:49.676Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/06/cf1564dcc2e2261c8c8c6c05628dc8b418943bdae2a4e58640ceb2f770fa/platformdirs-4.11.5.tar.gz", hash = "sha256:e8b31f4f8bcbbedef91a6b57a706255e4f148d2a4e01648382a0a47342539173", size = 34823, upload-time = "2026-08-27T21:36:37.46Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/be/0ff05fcd2938fb58ad9219bd54135968342d214737e012d62d43f06a2dd6/platformdirs-4.11.4-py3-none-any.whl", hash = "sha256:e34ff91a24bcddc6d939b878bdf3f5c437c9c46fe9e212b1bf455fdf1ee57586", size = 23741, upload-time = "2026-08-24T14:53:48.406Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/12/6f3fcd5067a9cbf4f8664b32957973498da8b083455203c8d9cab83a725c/platformdirs-4.11.5-py3-none-any.whl", hash = "sha256:89f8d42695853b89c7170bd49bc3dc593f98a71e695ede88e06a3b247bc4563b", size = 23900, upload-time = "2026-08-27T21:36:36.227Z" },
 ]
 
 [[package]]
@@ -805,7 +805,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.13.4"
+version = "2.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -813,50 +813,50 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/ef/fc4f868f4e2cee79f863883abffceff107875f569b848507319842d2a681/pydantic-2.13.5.tar.gz", hash = "sha256:51a9c5f7b2f8e636f04c6cada605d9b6a3bf1348fdf945a3d8869b19bba0ee08", size = 845750, upload-time = "2026-08-28T14:04:00.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/47/c95ffc2009878c7aac0c5e08528022dcb885933252a88b5f170058014464/pydantic-2.13.5-py3-none-any.whl", hash = "sha256:346a034f080da3755d8e9cb5e00e8b07de1d39e4f6e2c87d8ab7cafa0b269a73", size = 472589, upload-time = "2026-08-28T14:03:59.136Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.46.4"
+version = "2.46.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/f9/8a06bea35ef8daf588f707784c973a7046e0034c8d8cfb08828eeffb8b75/pydantic_core-2.46.5.tar.gz", hash = "sha256:10416c15b8839ecc4ef4d0885da76da6fd0f67333a0eb8aff6d93c4b8f2910fc", size = 472262, upload-time = "2026-08-28T10:01:31.677Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
-    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
-    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
-    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
-    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
-    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
-    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
-    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
-    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
-    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
-    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
-    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
-    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
-    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
-    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
-    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8a/14596f2a8367da50cf7cbac48169ee5d9c8e11d486a3b527082384630c72/pydantic_core-2.46.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c1c43ad4339643d70ebb8124e1305a7dab423001eff58bb41a0f731adbc98355", size = 2074081, upload-time = "2026-08-28T09:59:16.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d5/d8a4eb6d6c7f66b91dd37c576d76e9e60fba900caf5372c17bcf949febc2/pydantic_core-2.46.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1a353f84de772f423b5ffb11d7ae352fbbef0f446f3c0b0af0f8236d7233606e", size = 1920497, upload-time = "2026-08-28T09:59:18.065Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/26/092079428f86e927e030b2c0ced87df69dbb1c875cdeaa67bf42ea2be746/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5086029a57366b8cf81b130a43908738095c270c21a8d7f0e8bdfdb89718e2f3", size = 1952130, upload-time = "2026-08-28T09:59:20.476Z" },
+    { url = "https://files.pythonhosted.org/packages/08/c3/8ec0e290a9ebaebd64047bf5fda94be835c6b1551b02437e4b76778fbcd7/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46c25dda9d092a06c08db76ffe0a197107904d0dfac653f7d5306bbcd6d6119c", size = 2026371, upload-time = "2026-08-28T09:59:22.227Z" },
+    { url = "https://files.pythonhosted.org/packages/01/72/4fd20ad520fb8da0157f95b27a7eb05a72790ef08138e7701ac972c342ea/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:37ea7b83c935e5b0d68c9449b82651accf78a10828b2c02b2f2d9e9496446c21", size = 2202822, upload-time = "2026-08-28T09:59:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b0/d16e0771206b29314f0d52198b720be21e8a99ab2bf11e3bc0d7c9cebdff/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e64e88d5585bea9ce95861079de72006c7fa6d3df4e3a3b65ba31eb979c15c9f", size = 2262756, upload-time = "2026-08-28T09:59:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9b/59634b7ac631c63b2a37760eb6943af3e29573d6b59a4abc5e7f019d4cee/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d510bac3ee52247af28ed4bb18a1e799f040ac60fd2bf5ccd4c92f1fbe786f", size = 2068352, upload-time = "2026-08-28T09:59:29.044Z" },
+    { url = "https://files.pythonhosted.org/packages/08/7c/570abb1ad2155348dc754ea91be22e5aaa18eb6d69a6068f7c6f2679a6ed/pydantic_core-2.46.5-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:a2a5e1d0ff29adddc9f6d6821a66302e4493f8ca898b715b6b1182c2c201ea0a", size = 2104777, upload-time = "2026-08-28T09:59:30.95Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/25/5bf74adc65a1ac5b7be3f6cb0bcb5433615c1598a801c19d830d84c98ded/pydantic_core-2.46.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:03b9666e41e35d8909852ba191a0607520f81b74eaf12ccf8737005dbb313821", size = 2156312, upload-time = "2026-08-28T09:59:32.604Z" },
+    { url = "https://files.pythonhosted.org/packages/90/6a/2ef38830675e050121040618135564ed56b860b45433b02d9b4ebece46f3/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:a91c17edf6eea2402cb5457b4c89e99bc5ed1004aa34c4adf1d4258c1a5c22c2", size = 2150067, upload-time = "2026-08-28T09:59:34.453Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/a7dbb03a14a64c2a4621f989c615ed9a892535a6cad938fc27079f919d80/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b49924c73a235e969511bf2aabdff3beebf9820931f646c80274d5d780010c47", size = 2304516, upload-time = "2026-08-28T09:59:36.194Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f8/6bb4c4b80e8a6fde1904c64a51c62a1d04fcdfa3ea521a66b2ddefa1d885/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:2cbd9a5eff05e51c447c34dfa4632145b26b09120cf04bd0c871e44c1a5e1c9a", size = 2335223, upload-time = "2026-08-28T09:59:37.931Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/80/f46b8c681195190b2c1f1c7c0a81abce60663e987613e09ef64d433dd96b/pydantic_core-2.46.5-cp314-cp314-win32.whl", hash = "sha256:2d5d76654becf5efd62c9e51c3756c67b49498b0c9a40884934c40807adbd074", size = 1934827, upload-time = "2026-08-28T09:59:39.836Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/3c/60674207246bc0a4009d2391b7c7251c7159f279c8d2ab8aae8ef46f3dee/pydantic_core-2.46.5-cp314-cp314-win_amd64.whl", hash = "sha256:fa10ef4112775900e7a0661068635eb67b2ab824fbde764de6e0e21982a93db0", size = 2042648, upload-time = "2026-08-28T09:59:41.792Z" },
+    { url = "https://files.pythonhosted.org/packages/69/0c/117c562c7c1babdf44576b72a5e496906506c93690387ecfbca7c729ae2e/pydantic_core-2.46.5-cp314-cp314-win_arm64.whl", hash = "sha256:045ab3b6d308439e32b81cc173bba5b9018bc6ed896afd0c65b3b009b1699af5", size = 1989652, upload-time = "2026-08-28T09:59:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/66/9336ae58f9eb68c41d121894e52c4c89eccb07eb8f602a04ee9c3f37736a/pydantic_core-2.46.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8816f3d218beb4b787de5c9759c259b8fa61f9dec42dc7811f320a33771778b7", size = 2065829, upload-time = "2026-08-28T09:59:45.364Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/02/bc19b47a96c2d3109760711acf22369e56bd7e405ca52f7ade164d2ead57/pydantic_core-2.46.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bce57638e08ac148e5778cce7feb968307a727d66f8e2274a543d0cf0c9ad6a3", size = 1905716, upload-time = "2026-08-28T09:59:47.18Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a4/70b47c0509923dd98ccfed04fb3e32ea3849c82a0ff2205bb41009b43c00/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:976e1128455aa595ea04c79ccfedff1aaeab96ee013fcc916bed120c4f0ad94f", size = 1934216, upload-time = "2026-08-28T09:59:49.241Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ab/aa03b65f7bb198585edf806b906c3223ecf1795543e39e23aec4cce27ad2/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b891faeedeafba41b2983e5001a81b6a915b69544c7e7570d1989ce1c36ac7", size = 2010635, upload-time = "2026-08-28T09:59:51.692Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/8b/0da06343f30b84ec549aafd309c6456223d5dc8bd36af504c573faad561d/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f194189415698233dd1114a093a9b56e61e2c57e11b469be3b0506f46f0771c", size = 2209369, upload-time = "2026-08-28T09:59:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/844c4defaa34a3df66eb9257087d121d70c201298b96abdf9f492fc2f1bf/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82a36973cf8a2ef5406f4fe2edbf8ed0c99629535d959e0b100c76a32535a111", size = 2253238, upload-time = "2026-08-28T09:59:55.484Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/64/a4e536cb16d7f61a7fd3120b46c577fc7fa7325992f69c4f52bc786d77d8/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdbb78909f52b981d3b2d56b97328d71eb0b974c36bd77c920123a7ebb192829", size = 2065740, upload-time = "2026-08-28T09:59:58.038Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/75/aaa38c6bc2d085f6605b34eabdc6a8a4e0b2e61fc9c8e6e52b28e97b3125/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:52e24eacdb536cade636aa90fb851835222becff8484b7001fdc78cb0290f2aa", size = 2087425, upload-time = "2026-08-28T09:59:59.898Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ae/fcab4cfc39aba3689e1d20c8b5250ad280957022c09af2ed9cd585602a5e/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:37ae34309d7bd8c0d61ab839668058f2a7962ea1fc51d105d2db228fe0618034", size = 2139306, upload-time = "2026-08-28T10:00:03.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f4/f1d03a4bc9d9acbc62f4d742b8a319af52f71885079868b2ff8e48a651ee/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:0cdbada856a1c69a7624a64d3d9aefe79300bd6ef827b43a4f265010b9b55184", size = 2144589, upload-time = "2026-08-28T10:00:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f3/7a53bb1356de514a4cd295f25b6ac39237895620c0462d2592b76c16e114/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:545f26c504b27c3758439a5e6d9349931f0a04f855668d5fe323c89e82300a38", size = 2288882, upload-time = "2026-08-28T10:00:07.931Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/94/5a81583660c175c59d49ffb09f4b3a44debeaf86a19fca664ae1cdd9ee32/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:ff218293c9c806138dca139765e3b067621be52bcd93cdc14c7711be7ddc90a9", size = 2335210, upload-time = "2026-08-28T10:00:10.177Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9f/5d685c2693b972d1a59c998586e8823712b66603aeff47ee60a4bdaafd37/pydantic_core-2.46.5-cp314-cp314t-win32.whl", hash = "sha256:97cf3eb53a8cccacf9d46686a0926186c9bfb5574f2ed66d3639d5fe117cd3a9", size = 1921180, upload-time = "2026-08-28T10:00:12.35Z" },
+    { url = "https://files.pythonhosted.org/packages/70/12/5c94ee16d65a37a15f9e869f5e6256df111154491173801a4c5e800ab548/pydantic_core-2.46.5-cp314-cp314t-win_amd64.whl", hash = "sha256:d2f9fc07a8042a8f95925b35c4f04f469707c981fc33245b6ca187cf5d2dd290", size = 2020515, upload-time = "2026-08-28T10:00:14.774Z" },
+    { url = "https://files.pythonhosted.org/packages/63/19/67830dda664e6bdf9285ee2e40f355d0d7d6b92aa0c42e8d217bb8d33d36/pydantic_core-2.46.5-cp314-cp314t-win_arm64.whl", hash = "sha256:acf8a67ba51f4ca9ddbd0e6b3000a65ac51ab734661778b3e7ba64d99a710f2f", size = 1989276, upload-time = "2026-08-28T10:00:16.984Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Reuse verified unchanged audits and invalidate changed dependencies
- Require owned-scope coverage and route canonical citation sources
- Reconcile late validation requirements before synthesis and finalization
- Make worker handoffs self-contained and bind synthesis to plan context
- Report badge-only DOIs as insufficient context rather than mismatches
- Refresh development tool pins and locked dependencies

Closes #41 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added validation-requirement reconciliation and late-stage validation updates.
  - Added safer review evidence reuse for unchanged repository inputs.
  - Added source snapshots, audit lineage, scope limitations, and worker-input tracking.
  - Added coordinator fallback when worker creation cannot proceed.
  - Expanded citation and bibliography routing coverage.

- **Bug Fixes**
  - Improved detection of repository changes, renames, deletions, and permission updates.
  - DOI badges lacking context now receive clearer diagnostics.
  - Strengthened protection against stale, incomplete, or tampered review artifacts.

- **Documentation**
  - Expanded guidance and examples for validation, audit reuse, citations, and runtime operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->