### PR TITLE
fix(skills): preserve validation identities across tool boundaries

### DIFF
--- a/agents/.agents/skills/project-tooling-review/references/github-actions.md
+++ b/agents/.agents/skills/project-tooling-review/references/github-actions.md
@@ -26,6 +26,42 @@ failure remains failed evidence until the defect is corrected and current
 native evidence passes. Do not weaken the regression, remove the supported
 matrix cell, or add a skip merely to make the workflow green.
 
+## Pull Request Review State
+
+Treat third-party review surfaces as separate evidence:
+
+- a successful commit status or check run means that provider finished its
+  work for a particular head; it is not CI success or approval
+- the latest review decision may remain `CHANGES_REQUESTED` while an
+  incremental review finds no new issues
+- unresolved inline threads remain actionable or require an evidence-backed
+  maintainer disposition even when the provider has finished
+- walkthrough and aggregate-summary claims can lag current code and must not
+  override current source, thread state, or authoritative platform/tool docs
+
+Bind each observation to the current PR head and timestamp. Reconcile every
+outstanding claim against current code before recommending another patch;
+distinguish a stale summary, a false positive, and a genuine unresolved defect.
+Do not infer that an older thread was fixed merely because it disappeared from
+an incremental review.
+
+When a tool bundled by a review provider rejects newer platform syntax, retain
+the repository's local validation gate and look for a documented rule-level or
+path-level control. Do not disable the entire provider tool merely to suppress
+one unsupported diagnostic. CodeRabbit's
+[published actionlint integration](https://docs.coderabbit.ai/tools/actionlint)
+currently uses default actionlint configuration, and its
+[configuration reference](https://docs.coderabbit.ai/reference/configuration)
+exposes only tool-wide enablement. A narrow unsupported-syntax exception
+therefore requires provider/upstream support rather than a broad
+`.coderabbit.yaml` suppression.
+
+Replying with evidence, requesting a fresh incremental or full review,
+resolving a false-positive thread, or escalating reproducible provider behavior
+requires explicit maintainer authorization. Never dismiss a review, resolve a
+genuine finding, weaken branch protection, or trigger repeated reviews solely
+because the latest incremental pass produced no new comments.
+
 ## Version And Pinning Checks
 
 - Verify action versions against live releases when the user asks for currentness or when changing versions. Do not rely on model memory for latest action versions.

--- a/agents/.agents/skills/python-support-scripts/references/platform-subprocess-evidence.md
+++ b/agents/.agents/skills/python-support-scripts/references/platform-subprocess-evidence.md
@@ -5,12 +5,28 @@ platform-dependent subprocess transport.
 
 ## Transport Boundary
 
-Make text versus binary transport deliberate at every subprocess boundary. If
-the consumer's contract is byte-sensitive, send bytes without text-mode
-translation and verify the bytes the child consumed against a literal fixture
-or independently computed digest. A tool option that controls its own newline
-or checkout behavior does not disable transformations performed earlier by the
-host runtime, pipe, locale, or encoding layer.
+Trace the complete transport: producer bytes, stdout capture, intermediate
+representation or storage, and consumer stdin. Make text versus binary
+transport deliberate at both subprocess boundaries. If the contract is
+byte-sensitive, capture producer stdout as bytes, preserve bytes between
+processes, and send bytes without text-mode translation. A binary consumer
+cannot recover CRLFs or non-UTF-8 data already changed or rejected by an earlier
+text-mode stdout capture.
+
+Verify producer and consumer bytes against a literal fixture or independently
+computed digest. Use an actual child-process pipe when the regression concerns
+stdout transport; a subprocess mock returning an already-decoded string does
+not exercise newline conversion or decoding. A tool option that controls its
+own newline or checkout behavior does not disable transformations performed
+earlier by the host runtime, pipe, locale, or encoding layer.
+
+For user-visible output, exercise the active stream encoding as another
+boundary. Legacy Windows code pages can reject otherwise valid Unicode in
+previews, status marks, release notes, paths, or next-step instructions. Render
+or safely escape unsupported characters before an external mutation, and make
+post-mutation reporting encoding-safe so a successful tag, upload, or publish
+is not reported as a failed operation. Preserve the payload sent to the
+external tool; escaping terminal output must not rewrite stored annotations.
 
 For platform-dependent transport, separate a native run on the target platform
 from a focused model or emulation of the transformation. Emulation is useful
@@ -25,3 +41,9 @@ against the unfixed implementation or an exact isolated copy of its defective
 boundary and pass after the correction. Do not weaken the assertion, skip the
 test, or remove a supported platform cell when native CI exposes a missed
 boundary.
+
+Cover CRLF, mixed-newline, and non-UTF-8 producer output when bytes are
+meaningful. For legacy output encodings, cover both representable input followed
+by an unsupported status symbol and unsupported user-supplied preview content;
+assert exit status, mutation count, unchanged external payload, and usable
+next-step output.

--- a/agents/.agents/skills/python-test-quality/references/platform-regression-evidence.md
+++ b/agents/.agents/skills/python-test-quality/references/platform-regression-evidence.md
@@ -12,6 +12,18 @@ compare literal bytes or their independently computed digests. Cover text-mode
 translation, encoding, and newline composition when reachable; do not assume a
 downstream tool option controls earlier runtime or pipe conversion.
 
+For subprocess pipelines, trace and test producer stdout capture, every
+intermediate representation, and consumer stdin separately. Use a real child
+process to emit CRLF, mixed-newline, and non-UTF-8 fixtures when stdout
+transport owns the risk; a mock returning decoded text bypasses that boundary.
+
+For command output, exercise a strict legacy encoding such as CP1252 in
+addition to UTF-8 capture when Windows console behavior matters. Include output
+emitted after a mocked successful external mutation. Assert the exit status,
+exactly-once mutation, unchanged payload, and usable diagnostics or next-step
+instructions so an encoding failure cannot masquerade as a failed tag, upload,
+or publish.
+
 ## Prove Regression Sensitivity
 
 Include durable focused coverage and a sensitivity check showing, through an

--- a/agents/.agents/skills/review-graph/SKILL.md
+++ b/agents/.agents/skills/review-graph/SKILL.md
@@ -72,6 +72,8 @@ planner-owned fields in prompts.
 The materialized command policy is authoritative. Review nodes attest to every
 command and do not execute validator-owned commands without an exact duplicate
 authorization; authorized results remain explicit reusable evidence.
+Audits reference dispatched planned-validation IDs/digests instead of restating
+execution identities.
 Identical skill/source/scope leaves execute once; each catalog requirement
 retains ownership of the coalesced judgment and evidence.
 

--- a/agents/.agents/skills/review-graph/references/planning-contract.md
+++ b/agents/.agents/skills/review-graph/references/planning-contract.md
@@ -385,6 +385,14 @@ unmapped requirement or a command/directory/environment/dependency mismatch.
 already has accepted evidence. A generic CI pass cannot cover a different
 validation identity.
 
+Materialized review dispatches carry each planned unit's complete non-narrative
+execution identity and canonical digest. An audit that confirms a planned need
+references the dispatched requirement ID and digest instead of reconstructing
+commands, directories, or environment. Audit-specific reason and expected
+evidence remain provenance only: different narratives can map to the same unit.
+Unknown references and conflicting restatements fail compilation; a full
+requirement with a genuinely new identity still enters late expansion.
+
 Use `reconcile-validation-requirements` with `--journal`, `--dispatches`,
 `--current-capture`, and an input containing `plan` and `source_state` to inspect
 requirements and their exact origin/digest. To expand, supply `artifact_store`

--- a/agents/.agents/skills/review-graph/references/runtime-contract.md
+++ b/agents/.agents/skills/review-graph/references/runtime-contract.md
@@ -104,7 +104,8 @@ Return only `ReviewPayload`. Write its exact bytes to the candidate, then execut
 executable, script, and bound paths; it validates and atomically publishes
 `worker_payload_path`.
 
-Use the materialized payload schema for fields and enum values.
+Use the materialized payload schema; planned needs reference dispatched
+validation IDs/digests.
 
 `compile-node` seals accepted bytes in a read-only content-addressed sibling,
 recorded in evidence metadata. The dispatch-bound path remains staging;

--- a/agents/.agents/skills/review-graph/references/schemas/review-payload-v1.schema.json
+++ b/agents/.agents/skills/review-graph/references/schemas/review-payload-v1.schema.json
@@ -67,19 +67,35 @@
     "status": {"enum": ["completed", "no-findings", "blocked"]},
     "validation_requirements": {
       "items": {
-        "additionalProperties": false,
-        "properties": {
-          "commands": {"items": {"type": "string"}, "minItems": 1, "type": "array"},
-          "dependency_policy": {"enum": ["stop-on-failure", "continue-independent"]},
-          "environment": {"type": "string"},
-          "expected_evidence": {"type": "string"},
-          "owner": {"type": "string"},
-          "reason": {"type": "string"},
-          "requirement_id": {"type": "string"},
-          "working_directory": {"type": "string"}
-        },
-        "required": ["requirement_id", "owner", "reason", "commands", "working_directory", "environment", "expected_evidence", "dependency_policy"],
-        "type": "object"
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "commands": {"items": {"type": "string"}, "minItems": 1, "type": "array"},
+              "dependency_policy": {"enum": ["stop-on-failure", "continue-independent"]},
+              "environment": {"type": "string"},
+              "expected_evidence": {"type": "string"},
+              "owner": {"type": "string"},
+              "reason": {"type": "string"},
+              "requirement_id": {"type": "string"},
+              "working_directory": {"type": "string"}
+            },
+            "required": ["requirement_id", "owner", "reason", "commands", "working_directory", "environment", "expected_evidence", "dependency_policy"],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "expected_evidence": {"type": "string"},
+              "owner": {"type": "string"},
+              "planned_validation_digest": {"pattern": "sha256:[0-9a-f]{64}", "type": "string"},
+              "reason": {"type": "string"},
+              "requirement_id": {"type": "string"}
+            },
+            "required": ["requirement_id", "planned_validation_digest", "owner", "reason", "expected_evidence"],
+            "type": "object"
+          }
+        ]
       },
       "type": "array"
     }

