### PR TITLE
fix(skills): distinguish native from emulated validation evidence

### DIFF
--- a/agents/.agents/skills/project-tooling-review/references/github-actions.md
+++ b/agents/.agents/skills/project-tooling-review/references/github-actions.md
@@ -13,6 +13,19 @@ Use this reference for `.github/workflows/**`, reusable workflow calls, Actions-
 - Caches should key on lockfiles and toolchain files, not only broad branch names. Cache restore should not hide dependency drift.
 - Artifacts should have clear names, bounded retention, and no secrets or oversized generated clutter.
 
+## Native Matrix Evidence
+
+Treat a configured CI matrix, a local aggregate recipe, native platform jobs,
+and platform-boundary emulation as different evidence. Record the actual host
+for every executed check; never summarize a successful local command as proof
+that unexecuted native jobs passed.
+
+When relevant native CI for the reviewed source state is available, reconcile
+its result before reporting the tooling change as fully validated. A native
+failure remains failed evidence until the defect is corrected and current
+native evidence passes. Do not weaken the regression, remove the supported
+matrix cell, or add a skip merely to make the workflow green.
+
 ## Version And Pinning Checks
 
 - Verify action versions against live releases when the user asks for currentness or when changing versions. Do not rely on model memory for latest action versions.

--- a/agents/.agents/skills/project-tooling-review/references/standalone-workflow.md
+++ b/agents/.agents/skills/project-tooling-review/references/standalone-workflow.md
@@ -45,6 +45,8 @@ approval, use the strongest read-only local check and report the remaining gap.
 
 Lead with unresolved tooling risks. Then report files changed and why, surfaces
 reviewed, references loaded, parent-handoff evidence, validators and results,
+the actual platform for each native or emulated check, unexecuted matrix cells,
 live or local-only version checks, managed tool updates and before/after
 versions, pins reconciled, language-orchestrator handoffs, deferred work, and
-git-state status.
+git-state status. Reconcile any available native CI result for the reviewed
+source state instead of presenting a narrower local pass as matrix coverage.

--- a/agents/.agents/skills/python-production-review/SKILL.md
+++ b/agents/.agents/skills/python-production-review/SKILL.md
@@ -111,6 +111,13 @@ nondeterminism diagnosis. Do not run full CI solely because this is the final
 pass; follow repository requirements and escalate only when narrower
 non-overlapping coverage is insufficient.
 
+Key platform entries by the actual executor and distinguish native runs from
+focused emulation. Emulated boundary coverage cannot satisfy a native platform
+configuration, and unexecuted matrix cells remain limitations. If available
+native CI for the same source state fails after local or modeled checks passed,
+preserve the contradiction as a readiness blocker until the defect is fixed
+and current native evidence is reconciled.
+
 ## Output
 
 In orchestrated mode, synthesize specialist outcomes, remove duplicate findings, identify cross-cutting blockers, and name residual risk. In standalone mode, lead with findings ordered by severity and list focused skills or checklist sections used. Always report validation performed, reused ledger evidence, and meaningful limitations.

--- a/agents/.agents/skills/python-support-scripts/SKILL.md
+++ b/agents/.agents/skills/python-support-scripts/SKILL.md
@@ -58,6 +58,9 @@ Keep absolute paths, usernames, temporary roots, process IDs, nondeterministic h
 
 Use argument arrays rather than interpolated shells. Check return status, preserve stderr/stdout context, set a timeout when a hang can block automation, and pass deterministic environment values when output is parsed.
 
+For byte-sensitive or platform-dependent transport, read
+[platform subprocess evidence](references/platform-subprocess-evidence.md).
+
 Do not log tokens, signing material, GitHub credentials, or private payloads. Distinguish command absence, timeout, nonzero exit, malformed output, and empty-but-valid output when callers need different actions.
 
 Avoid catching `CalledProcessError` only to discard its command and diagnostics. Keep publish, upload, tag, or release effects behind explicit intent and dry-run support where appropriate.