--- a/agents/.agents/skills/review-graph/references/schemas/review-payload-v1.schema.json
+++ b/agents/.agents/skills/review-graph/references/schemas/review-payload-v1.schema.json
@@ -88,7 +88,7 @@
             "properties": {
               "expected_evidence": {"type": "string"},
               "owner": {"type": "string"},
-              "planned_validation_digest": {"pattern": "sha256:[0-9a-f]{64}", "type": "string"},
+              "planned_validation_digest": {"pattern": "^sha256:[0-9a-f]{64}$", "type": "string"},
               "reason": {"type": "string"},
               "requirement_id": {"type": "string"}
             },

--- a/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
@@ -130,6 +130,37 @@ _BOUNDED_WORKSPACE_ENTRY_LIMIT = 256
 _BOUNDED_WORKSPACE_POLICY = "bounded-directory-metadata-v3"
 _RECURSIVE_WORKSPACE_POLICY = "recursive-content-sha256-v2"
 _SCHEMA_ID_VERSION_RE = re.compile(r"(?P<name>[^/]+)-v(?P<version>[1-9][0-9]*)\.schema\.json\Z")
+_PLANNED_VALIDATION_IDENTITY_KEYS = frozenset(
+    {
+        "allowed_artifacts",
+        "artifact_owner",
+        "baseline",
+        "canonical_recipe",
+        "capture_command",
+        "captured_paths",
+        "commands",
+        "dependency_policy",
+        "environment",
+        "execution_strategy",
+        "expected_workspace_effects",
+        "features",
+        "independence_basis",
+        "isolation_root",
+        "mutation_lock",
+        "planning_blocker",
+        "platform",
+        "requested_scope",
+        "required",
+        "requires_isolation",
+        "source_state",
+        "toolchain",
+        "working_directories",
+    }
+)
+_PLANNED_VALIDATION_REFERENCE_KEYS = frozenset({"expected_evidence", "owner", "planned_validation_digest", "reason", "requirement_id"})
+_LEGACY_VALIDATION_REQUIREMENT_KEYS = frozenset(
+    {"commands", "dependency_policy", "environment", "expected_evidence", "owner", "reason", "requirement_id", "working_directory"}
+)
 
 
 @dataclass(frozen=True)
@@ -294,9 +325,20 @@ def _validation_records(payload: dict[str, Any]) -> tuple[tuple[str, dict[str, A
     records: list[tuple[str, dict[str, Any]]] = []
     for requirement in _records(payload, "validation_requirements"):
         requirement_id = _required_text(requirement, "requirement_id")
-        for field_name in ("owner", "reason", "working_directory", "environment", "expected_evidence", "dependency_policy"):
+        for field_name in ("owner", "reason", "expected_evidence"):
             _required_text(requirement, field_name)
-        _text_list(requirement, "commands", required=True)
+        if "planned_validation_digest" in requirement:
+            if frozenset(requirement) != _PLANNED_VALIDATION_REFERENCE_KEYS:
+                msg = f"planned validation reference {requirement_id} must contain only its ID, digest, owner, reason, and expected evidence"
+                raise ValueError(msg)
+            _sha256_digest(_required_text(requirement, "planned_validation_digest"), "planned validation digest")
+        else:
+            if frozenset(requirement) != _LEGACY_VALIDATION_REQUIREMENT_KEYS:
+                msg = f"validation requirement {requirement_id} must contain the complete legacy execution identity"
+                raise ValueError(msg)
+            for field_name in ("working_directory", "environment", "dependency_policy"):
+                _required_text(requirement, field_name)
+            _text_list(requirement, "commands", required=True)
         records.append((requirement_id, requirement))
     identifiers = tuple(requirement_id for requirement_id, _ in records)
     if len(identifiers) != len(set(identifiers)):
@@ -377,23 +419,31 @@ def _findings_body(findings: tuple[tuple[str, dict[str, Any]], ...]) -> str:
 def _validation_body(records: tuple[tuple[str, dict[str, Any]], ...]) -> str:
     if not records:
         return "none"
-    return "\n".join(
-        "\n".join(
-            (
-                f"- Requirement ID: {requirement_id}",
-                f"  - Owner: {record['owner']}",
-                f"  - Reason: {record['reason']}",
+    rendered: list[str] = []
+    for requirement_id, record in records:
+        if "planned_validation_digest" in record:
+            identity = (f"  - Planned validation digest: {record['planned_validation_digest']}", "  - Execution identity: dispatch-planned validation unit")
+        else:
+            identity = (
                 f"  - Commands: {' && '.join(record['commands'])}",
                 f"  - Working directories: {record['working_directory']}",
                 f"  - Environment/configuration: {record['environment']}",
-                f"  - Expected evidence: {record['expected_evidence']}",
                 f"  - Dependency policy: {record['dependency_policy']}",
-                "  - Disposition: required",
-                "  - Ledger evidence: none",
+            )
+        rendered.append(
+            "\n".join(
+                (
+                    f"- Requirement ID: {requirement_id}",
+                    f"  - Owner: {record['owner']}",
+                    f"  - Reason: {record['reason']}",
+                    *identity,
+                    f"  - Expected evidence: {record['expected_evidence']}",
+                    "  - Disposition: required",
+                    "  - Ledger evidence: none",
+                )
             )
         )
-        for requirement_id, record in records
-    )
+    return "\n".join(rendered)
 
 
 def _handoffs_body(records: tuple[tuple[str, dict[str, Any]], ...]) -> str:
@@ -512,6 +562,116 @@ def _review_command_policy_blockers(dispatch: dict[str, Any], payload: dict[str,
     if duplicates:
         return ("review payload executed commands owned by planned validators: " + ", ".join(duplicates),)
     return ()
+
+
+def _planned_validation_identity(unit: ValidationUnit) -> dict[str, Any]:
+    """Return the exact non-narrative identity used to coalesce validator work."""
+    return {
+        "allowed_artifacts": [asdict(artifact) for artifact in unit.allowed_artifacts],
+        "artifact_owner": unit.artifact_owner,
+        "baseline": unit.baseline,
+        "canonical_recipe": unit.canonical_recipe,
+        "capture_command": unit.capture_command,
+        "captured_paths": list(unit.captured_paths),
+        "commands": list(unit.commands),
+        "dependency_policy": unit.dependency_policy,
+        "environment": unit.environment,
+        "execution_strategy": unit.execution_strategy,
+        "expected_workspace_effects": list(unit.expected_workspace_effects),
+        "features": list(unit.features),
+        "independence_basis": unit.independence_basis,
+        "isolation_root": unit.isolation_root,
+        "mutation_lock": unit.mutation_lock,
+        "planning_blocker": unit.planning_blocker,
+        "platform": unit.platform,
+        "requested_scope": unit.requested_scope,
+        "required": unit.required,
+        "requires_isolation": unit.requires_isolation,
+        "source_state": list(unit.source_state),
+        "toolchain": unit.toolchain,
+        "working_directories": list(unit.working_directories),
+    }
+
+
+def _planned_validation_digest(unit: ValidationUnit) -> str:
+    return _sha256_bytes(_canonical_json(_planned_validation_identity(unit)).encode())
+
+
+def _planned_validation_units(plan: GraphPlan) -> list[dict[str, Any]]:
+    return [
+        {
+            "execution_identity": _planned_validation_identity(unit),
+            "planned_validation_digest": _planned_validation_digest(unit),
+            "requirement_ids": list(unit.requirement_ids),
+            "validation_unit_id": unit.node_id,
+        }
+        for unit in sorted(plan.coalesced_validation_units, key=lambda item: item.node_id)
+    ]
+
+
+def _dispatched_planned_validations(dispatch: dict[str, Any]) -> dict[str, tuple[str, str, dict[str, Any]]]:
+    raw_policy = dispatch.get("command_policy")
+    if raw_policy is None:
+        return {}
+    if not isinstance(raw_policy, dict):
+        msg = "review dispatch command_policy must be an object"
+        raise TypeError(msg)
+    by_requirement: dict[str, tuple[str, str, dict[str, Any]]] = {}
+    unit_ids: set[str] = set()
+    for record in _records(raw_policy, "planned_validation_units"):
+        if frozenset(record) != frozenset({"execution_identity", "planned_validation_digest", "requirement_ids", "validation_unit_id"}):
+            msg = "planned validation unit dispatch records must contain only unit ID, requirement IDs, identity, and digest"
+            raise ValueError(msg)
+        unit_id = _required_text(record, "validation_unit_id")
+        if unit_id in unit_ids:
+            msg = f"planned validation unit dispatch contains duplicate unit ID {unit_id}"
+            raise ValueError(msg)
+        unit_ids.add(unit_id)
+        requirement_ids = _text_list(record, "requirement_ids", required=True)
+        identity = record.get("execution_identity")
+        if not isinstance(identity, dict) or frozenset(identity) != _PLANNED_VALIDATION_IDENTITY_KEYS:
+            msg = f"planned validation unit {unit_id} has an incomplete execution identity"
+            raise ValueError(msg)
+        digest = _required_text(record, "planned_validation_digest")
+        _sha256_digest(digest, "planned validation digest")
+        if digest != _sha256_bytes(_canonical_json(identity).encode()):
+            msg = f"planned validation unit {unit_id} digest does not match its execution identity"
+            raise ValueError(msg)
+        for requirement_id in requirement_ids:
+            if requirement_id in by_requirement:
+                msg = f"planned validation dispatch maps requirement {requirement_id} more than once"
+                raise ValueError(msg)
+            by_requirement[requirement_id] = (unit_id, digest, identity)
+    return by_requirement
+
+
+def _review_validation_requirement_blockers(dispatch: dict[str, Any], validations: tuple[tuple[str, dict[str, Any]], ...]) -> tuple[str, ...]:
+    try:
+        planned = _dispatched_planned_validations(dispatch)
+    except (TypeError, ValueError) as error:
+        return (str(error),)
+    blockers: list[str] = []
+    for requirement_id, requirement in validations:
+        planned_record = planned.get(requirement_id)
+        if "planned_validation_digest" in requirement:
+            if planned_record is None:
+                blockers.append(f"validation requirement {requirement_id} references an unplanned validation identity")
+            elif requirement["planned_validation_digest"] != planned_record[1]:
+                blockers.append(f"validation requirement {requirement_id} planned validation digest conflicts with its dispatch")
+            continue
+        if planned_record is None:
+            continue
+        identity = planned_record[2]
+        matches = (
+            identity["commands"] == list(_text_list(requirement, "commands"))
+            and identity["working_directories"] == [requirement["working_directory"]] * len(cast("list[str]", identity["commands"]))
+            and identity["environment"] == requirement["environment"]
+            and identity["dependency_policy"] == requirement["dependency_policy"]
+            and identity["required"] is True
+        )
+        if not matches:
+            blockers.append(f"validation requirement {requirement_id} restates a conflicting planned validation identity")
+    return tuple(blockers)
 
 
 def _review_handoff_catalog_blockers(dispatch: dict[str, Any], handoffs: tuple[tuple[str, dict[str, Any]], ...]) -> tuple[str, ...]:
@@ -637,6 +797,7 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
     validations = _validation_records(payload)
     handoffs = _handoff_records(payload, node_id)
     policy_blockers = _review_command_policy_blockers(dispatch, payload)
+    validation_requirement_blockers = _review_validation_requirement_blockers(dispatch, validations)
     handoff_blockers = _review_handoff_catalog_blockers(dispatch, handoffs)
     scope_blockers = _review_scope_coverage_blockers(dispatch, payload, status=status)
     limitations = _text_list(payload, "limitations")
@@ -786,7 +947,7 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
     evidence = replace(evidence, raw_result_digest=_sha256_bytes(content))
     envelope_assessment = assess_review_evidence(expectation, evidence)
     native_blockers = _review_native_result_blockers(content, expectation, evidence)
-    blockers = (*policy_blockers, *handoff_blockers, *scope_blockers, *envelope_assessment.blockers, *native_blockers)
+    blockers = (*policy_blockers, *validation_requirement_blockers, *handoff_blockers, *scope_blockers, *envelope_assessment.blockers, *native_blockers)
     if blockers:
         msg = "compiled review artifact failed verification: " + "; ".join(blockers)
         raise ValueError(msg)
@@ -2302,7 +2463,7 @@ def _load_evidence_source(  # noqa: C901, PLR0912, PLR0915
 
 def _validation_reconciliation(plan: GraphPlan, records: list[dict[str, Any]]) -> dict[str, Any]:
     """Bind discovered needs to exact command plans, never to a generic CI pass."""
-    units = {requirement: unit for unit in plan.coalesced_validation_units for requirement in unit.requirement_ids}
+    units = {requirement: (unit, _planned_validation_digest(unit)) for unit in plan.coalesced_validation_units for requirement in unit.requirement_ids}
     exclusions = {(item.originating_evidence_id, item.requirement_id, item.requirement_digest): item for item in plan.validation_exclusions}
     results: list[dict[str, Any]] = []
     blockers: list[str] = []
@@ -2312,15 +2473,19 @@ def _validation_reconciliation(plan: GraphPlan, records: list[dict[str, Any]]) -
         for requirement_id, requirement in _validation_records(record):
             digest = _sha256_bytes(_canonical_json(requirement).encode())
             origin = _required_text(record, "evidence_id")
-            unit = units.get(requirement_id)
+            planned = units.get(requirement_id)
+            unit = planned[0] if planned is not None else None
             exclusion = exclusions.get((origin, requirement_id, digest))
-            matches = unit is not None and (
-                unit.commands == _text_list(requirement, "commands")
-                and unit.working_directories == (requirement["working_directory"],) * len(unit.commands)
-                and unit.environment == requirement["environment"]
-                and unit.dependency_policy == requirement["dependency_policy"]
-                and unit.required
-            )
+            if "planned_validation_digest" in requirement:
+                matches = planned is not None and requirement["planned_validation_digest"] == planned[1] and unit is not None and unit.required
+            else:
+                matches = unit is not None and (
+                    unit.commands == _text_list(requirement, "commands")
+                    and unit.working_directories == (requirement["working_directory"],) * len(unit.commands)
+                    and unit.environment == requirement["environment"]
+                    and unit.dependency_policy == requirement["dependency_policy"]
+                    and unit.required
+                )
             resolution = "planned" if matches else "user-excluded" if exclusion else "identity-conflict" if unit else "requires-expansion"
             if resolution in {"identity-conflict", "requires-expansion"}:
                 blockers.append(f"validation requirement {requirement_id} from {origin} needs exact validation reconciliation ({resolution})")
@@ -2485,8 +2650,11 @@ def build_routing_projection_document(
 
 def _required_schema_shape(node: dict[str, Any]) -> object:
     """Return a compact recursive description of every schema-required field."""
-    if isinstance(node.get("enum"), list):
-        shape: object = " | ".join(str(value) for value in node["enum"])
+    shape: object
+    if isinstance(node.get("oneOf"), list):
+        shape = {"oneOf": [_required_schema_shape(branch) for branch in node["oneOf"] if isinstance(branch, dict)]}
+    elif isinstance(node.get("enum"), list):
+        shape = " | ".join(str(value) for value in node["enum"])
     elif "const" in node:
         shape = node["const"]
     elif node.get("type") == "object":
@@ -2566,7 +2734,12 @@ def _materialized_command_policy(plan: GraphPlan, node: WorkerNode, authorized_d
         "allowed_commands": ["read-only inspection commands that do not execute a planned validator recipe"],
         "authorized_duplicate_commands": list(authorized_duplicates),
         "attestation_required": True,
-        "policy": "planned validators own execution; return validation requirements without rerunning their commands",
+        "planned_validation_units": _planned_validation_units(plan),
+        "policy": (
+            "planned validators own execution; for a covered need, return the planned-reference validation requirement variant with the exact "
+            "requirement_id and planned_validation_digest while keeping owner, reason, and expected_evidence audit-specific; use the full execution "
+            "variant only for a genuinely new validation identity; do not rerun validator commands"
+        ),
         "prohibited_commands": list(prohibited),
         "validator_owned_commands": list(validator_commands),
     }

--- a/agents/.agents/skills/review-graph/scripts/review_graph_schema.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_schema.py
@@ -113,10 +113,28 @@ def _shape(schema: dict[str, Any]) -> str:
     return "value described by schema"
 
 
-def _diagnose(value: object, schema: dict[str, Any], root: dict[str, Any], path: str, output: list[SchemaDiagnostic]) -> None:  # noqa: C901, PLR0912
+def _diagnose(  # noqa: C901, PLR0912, PLR0915
+    value: object, schema: dict[str, Any], root: dict[str, Any], path: str, output: list[SchemaDiagnostic]
+) -> None:
     reference = schema.get("$ref")
     if isinstance(reference, str):
         _diagnose(value, _resolve_ref(root, reference), root, path, output)
+        return
+    one_of = schema.get("oneOf")
+    if isinstance(one_of, list) and one_of and all(isinstance(branch, dict) for branch in one_of):
+        branch_diagnostics: list[list[SchemaDiagnostic]] = []
+        for branch in one_of:
+            diagnostics: list[SchemaDiagnostic] = []
+            _diagnose(value, branch, root, path, diagnostics)
+            branch_diagnostics.append(diagnostics)
+        matching = tuple(diagnostics for diagnostics in branch_diagnostics if not diagnostics)
+        if len(matching) == 1:
+            return
+        if not matching:
+            best = min(branch_diagnostics, key=lambda diagnostics: (len(diagnostics), tuple((item.path, item.code) for item in diagnostics)))
+            output.extend(best)
+        else:
+            output.append(SchemaDiagnostic(path, "oneOf", "matches more than one allowed shape", "exactly one allowed shape"))
         return
     accepted = _accepted_types(schema)
     if accepted and not _matches_type(value, accepted):

--- a/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
@@ -36,6 +36,7 @@ from review_graph_runtime import (
     _argument_parser,
     _git_path_status,
     _graph_plan,
+    _planned_validation_digest,
     _reconciled_handoffs,
     _schema_reference,
     _validation_workspace_audit,
@@ -431,6 +432,35 @@ def test_review_payload_schema_reports_all_field_diagnostics() -> None:
     assert {"$.changes", "$.command_policy_attested", "$.commands_executed", "$.status", "$.unexpected"} <= paths
     status = next(item for item in diagnostics if item["path"] == "$.status")
     assert status["accepted_values"] == ["completed", "no-findings", "blocked"]
+
+
+def test_review_payload_schema_accepts_only_one_validation_requirement_shape() -> None:
+    payload = {
+        "changes": [],
+        "command_policy_attested": True,
+        "commands_executed": [],
+        "files_inspected": [STATE_FIXTURE],
+        "findings": [],
+        "handoffs": [],
+        "limitations": [],
+        "nearby_contract_owners": [],
+        "scope_limitations": [],
+        "status": "no-findings",
+        "validation_requirements": [
+            {
+                "expected_evidence": "planned validation passes",
+                "owner": "rust-build-portability",
+                "planned_validation_digest": "sha256:" + "0" * 64,
+                "reason": "the audit confirms the planned validation need",
+                "requirement_id": "baseline-validation",
+            }
+        ],
+    }
+
+    require_schema(payload, SCHEMA_ROOT / "review-payload-v1.schema.json")
+    cast("list[dict[str, Any]]", payload["validation_requirements"])[0]["commands"] = ["true"]
+    with pytest.raises(SchemaValidationError):
+        require_schema(payload, SCHEMA_ROOT / "review-payload-v1.schema.json")
 
 
 def test_planning_schema_aggregates_enum_and_required_field_diagnostics() -> None:
@@ -2021,6 +2051,22 @@ def test_validation_coalescing_ignores_narrative_differences_without_losing_prov
     )
 
 
+def _assert_planned_validation_policy(audit_dispatch: dict[str, Any], validation_dispatch: dict[str, Any]) -> None:
+    assert "command_policy_attested" in audit_dispatch["payload_schema"]["required_fields"]
+    assert audit_dispatch["command_policy"]["validator_owned_commands"] == ["true"]
+    planned_validation = audit_dispatch["command_policy"]["planned_validation_units"]
+    assert len(planned_validation) == 1
+    assert planned_validation[0]["requirement_ids"] == ["baseline-validation"]
+    assert planned_validation[0]["validation_unit_id"] == validation_dispatch["validation_unit"]["node_id"]
+    assert planned_validation[0]["execution_identity"]["working_directories"] == validation_dispatch["validation_unit"]["working_directories"]
+    assert planned_validation[0]["planned_validation_digest"].startswith("sha256:")
+    validation_requirement_shape = audit_dispatch["payload_schema"]["required_shape"]["validation_requirements"][0]
+    assert {tuple(sorted(shape)) for shape in validation_requirement_shape["oneOf"]} == {
+        ("commands", "dependency_policy", "environment", "expected_evidence", "owner", "reason", "requirement_id", "working_directory"),
+        ("expected_evidence", "owner", "planned_validation_digest", "reason", "requirement_id"),
+    }
+
+
 def test_dispatch_materialization_and_ready_nodes_are_plan_derived(tmp_path: Path) -> None:
     plan = _sparse_plan()
     result = materialize_dispatches(
@@ -2052,8 +2098,7 @@ def test_dispatch_materialization_and_ready_nodes_are_plan_derived(tmp_path: Pat
     assert validation_dispatch["payload_schema"]["id"].endswith("validation-payload-v2.schema.json")
     assert audit_dispatch["payload_schema"]["version"] == 1
     assert validation_dispatch["payload_schema"]["version"] == 2
-    assert "command_policy_attested" in audit_dispatch["payload_schema"]["required_fields"]
-    assert audit_dispatch["command_policy"]["validator_owned_commands"] == ["true"]
+    _assert_planned_validation_policy(audit_dispatch, validation_dispatch)
     assert str(SKILL_ROOT.parents[2] / "AGENTS.md") in audit_dispatch["instruction_paths"]
     assert all(entry["worker_prompt"] for entry in result["dispatches"])
     assert all("persist-worker-payload" in entry["worker_prompt"] for entry in result["dispatches"])
@@ -3094,6 +3139,7 @@ def _compile_materialized_evidence(  # noqa: PLR0913
     plan: GraphPlan | None = None,
     skip_node_ids: tuple[str, ...] = (),
     late_requirements: list[dict[str, Any]] | None = None,
+    reference_planned_validation: bool = False,
 ) -> tuple[GraphPlan, list[dict[str, str]]]:
     plan = plan or _sparse_plan()
     materialized = materialize_dispatches(
@@ -3113,6 +3159,9 @@ def _compile_materialized_evidence(  # noqa: PLR0913
         dispatch = entry["dispatch"]
         dispatch.update({"after_state": ["scope", "worktree", "repository"], "before_state": ["scope", "worktree", "repository"]})
         if entry["result_contract"] == "compact-validation":
+            if dispatch["workspace_policy"]["snapshots_required"]:
+                snapshot = capture_workspace_snapshot(dispatch)["records"]
+                dispatch.update({"workspace_after": snapshot, "workspace_before": snapshot})
             unit = dispatch["validation_unit"]
             payload = {
                 "artifacts": [],
@@ -3155,6 +3204,19 @@ def _compile_materialized_evidence(  # noqa: PLR0913
                 ]
             else:
                 handoffs = []
+            if reference_planned_validation and dispatch["mode"] == "audit":
+                planned = dispatch["command_policy"]["planned_validation_units"][0]
+                validation_requirements = [
+                    {
+                        "expected_evidence": f"{dispatch['skill_id']} expects the planned command to pass",
+                        "owner": dispatch["skill_id"],
+                        "planned_validation_digest": planned["planned_validation_digest"],
+                        "reason": f"{dispatch['node_id']} independently confirms the planned validation need",
+                        "requirement_id": planned["requirement_ids"][0],
+                    }
+                ]
+            else:
+                validation_requirements = late_requirements or [] if dispatch["node_id"] == "audit-001" else []
             payload = {
                 "command_policy_attested": True,
                 "commands_executed": [],
@@ -3165,7 +3227,7 @@ def _compile_materialized_evidence(  # noqa: PLR0913
                 "scope_limitations": [],
                 "nearby_contract_owners": [],
                 "status": "no-findings",
-                "validation_requirements": late_requirements or [] if dispatch["node_id"] == "audit-001" else [],
+                "validation_requirements": validation_requirements,
             }
             content, metadata = compile_review({"dispatch": dispatch, "payload": payload})
             kind = "review"
@@ -3179,6 +3241,94 @@ def _compile_materialized_evidence(  # noqa: PLR0913
 
 def _source_by_node(sources: list[dict[str, str]]) -> dict[str, dict[str, str]]:
     return {json.loads(Path(source["metadata_path"]).read_text(encoding="utf-8"))["evidence"]["node_id"]: source for source in sources}
+
+
+def test_isolated_validator_identity_reconciles_multiple_audit_references(tmp_path: Path) -> None:
+    isolation_root = tmp_path / "isolated-validator"
+    working_directory = isolation_root / "repository-copy"
+    working_directory.mkdir(parents=True)
+    plan = _sparse_plan()
+    unit = replace(
+        plan.coalesced_validation_units[0],
+        environment="isolated repository replica",
+        isolation_root=str(isolation_root),
+        requires_isolation=True,
+        working_directories=(str(working_directory),),
+    )
+    isolated_plan = replace(plan, coalesced_validation_units=(unit,))
+
+    isolated_plan, sources = _compile_materialized_evidence(tmp_path / "evidence", plan=isolated_plan, reference_planned_validation=True)
+    final = finalize_proof(
+        {
+            "current_source_state": ["scope", "worktree", "repository"],
+            "plan": _json_plan(isolated_plan),
+            "source_state": ["scope", "worktree", "repository"],
+            "sources": sources,
+        }
+    )
+
+    reconciled = [item for item in final["validation_reconciliation"]["requirements"] if item["requirement_id"] == "baseline-validation"]
+    assert final["status"] == "complete", final["blockers"]
+    assert len(reconciled) == 2
+    assert {item["resolution"] for item in reconciled} == {"planned"}
+    assert {item["validation_unit_id"] for item in reconciled} == {unit.node_id}
+    assert len({item["requirement"]["reason"] for item in reconciled}) == 2
+    assert {item["requirement"]["planned_validation_digest"] for item in reconciled} == {_planned_validation_digest(unit)}
+
+
+@pytest.mark.parametrize("conflict", ["digest", "restatement"])
+def test_compile_review_rejects_conflicting_planned_validation_identity(tmp_path: Path, conflict: str) -> None:
+    plan = _sparse_plan()
+    materialized = materialize_dispatches(
+        {
+            "artifact_store": str(tmp_path),
+            "authorization": "review-only",
+            "plan": _json_plan(plan),
+            "repository_root": str(SKILL_ROOT.parents[2]),
+            "source_state": ["scope", "worktree", "repository"],
+            "state_verification_command": "capture_scope.py --mode baseline",
+        }
+    )
+    dispatch = next(entry["dispatch"] for entry in materialized["dispatches"] if entry["dispatch"].get("mode") == "audit")
+    dispatch.update({"after_state": dispatch["source_state"], "before_state": dispatch["source_state"]})
+    planned = dispatch["command_policy"]["planned_validation_units"][0]
+    if conflict == "digest":
+        requirement = {
+            "expected_evidence": "planned validation passes",
+            "owner": dispatch["skill_id"],
+            "planned_validation_digest": "sha256:" + "0" * 64,
+            "reason": "audit confirms the planned need",
+            "requirement_id": planned["requirement_ids"][0],
+        }
+        expected = "planned validation digest conflicts"
+    else:
+        requirement = {
+            "commands": planned["execution_identity"]["commands"],
+            "dependency_policy": planned["execution_identity"]["dependency_policy"],
+            "environment": planned["execution_identity"]["environment"],
+            "expected_evidence": "planned validation passes",
+            "owner": dispatch["skill_id"],
+            "reason": "audit restates the planned need incorrectly",
+            "requirement_id": planned["requirement_ids"][0],
+            "working_directory": str(tmp_path / "different-live-root"),
+        }
+        expected = "restates a conflicting planned validation identity"
+    payload = {
+        "changes": [],
+        "command_policy_attested": True,
+        "commands_executed": [],
+        "files_inspected": dispatch["owned_paths"],
+        "findings": [],
+        "handoffs": [],
+        "limitations": [],
+        "nearby_contract_owners": [],
+        "scope_limitations": [],
+        "status": "no-findings",
+        "validation_requirements": [requirement],
+    }
+
+    with pytest.raises(ValueError, match=expected):
+        compile_review({"dispatch": dispatch, "payload": payload})
 
 
 def _late_validation_requirement() -> dict[str, Any]:
@@ -3260,6 +3410,7 @@ def test_late_validation_blocks_readiness_and_finalization_then_expands_without_
         for path in [journal, dispatch_path, *(Path(source[field]) for source in sources for field in ("artifact_path", "metadata_path"))]
     }
     discovery = ready["validation_reconciliation"]["requirements"][0]
+    assert discovery["resolution"] == "requires-expansion"
     request = {**lifecycle, "artifact_store": str(tmp_path / "revision")}
     if exclude:
         request["user_exclusions"] = [

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ python_paths := "agents/.agents/skills scripts"
 dprint_version := "0.57.0"
 just_version := "1.58.0"
 rumdl_version := "0.2.62"
-uv_version := "0.12.7"
+uv_version := "0.12.8"
 zizmor_version := "1.30.0"
 
 _ensure-actionlint:
@@ -325,8 +325,19 @@ setup:
     DOTFILES_DIR="$PWD" bin/bootstrap.sh
     just python-sync
 
+_preflight-stable-uv: _ensure-brew
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    uv_executable="$(brew --prefix uv)/bin/uv"
+    if [[ ! -x "$uv_executable" ]]; then
+        echo "Homebrew-managed uv is unavailable at $uv_executable." >&2
+        exit 1
+    fi
+    "$uv_executable" run --locked --no-sync python scripts/update_tool_pins.py --check-uv-version --uv-executable "$uv_executable"
+
 # Update the Homebrew bundle, uv lock, and repository-owned Cargo tools.
-update: update-dependencies update-cargo-tools
+update: _preflight-stable-uv update-dependencies update-cargo-tools
     @echo "Repository dependencies and tools updated."
 
 # Update the Cargo CLI tools installed by bootstrap.sh and reconcile their pins.
@@ -345,6 +356,7 @@ update-cargo-tools: _ensure-brew
         echo "Homebrew-managed uv is unavailable at $uv_executable." >&2
         exit 1
     fi
+    "$uv_executable" run --locked --no-sync python scripts/update_tool_pins.py --check-uv-version --uv-executable "$uv_executable"
 
     packages=(dprint just rumdl zizmor)
     cargo install-update --locked "${packages[@]}"
@@ -361,6 +373,7 @@ update-dependencies: _ensure-brew
         echo "Homebrew-managed uv is unavailable at $uv_executable." >&2
         exit 1
     fi
+    "$uv_executable" run --locked --no-sync python scripts/update_tool_pins.py --check-uv-version --uv-executable "$uv_executable"
     "$uv_executable" lock --upgrade
     "$uv_executable" sync --locked --group dev
 

--- a/justfile
+++ b/justfile
@@ -367,6 +367,13 @@ update-dependencies: _ensure-brew
     #!/usr/bin/env bash
     set -euo pipefail
 
+    uv_executable="$(brew --prefix uv)/bin/uv"
+    if [[ ! -x "$uv_executable" ]]; then
+        echo "Homebrew-managed uv is unavailable at $uv_executable." >&2
+        exit 1
+    fi
+    "$uv_executable" run --locked --no-sync python scripts/update_tool_pins.py --check-uv-version --uv-executable "$uv_executable"
+
     brew bundle upgrade --file="$PWD/Brewfile"
     uv_executable="$(brew --prefix uv)/bin/uv"
     if [[ ! -x "$uv_executable" ]]; then

--- a/scripts/test_update_tool_pins.py
+++ b/scripts/test_update_tool_pins.py
@@ -155,24 +155,35 @@ def test_check_uv_version_rejects_unstable_or_ambiguous_output_before_reading_ca
     assert "failed to validate uv version: invalid tool state:" in capsys.readouterr().err
 
 
-def test_update_recipe_preflights_uv_before_homebrew_and_cargo_mutations() -> None:
+def test_update_recipes_preflight_uv_before_homebrew_and_cargo_mutations() -> None:
     repository = Path(__file__).resolve().parents[1]
     just = shutil.which("just")
     assert just is not None
+
+    dependency_result = subprocess.run(  # noqa: S603 - resolved Just executable and fixed arguments.
+        [just, "--justfile", str(repository / "justfile"), "--dry-run", "update-dependencies"], check=True, capture_output=True, text=True, cwd=repository
+    )
+    dependency_output = f"{dependency_result.stdout}\n{dependency_result.stderr}"
+    preflight = "scripts/update_tool_pins.py --check-uv-version"
+    first_dependency_preflight = dependency_output.index(preflight)
+    homebrew_mutation = dependency_output.index('brew bundle upgrade --file="$PWD/Brewfile"')
+    second_dependency_preflight = dependency_output.index(preflight, first_dependency_preflight + 1)
+    uv_mutation = dependency_output.index('"$uv_executable" lock --upgrade')
+    assert first_dependency_preflight < homebrew_mutation < second_dependency_preflight < uv_mutation
 
     result = subprocess.run(  # noqa: S603 - resolved Just executable and fixed arguments.
         [just, "--justfile", str(repository / "justfile"), "--dry-run", "update"], check=True, capture_output=True, text=True, cwd=repository
     )
 
     output = f"{result.stdout}\n{result.stderr}"
-    preflight = "scripts/update_tool_pins.py --check-uv-version"
     first_preflight = output.index(preflight)
-    homebrew_mutation = output.index('brew bundle upgrade --file="$PWD/Brewfile"')
     second_preflight = output.index(preflight, first_preflight + 1)
-    uv_mutation = output.index('"$uv_executable" lock --upgrade')
     third_preflight = output.index(preflight, second_preflight + 1)
+    homebrew_mutation = output.index('brew bundle upgrade --file="$PWD/Brewfile"')
+    fourth_preflight = output.index(preflight, third_preflight + 1)
+    uv_mutation = output.index('"$uv_executable" lock --upgrade')
     cargo_mutation = output.index('cargo install-update --locked "${packages[@]}"')
-    assert first_preflight < homebrew_mutation < second_preflight < uv_mutation < third_preflight < cargo_mutation
+    assert first_preflight < second_preflight < homebrew_mutation < third_preflight < uv_mutation < fourth_preflight < cargo_mutation
 
 
 @pytest.mark.parametrize(

--- a/scripts/test_update_tool_pins.py
+++ b/scripts/test_update_tool_pins.py
@@ -1,14 +1,12 @@
 """Tests for atomic repository tool-pin reconciliation."""
 
+import shutil
 import subprocess
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 
 import update_tool_pins
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def cargo_output(*, override: tuple[str, str] | None = None) -> str:
@@ -115,7 +113,66 @@ def test_main_uses_supplied_uv_executable(tmp_path: Path, monkeypatch: pytest.Mo
     result = update_tool_pins.main(["--justfile", str(justfile), "--uv-executable", str(uv_executable)])
 
     assert result == 0
-    assert commands[1] == [str(uv_executable), "--version"]
+    assert commands[0] == [str(uv_executable), "--version"]
+
+
+def test_check_uv_version_accepts_a_newer_stable_version_without_reading_cargo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    uv_executable = tmp_path / "homebrew-uv"
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="uv 9.8.7\n", stderr="")
+
+    monkeypatch.setattr(update_tool_pins.subprocess, "run", fake_run)
+
+    result = update_tool_pins.main(["--check-uv-version", "--uv-executable", str(uv_executable)])
+
+    assert result == 0
+    assert commands == [[str(uv_executable), "--version"]]
+    assert "uv 9.8.7 satisfies the stable X.Y.Z contract" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("output", ["uv 1.2.3-rc.1", "uv release-1.2.3", "uv unknown", "uv 1.2.3 using runtime 3.14.0"])
+def test_check_uv_version_rejects_unstable_or_ambiguous_output_before_reading_cargo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], output: str
+) -> None:
+    uv_executable = tmp_path / "homebrew-uv"
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **_: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout=output, stderr="")
+
+    monkeypatch.setattr(update_tool_pins.subprocess, "run", fake_run)
+
+    result = update_tool_pins.main(["--check-uv-version", "--uv-executable", str(uv_executable)])
+
+    assert result == 1
+    assert commands == [[str(uv_executable), "--version"]]
+    assert "failed to validate uv version: invalid tool state:" in capsys.readouterr().err
+
+
+def test_update_recipe_preflights_uv_before_homebrew_and_cargo_mutations() -> None:
+    repository = Path(__file__).resolve().parents[1]
+    just = shutil.which("just")
+    assert just is not None
+
+    result = subprocess.run(  # noqa: S603 - resolved Just executable and fixed arguments.
+        [just, "--justfile", str(repository / "justfile"), "--dry-run", "update"], check=True, capture_output=True, text=True, cwd=repository
+    )
+
+    output = f"{result.stdout}\n{result.stderr}"
+    preflight = "scripts/update_tool_pins.py --check-uv-version"
+    first_preflight = output.index(preflight)
+    homebrew_mutation = output.index('brew bundle upgrade --file="$PWD/Brewfile"')
+    second_preflight = output.index(preflight, first_preflight + 1)
+    uv_mutation = output.index('"$uv_executable" lock --upgrade')
+    third_preflight = output.index(preflight, second_preflight + 1)
+    cargo_mutation = output.index('cargo install-update --locked "${packages[@]}"')
+    assert first_preflight < homebrew_mutation < second_preflight < uv_mutation < third_preflight < cargo_mutation
 
 
 @pytest.mark.parametrize(

--- a/scripts/update_tool_pins.py
+++ b/scripts/update_tool_pins.py
@@ -56,6 +56,12 @@ def parse_tool_version(output: str, tool: str) -> str:
     return require_stable_version(versions[0], tool)
 
 
+def read_stable_uv_version(uv_executable: Path) -> str:
+    """Read and validate the stable version of the selected uv executable."""
+    result = subprocess.run([str(uv_executable), "--version"], check=True, capture_output=True, text=True, timeout=30)  # noqa: S603
+    return parse_tool_version(result.stdout, "uv")
+
+
 def sanitize_diagnostic(value: object) -> str:
     """Return one bounded line without terminal control sequences."""
     text = value.decode(errors="replace") if isinstance(value, bytes) else str(value)
@@ -133,18 +139,23 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--justfile", type=Path, default=Path("justfile"), help="Just source containing repository tool pins")
     parser.add_argument("--uv-executable", type=Path, required=True, help="Verified Homebrew-managed uv executable")
+    parser.add_argument("--check-uv-version", action="store_true", help="validate that uv reports exactly one stable X.Y.Z version without reconciling pins")
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     """Reconcile managed tool pins from the local installations."""
     args = parse_args(argv)
+    operation = "validate uv version" if args.check_uv_version else "update tool pins"
     try:
+        uv_version = read_stable_uv_version(args.uv_executable)
+        if args.check_uv_version:
+            print(f"Homebrew-managed uv {uv_version} satisfies the stable X.Y.Z contract.")
+            return 0
         cargo = subprocess.run(["cargo", "install", "--list"], check=True, capture_output=True, text=True, timeout=30)  # noqa: S607
-        uv = subprocess.run([str(args.uv_executable), "--version"], check=True, capture_output=True, text=True, timeout=30)  # noqa: S603
-        changes = reconcile_pins(args.justfile, cargo.stdout, uv.stdout)
+        changes = reconcile_pins(args.justfile, cargo.stdout, uv_version)
     except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired, ValueError) as error:
-        print(f"failed to update tool pins: {format_failure(error)}", file=sys.stderr)
+        print(f"failed to {operation}: {format_failure(error)}", file=sys.stderr)
         return 1
 
     if not changes:

--- a/uv.lock
+++ b/uv.lock
@@ -763,11 +763,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.5"
+version = "4.11.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ea/06/cf1564dcc2e2261c8c8c6c05628dc8b418943bdae2a4e58640ceb2f770fa/platformdirs-4.11.5.tar.gz", hash = "sha256:e8b31f4f8bcbbedef91a6b57a706255e4f148d2a4e01648382a0a47342539173", size = 34823, upload-time = "2026-08-27T21:36:37.46Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/b7/802a56eca9f2fac455b8bab5375a2647b0f0e14a2cd63ef077de3c4a7658/platformdirs-4.11.7.tar.gz", hash = "sha256:4f41487eeeeeb07f3a6625e61d9bc0ae6809f92d3386dbd74392fbb76108104d", size = 35127, upload-time = "2026-09-01T13:35:10.502Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/12/6f3fcd5067a9cbf4f8664b32957973498da8b083455203c8d9cab83a725c/platformdirs-4.11.5-py3-none-any.whl", hash = "sha256:89f8d42695853b89c7170bd49bc3dc593f98a71e695ede88e06a3b247bc4563b", size = 23900, upload-time = "2026-08-27T21:36:36.227Z" },
+    { url = "https://files.pythonhosted.org/packages/27/6e/80993e10a0482f630cef528635789233224f36b1ffd11592aa15d13ff9ce/platformdirs-4.11.7-py3-none-any.whl", hash = "sha256:8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6", size = 23938, upload-time = "2026-09-01T13:35:09.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Reference planned validation units by digest so isolated workdirs reconcile without duplicate execution.
- Reject unstable uv versions before dependency mutations and update managed pins.
- Strengthen CodeRabbit review-state and Windows subprocess evidence guidance.

Fixes #44
Fixes #45
Fixes #46
Fixes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified review-state interpretation, subprocess evidence requirements, platform regression coverage, and validation audit guidance.
  - Documented planned validation references, canonical digests, execution identity, and late-validation rules.

- **Validation**
  - Added support for planned validation references alongside legacy requirements.
  - Improved digest reconciliation, identity consistency checks, and diagnostics for alternative payload formats.
  - Tightened digest format validation and expanded subprocess regression coverage.

- **Tooling**
  - Added stable `uv` version checks before update operations.
  - Added a command-line option to verify the selected `uv` version without modifying dependencies or tool pins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->