--- a/agents/.agents/skills/python-support-scripts/references/platform-subprocess-evidence.md
+++ b/agents/.agents/skills/python-support-scripts/references/platform-subprocess-evidence.md
@@ -1,0 +1,27 @@
+# Platform Subprocess Evidence
+
+Read this reference when support-script behavior depends on byte-sensitive or
+platform-dependent subprocess transport.
+
+## Transport Boundary
+
+Make text versus binary transport deliberate at every subprocess boundary. If
+the consumer's contract is byte-sensitive, send bytes without text-mode
+translation and verify the bytes the child consumed against a literal fixture
+or independently computed digest. A tool option that controls its own newline
+or checkout behavior does not disable transformations performed earlier by the
+host runtime, pipe, locale, or encoding layer.
+
+For platform-dependent transport, separate a native run on the target platform
+from a focused model or emulation of the transformation. Emulation is useful
+for deterministic regression coverage but proves only the modeled boundary;
+report the actual host and leave the native matrix cell unverified until it
+runs there.
+
+## Regression Sensitivity
+
+Demonstrate sensitivity to the original behavior: the new case must fail
+against the unfixed implementation or an exact isolated copy of its defective
+boundary and pass after the correction. Do not weaken the assertion, skip the
+test, or remove a supported platform cell when native CI exposes a missed
+boundary.

--- a/agents/.agents/skills/python-test-quality/SKILL.md
+++ b/agents/.agents/skills/python-test-quality/SKILL.md
@@ -70,6 +70,9 @@ When relevant, test cancellation, timeout, shutdown, worker exceptions, backpres
 
 For subprocess code, distinguish command-not-found, timeout, nonzero exit, malformed output, and successful empty output. Assert the resulting diagnostic without leaking secrets.
 
+For platform-sensitive or byte-sensitive subprocess regressions, read
+[platform regression evidence](references/platform-regression-evidence.md).
+
 ## Packaging And Configuration Evidence
 
 When build or install behavior is the contract, test built artifacts rather than only in-tree imports. Cover the minimal supported Python/platform/extra/configuration combinations that distinguish behavior, external entry points, package data, optional imports, and installed consumers.

--- a/agents/.agents/skills/python-test-quality/references/platform-regression-evidence.md
+++ b/agents/.agents/skills/python-test-quality/references/platform-regression-evidence.md
@@ -1,0 +1,32 @@
+# Platform Regression Evidence
+
+Read this reference when test confidence depends on an operating-system,
+runtime, or byte-transport boundary.
+
+## Exercise The Owning Boundary
+
+Exercise the actual boundary rather than only a related application or tool
+setting. For byte-sensitive stdin, stdout, files, hashes, signatures, or
+archives, derive expected bytes independently from the production transform and
+compare literal bytes or their independently computed digests. Cover text-mode
+translation, encoding, and newline composition when reachable; do not assume a
+downstream tool option controls earlier runtime or pipe conversion.
+
+## Prove Regression Sensitivity
+
+Include durable focused coverage and a sensitivity check showing, through an
+isolated copy or controlled fault injection, that the case fails with the
+original behavior and passes with the fix. Keep captured source unchanged.
+
+Label evidence as a native target-platform run, a model or emulation executed
+on the actual host, or an unexecuted matrix cell. Emulation can prove the modeled
+transformation but cannot establish native platform portability.
+
+## Reconcile Native Evidence
+
+Do not infer a platform pass from matrix configuration, a successful local
+aggregate command, or emulation. When native CI contradicts earlier local or
+modeled evidence, preserve the failure, strengthen the regression at the missed
+boundary, and require current native evidence before restoring the portability
+claim. Do not weaken or skip the regression or remove a supported platform cell
+merely to make the matrix green.

--- a/agents/.agents/skills/python-test-quality/references/standalone-workflow.md
+++ b/agents/.agents/skills/python-test-quality/references/standalone-workflow.md
@@ -14,6 +14,10 @@ Maintain a ledger keyed by source and environment state, built artifact, Python
 version, platform, dependency/configuration set, instrumentation, and exact
 test selection. Inspect repository recipes before execution, decide whether
 policy or scope requires an indivisible full gate, and reuse valid evidence.
+Record the actual executor platform separately from any target platform and
+classify each result as native execution or focused emulation. An unexecuted
+target cell remains a gap even when its workflow is configured or its boundary
+has been modeled elsewhere.
 
 Choose the smallest single selection proving the touched risk. Do not run a
 named case followed by its class, module, suite, and full CI as successive
@@ -39,4 +43,5 @@ Classify the result as `PASS`, `NEEDS IMPROVEMENT`, or `FAIL`. Order findings
 by behavioral risk. Identify the unproven contract, why current evidence can
 pass incorrectly, and a concrete Given/When/Then scenario or property. Report
 the non-overlapping ledger, seeds or counterexamples, skipped environments,
-justified reruns, independent reproduction, and other limitations.
+justified reruns, independent reproduction, native versus emulated platform
+evidence, unexecuted matrix cells, and other limitations.

--- a/agents/.agents/skills/repository-production-review/SKILL.md
+++ b/agents/.agents/skills/repository-production-review/SKILL.md
@@ -37,8 +37,15 @@ an unresolved applicability handoff. Never infer that omitted work passed.
    `remaining`, `accepted-risk`, or `blocked`.
 5. Treat validator failures as evidence until an owning reviewer diagnoses
    them; do not manufacture findings from command output.
-6. Require accepted independent review for a concrete change target.
-7. Classify production readiness only after all required evidence and
+6. Preserve platform provenance: actual native executor, focused emulation, and
+   unexecuted matrix cells are distinct evidence. Never promote local or
+   emulated success into a native-platform pass.
+7. When available native CI for the reviewed source state contradicts earlier
+   local or emulated evidence, keep the native failure and resulting gap visible
+   until owning review and current native validation reconcile it. Do not infer
+   readiness from a configured matrix or a narrower successful aggregate run.
+8. Require accepted independent review for a concrete change target.
+9. Classify production readiness only after all required evidence and
    fingerprints reconcile.
 
 ## Result Contract
@@ -49,9 +56,11 @@ Return:
 - `Routing Closure`: consulted routers, exhaustive-ledger status, exclusions,
   reuse, and unresolved handoffs
 - `Canonical Findings`: severity, owner, evidence, duplicates, and disposition
-- `Validation Reconciliation`: each requirement and its accepted validator or
-  exact reuse evidence
-- `Cross-Surface Risks`: conflicts, shared-file ownership, and residual gaps
+- `Validation Reconciliation`: each requirement, actual executor platform,
+  native or emulated mode, unexecuted cells, and its accepted validator or exact
+  reuse evidence
+- `Cross-Surface Risks`: conflicts, shared-file ownership, contradictory native
+  CI, and residual gaps
 - `Repository Verdict`: `ready`, `not-ready`, or `blocked`, with exact reasons
 
 Do not create subagents or recursively invoke `review-graph`.

--- a/agents/.agents/skills/review-graph/references/report-contract.md
+++ b/agents/.agents/skills/review-graph/references/report-contract.md
@@ -64,16 +64,27 @@ that no files were changed.
 ### Validation
 
 List each unique command or canonical recipe once with requirement IDs and
-result. Distinguish execution from exact reuse. Failed or blocked validation
-remains evidence, not an automatically promoted finding.
+result. For every platform-sensitive result, name the actual executor platform
+and runtime and distinguish a native target-platform run from focused emulation.
+List unexecuted matrix cells explicitly; neither configured CI nor a successful
+local aggregate command proves those cells. Distinguish execution from exact
+reuse. Failed or blocked validation remains evidence, not an automatically
+promoted finding.
 Report `repository_validation_status` independently from
 `graph_proof_status`; a command failure and an orchestration-proof gap are
 different outcomes.
 
+When native CI for the reviewed source state becomes available and contradicts
+earlier local or emulated evidence, report the native failure and the resulting
+portability gap until a corrected revision has current native evidence. Do not
+describe the change as fully validated, weaken the regression, or omit the
+supported platform merely to make the matrix green.
+
 ### Coverage And Limitations
 
 Name selected skills, explicit exclusions, blocked or stale requirements,
-unresolved handoffs, untested configurations, and remaining risks. Omit routine
+unresolved handoffs, untested configurations, emulation boundaries, unexecuted
+native matrix cells, and remaining risks. Omit routine
 `not-applicable` candidates; their exhaustive records remain in the proof
 store.
 For independent review, distinguish structurally accepted evidence from

--- a/agents/.agents/skills/review-validator/SKILL.md
+++ b/agents/.agents/skills/review-validator/SKILL.md
@@ -40,6 +40,8 @@ the runtime-owned `persist-worker-payload` operation, and return those bytes.
   configuration to make a command pass.
 - Reuse evidence only when source, command, environment, configuration,
   selection, and artifact identity match exactly.
+- Bind evidence to the actual executor; emulation never proves an unexecuted
+  native matrix cell.
 - A failed command is validation evidence, not automatically a product finding.
 
 ## Status

--- a/agents/.agents/skills/review-validator/references/graph-dispatch.md
+++ b/agents/.agents/skills/review-validator/references/graph-dispatch.md
@@ -14,8 +14,8 @@ Require:
 - execution location and fresh-context identity
 - exact commands, corresponding working directories, environment, toolchain,
   features, platform naming the actual executor, artifact owner, and mutation
-  lock; target-platform emulation must be distinct in the supplied
-  environment, features, target, or expected evidence
+  lock; encode the target platform and native/emulated mode in the
+  digest-covered environment or features rather than only in narrative evidence
 - approved artifacts with status provenance; exact effects, absolute isolation
   root, and runtime snapshot policy
 - recursive required payload shape and the exact worker payload path

--- a/agents/.agents/skills/review-validator/references/graph-dispatch.md
+++ b/agents/.agents/skills/review-validator/references/graph-dispatch.md
@@ -13,7 +13,9 @@ Require:
 - exact state-verification command
 - execution location and fresh-context identity
 - exact commands, corresponding working directories, environment, toolchain,
-  features, platform, artifact owner, and mutation lock
+  features, platform naming the actual executor, artifact owner, and mutation
+  lock; target-platform emulation must be distinct in the supplied
+  environment, features, target, or expected evidence
 - approved artifacts with status provenance; exact effects, absolute isolation
   root, and runtime snapshot policy
 - recursive required payload shape and the exact worker payload path
@@ -32,7 +34,9 @@ discovery.
    `continue-independent`. Isolated working directories and external artifacts
    must remain beneath the dispatched isolation root.
 4. Record command, working directory, executor, result, exit code, elapsed time,
-   concise output evidence, and approved artifact paths.
+   concise output evidence, actual platform and native/emulated mode, and
+   approved artifact paths. Put unexecuted target cells and the boundary of any
+   emulation in `limitations`.
 5. Repeat the source-state check. Complete the payload, including `exit_code`,
    `elapsed`, and `artifact_paths` for every execution. Write its exact bytes to
    the dispatched candidate path, invoke the runtime-owned
@@ -42,6 +46,10 @@ discovery.
    post-execution snapshot immediately afterward.
 
 Do not report artifact digests, snapshots, fingerprints, or compiler identities.
+
+A successful command proves only the dispatched execution environment. Do not
+describe a local aggregate run or focused emulation as native evidence for a
+different platform.
 
 Do not review code, diagnose findings, edit, install substitute toolchains,
 change dependencies, re-plan, or create another worker.

--- a/agents/.agents/skills/review-validator/references/result-contract.md
+++ b/agents/.agents/skills/review-validator/references/result-contract.md
@@ -66,21 +66,24 @@ repository_state_fingerprint: content digest covering HEAD, branch, index,
 state_verification_command: exact read-only command that recomputes all three digests
 requirement_ids: exact validation requirements owned by this unit
 unit_coalescing_basis: source state, command or canonical recipe, working
-  directories, environment/toolchain, features, platform, artifact ownership,
-  and mutation/locking compatibility shared by those requirements
+  directories, environment/toolchain, features, actual executor platform,
+  target platform, native/emulated mode, artifact ownership, and
+  mutation/locking compatibility shared by those requirements
 requirement_evidence_mapping: every requirement ID mapped to this unit and its
   exact candidate ledger entry or none
 commands: ordered exact commands, including arguments
 working_directories: one exact directory for each command
 environment_configuration: toolchain, actual executor platform and runtime,
-  features, target, dependency, instrumentation, service, and relevant
-  environment identity; target-platform emulation must be distinguished in the
-  existing configuration or expected evidence, and an unexecuted target remains
-  a limitation rather than an execution
+  target platform, native or emulated mode, features, target, dependency,
+  instrumentation, service, and relevant environment identity; encode target
+  platform and mode in the digest-covered environment or features, and leave an
+  unexecuted target as a limitation rather than an execution
 command_identity_digest: canonical SHA-256 digest of the exact commands,
   corresponding working directories, and canonical recipe
 environment_digest: canonical SHA-256 digest of the environment, toolchain,
-  features, platform, artifact owner, and mutation/locking identity
+  features, actual executor platform, artifact owner, and mutation/locking
+  identity; environment or features carry target platform and native/emulated
+  mode
 command_mutation_classification: non-mutating, with exact definition or policy basis
 expected_evidence: what successful execution must demonstrate
 dependency_policy: stop-on-failure | continue-independent
@@ -109,6 +112,11 @@ serialize in this order: `allowed_artifacts`, `artifact_owner`, `environment`,
 `allowed_artifacts` is one object whose fields serialize in this order:
 `artifact_digest`, `artifact_digest_mode`, `artifact_id`, `kind`, `path`,
 `repository_status`, `status_rule`, and `status_source`.
+
+Encode target platform and native/emulated mode in `environment` or `features`
+before computing this digest. `expected_evidence` and other narrative fields may
+explain that boundary but cannot be its only identity because they are not part
+of the canonical environment digest.
 
 Sort object keys lexicographically at every level; preserve array element
 order; serialize tuples as JSON arrays and absent optional values as JSON
@@ -177,7 +185,9 @@ Return every heading, using `none` when a section has no entries.
 - Command identity digest: <canonical digest from the exact dispatched commands,
   working directories, and canonical recipe>
 - Environment digest: <canonical digest from the exact dispatched environment,
-  toolchain, features, platform, artifact owner, and mutation/locking identity>
+  toolchain, features, actual executor platform, artifact owner, and
+  mutation/locking identity, with target platform and native/emulated mode
+  encoded in environment or features>
 - Requirement-to-evidence mapping:
   - <requirement-id>: <this unit and exact candidate ledger entry, or none>
 - Meaningful skips: <command and reason or none>
@@ -395,9 +405,10 @@ Accept a result only when:
   ownership, and mutation/locking compatibility; every requirement maps
   exactly once to this unit and any candidate evidence
 - environment and execution evidence identify the actual executor platform and
-  runtime; target-platform emulation is a distinct configuration, states the
-  modeled boundary under Limitations, and never satisfies or is reused for a
-  native target-platform requirement; unexecuted matrix cells remain explicit
+  runtime; target platform and native/emulated mode are encoded in the
+  digest-covered environment or features, emulation states its modeled boundary
+  under Limitations, and never satisfies or is reused for a native
+  target-platform requirement; unexecuted matrix cells remain explicit
 - command and environment digests use the canonical validation-dispatch
   serialization above over the exact coalesced dispatch fields, are repeated
   exactly in the result, and match the graph's independently derived

--- a/agents/.agents/skills/review-validator/references/result-contract.md
+++ b/agents/.agents/skills/review-validator/references/result-contract.md
@@ -72,8 +72,11 @@ requirement_evidence_mapping: every requirement ID mapped to this unit and its
   exact candidate ledger entry or none
 commands: ordered exact commands, including arguments
 working_directories: one exact directory for each command
-environment_configuration: toolchain, platform, features, target, dependency,
-  instrumentation, service, and relevant environment identity
+environment_configuration: toolchain, actual executor platform and runtime,
+  features, target, dependency, instrumentation, service, and relevant
+  environment identity; target-platform emulation must be distinguished in the
+  existing configuration or expected evidence, and an unexecuted target remains
+  a limitation rather than an execution
 command_identity_digest: canonical SHA-256 digest of the exact commands,
   corresponding working directories, and canonical recipe
 environment_digest: canonical SHA-256 digest of the environment, toolchain,
@@ -208,7 +211,8 @@ Return every heading, using `none` when a section has no entries.
   - Executor: <parent|subagent node-id>
   - Command: <exact command>
   - Working directory: <absolute path>
-  - Environment/configuration: <complete relevant identity>
+  - Environment/configuration: <complete relevant identity, including actual
+    executor platform/runtime and native or emulated evidence mode>
   - Result: <passed|failed|blocked|not-run>
   - Exit code: <integer|none>
   - Elapsed: <duration|none>
@@ -329,7 +333,9 @@ sample; it must never be interpreted as a content digest.
 
 ## Limitations
 
-<unavailable configurations, skipped dependent commands, stale evidence, or none>
+<unavailable or unexecuted configurations, boundaries modeled only by
+emulation, conflicting native evidence, skipped dependent commands, stale
+evidence, or none>
 
 ## Machine Evidence
 
@@ -388,6 +394,10 @@ Accept a result only when:
   working directories, environment/toolchain, features, platform, artifact
   ownership, and mutation/locking compatibility; every requirement maps
   exactly once to this unit and any candidate evidence
+- environment and execution evidence identify the actual executor platform and
+  runtime; target-platform emulation is a distinct configuration, states the
+  modeled boundary under Limitations, and never satisfies or is reused for a
+  native target-platform requirement; unexecuted matrix cells remain explicit
 - command and environment digests use the canonical validation-dispatch
   serialization above over the exact coalesced dispatch fields, are repeated
   exactly in the result, and match the graph's independently derived

--- a/agents/.agents/skills/review-validator/references/standalone-workflow.md
+++ b/agents/.agents/skills/review-validator/references/standalone-workflow.md
@@ -38,7 +38,8 @@ classification, dependency policy, approved artifacts, and elapsed bounds.
 Identify the actual executor platform and runtime separately from any target
 platform. Classify target-bound evidence as native execution, focused emulation,
 or unexecuted; emulation is a distinct configuration and cannot satisfy a
-native requirement.
+native requirement. Encode target platform and mode in the digest-covered
+environment or features before coalescing.
 Coalesce only requirements with identical source state, recipe or commands,
 working directories, environment, toolchain, features, platform, artifact
 ownership, and mutation lock. Preserve unit-to-requirement and

--- a/agents/.agents/skills/review-validator/references/standalone-workflow.md
+++ b/agents/.agents/skills/review-validator/references/standalone-workflow.md
@@ -35,6 +35,10 @@ the final user-visible result.
 Build stable requirement IDs, exact commands and working directories, complete
 relevant environment and toolchain identity, expected evidence, mutation
 classification, dependency policy, approved artifacts, and elapsed bounds.
+Identify the actual executor platform and runtime separately from any target
+platform. Classify target-bound evidence as native execution, focused emulation,
+or unexecuted; emulation is a distinct configuration and cannot satisfy a
+native requirement.
 Coalesce only requirements with identical source state, recipe or commands,
 working directories, environment, toolchain, features, platform, artifact
 ownership, and mutation lock. Preserve unit-to-requirement and
@@ -55,7 +59,10 @@ each coalesced command once and map its accepted evidence to every owned
 requirement. Stop dependent commands after prerequisite failure; continue only
 independent units when the plan permits it. Preserve exact commands, exit codes,
 concise output facts, environment identity, elapsed time, approved artifacts,
-and limitations.
+and limitations. Include the actual host, native or emulated evidence mode, the
+modeled boundary, and every unexecuted target cell. If supplied native CI
+evidence for the same source state conflicts with local or emulated evidence,
+preserve the native failure instead of reporting the matrix as passed.
 
 Run the source-state check again. Any scoped source, repository source, index,
 HEAD, or branch mutation makes the evidence stale and the result `blocked`.
@@ -80,7 +87,9 @@ preserves each status and execution record, and reconciles the final result.
 Always return the complete `Validation Result` from `result-contract.md`, even
 for passed, reused, blocked, or not-applicable outcomes. Lead with outcome and
 counts. State that P0 through P3 were not evaluated because this is
-validation-only. Include the full ledger export and mappings.
+validation-only. Include the full ledger export and mappings. Scope every
+platform claim to its actual executor, distinguish native runs from emulation,
+and name unexecuted matrix cells.
 
 Standalone evidence is portable candidate evidence, not a transferable pass.
 A later graph must recapture state and verify exact source, command,


### PR DESCRIPTION
- Require byte-sensitive regressions to exercise the owning OS boundary and independently detect the original behavior.
- Keep native execution, focused emulation, and unexecuted matrix cells distinct throughout validation and synthesis.
- Reconcile contradictory native CI without weakening regressions or dropping supported platforms.

Fixes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for distinguishing native platform execution, emulation, and unexecuted matrix cells.
  * Validation reports now record executor platform, runtime, target platform, and evidence mode.
  * Platform-sensitive subprocess and regression checks now require byte-level verification and direct boundary testing.
  * Native CI failures and unexecuted configurations remain visible as validation limitations.
  * Standalone and repository reviews now provide clearer platform coverage and residual-gap reporting.
  * Validation records use platform and execution mode when identifying and reconciling results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->