### PR TITLE
fix(skills): harden review graph and Python validation

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -32,7 +32,10 @@ reviews:
   auto_assign_reviewers: false
   poem: true
   labeling_instructions: []
-  path_filters: []
+  # Deliberately invalid Semgrep fixtures are validated by repository-owned
+  # Ruff, ty, and Semgrep gates instead of general-purpose AI review.
+  path_filters:
+    - "!tests/semgrep/**"
   path_instructions:
     - path: "agents/.agents/skills/**"
       instructions: |
@@ -91,7 +94,7 @@ reviews:
       enabled: true
   pre_merge_checks:
     docstrings:
-      mode: warning
+      mode: off
       threshold: 100
     title:
       mode: warning

--- a/agents/.agents/skills/repository-independent-review/SKILL.md
+++ b/agents/.agents/skills/repository-independent-review/SKILL.md
@@ -38,8 +38,9 @@ sections, in order, with no preamble or machine-authored identifiers:
   Ordinary Markdown backticks around repository paths are accepted and
   normalized by the compiler.
 - `## Findings`: `No findings.` for a no-findings result; otherwise ordered
-  `- Finding:` records with `Severity`, `Location`, `Summary`, `Evidence`,
-  `Impact`, `Owner`, and `Remediation`
+  `- Finding: <short identity>` records with a non-empty identity on that same
+  line, followed by `Severity`, `Location`, `Summary`, `Evidence`, `Impact`,
+  `Owner`, and `Remediation`. Severity is exactly `P0`, `P1`, `P2`, or `P3`.
 - `## No-Finding Evidence`: one `- Inspected:` record for every dispatched
   adversarial check and every material contract supporting a no-findings claim
 - `## Routing Handoffs`: exact `none` or ordered `- Catalog ID:` records with
@@ -47,9 +48,13 @@ sections, in order, with no preamble or machine-authored identifiers:
 - `## Fingerprint Proof`: expected, before, and after identities
 - `## Git State`: confirmation that no source or Git mutation occurred
 
-Use [references/native-example.md](references/native-example.md) as the exact
-syntax example. Its concrete values are illustrative; copy the dispatched
-target, paths, fingerprints, and adversarial checks instead of those values.
+Use [the no-findings example](references/native-example.md) or [the positive
+finding example](references/native-positive-example.md) as the exact syntax
+example. Their concrete values are illustrative; copy the dispatched target,
+paths, fingerprints, and adversarial checks instead of those values. Ordinary
+single-backtick Markdown is normalized only around repository path items and
+catalog IDs. Keep severity and field labels unformatted; descriptive field
+values are preserved as written.
 
 The coordinator runs `compile-independent-review`. That compiler assigns
 finding, handoff, evidence, and artifact identities; appends the canonical

--- a/agents/.agents/skills/repository-independent-review/references/native-positive-example.md
+++ b/agents/.agents/skills/repository-independent-review/references/native-positive-example.md
@@ -1,0 +1,51 @@
+# Repository Independent Review
+
+## Scope Inspected
+
+- Change target: git diff -- agents/.agents/skills/review-graph/scripts/fixtures/state.rs
+- Files: `agents/.agents/skills/review-graph/scripts/fixtures/state.rs`
+- Branches: captured change target
+- Boundary cases: dispatched adversarial checks
+- Tests: planned validator evidence
+
+## Findings
+
+- Finding: unchecked state transition
+  - Severity: P2
+  - Location: agents/.agents/skills/review-graph/scripts/fixtures/state.rs:1
+  - Summary: The changed transition accepts an invalid state.
+  - Evidence: The branch updates state without checking the required precondition.
+  - Impact: Invalid state can reach downstream callers.
+  - Owner: rust-invariant-state-transitions
+  - Remediation: Check the precondition before publishing the new state.
+
+## No-Finding Evidence
+
+none
+
+## Routing Handoffs
+
+- Catalog ID: `rust.errors`
+  - Observed trigger: The invalid transition needs a typed failure path.
+  - Reason: Error ownership is outside the independent review leaf.
+  - Scope: `agents/.agents/skills/review-graph/scripts/fixtures/state.rs`
+
+## Fingerprint Proof
+
+- Expected:
+  - Scope fingerprint: scope
+  - Worktree fingerprint: worktree
+  - Repository state fingerprint: repository
+- Before:
+  - Scope fingerprint: scope
+  - Worktree fingerprint: worktree
+  - Repository state fingerprint: repository
+- After:
+  - Scope fingerprint: scope
+  - Worktree fingerprint: worktree
+  - Repository state fingerprint: repository
+
+## Git State
+
+- Source-controlled files changed: none
+- Git state mutated: no

--- a/agents/.agents/skills/review-graph/references/node-contract.md
+++ b/agents/.agents/skills/review-graph/references/node-contract.md
@@ -549,3 +549,10 @@ or detected mutation; its Result dispositions must reconcile with the observed
 identities, its handoffs must still match the typed tuple, and it must state one
 concrete limitation. Assign stable graph-finding IDs deterministically without
 rewriting the preserved native report.
+
+In the worker-authored native input, each positive record starts with
+`- Finding: <short identity>` and the identity must be non-empty on that same
+line. The runtime reports all missing, duplicate, empty, out-of-order, and
+invalid-severity fields it can determine in one compilation pass. It normalizes
+ordinary single-backtick Markdown around repository path items and catalog IDs;
+field labels and `P0` through `P3` severity values remain unformatted.

--- a/agents/.agents/skills/review-graph/references/planning-contract.md
+++ b/agents/.agents/skills/review-graph/references/planning-contract.md
@@ -401,6 +401,10 @@ requirement ID, ordered commands, working directory for each command, environmen
 and dependency policy; explicitly plan toolchain, platform, expected artifacts,
 isolation, and remaining execution fields. Units must be required and source-bound.
 An existing requirement ID cannot be repurposed for different commands.
+Before expansion, the runtime checks Cargo benchmark target `required-features`,
+requires a repository canonical `just` benchmark recipe when one exists, checks
+non-isolated working directories against the captured current state, and rejects
+post-remediation-only evidence in a review-only source epoch.
 
 Alternatively, record an actual user scope decision in `user_exclusions`, using
 the returned `originating_evidence_id`, `requirement_id`, `requirement_digest`,

--- a/agents/.agents/skills/review-graph/references/runtime-contract.md
+++ b/agents/.agents/skills/review-graph/references/runtime-contract.md
@@ -13,6 +13,8 @@ Public contracts:
 - `schemas/runtime-operation-inputs-v1.schema.json`
 - `runtime-operation-examples-v1.json`
 
+Safety details: [runtime-safety.md](runtime-safety.md).
+
 `--help` links input definitions and examples.
 
 Bootstrap capture provenance into the routing/validation template:

--- a/agents/.agents/skills/review-graph/references/runtime-safety.md
+++ b/agents/.agents/skills/review-graph/references/runtime-safety.md
@@ -1,0 +1,40 @@
+# Review Graph Runtime Safety
+
+Read this reference when materializing or retrying a graph, compiling a node,
+coordinating a large ready set, diagnosing isolation, or expanding late
+validation.
+
+## Retry-Safe Materialization
+
+The exact symbolic triple `["scope", "worktree", "repository"]` in the public
+operation example means “use the plan-bound captured triple.” Materialization
+resolves it only when planned validation units agree on one triple. It stages
+the complete immutable file set outside the requested store, preflights every
+conflict, and publishes only after all dispatches and contracts validate. A
+CLI operation-result path must be outside the store. The runtime publishes that
+result and the store with rollback on either failure, so a failed attempt leaves
+both destinations retryable.
+
+## Transactional Compilation
+
+`compile-node --output` names the operation-result JSON, not the dispatch-owned
+compiled artifact. All destinations must be distinct. The runtime preflights
+them, publishes compiled evidence and the operation result, then appends the
+journal event as the final acceptance commit.
+
+## Isolation And Compact Readiness
+
+For `fresh_context: true`, compilation rejects a command ledger that names
+another node's worker input, payload, compiled report, or evidence sidecar.
+
+Use `next-ready --compact` for large ready sets. It returns node IDs, result
+contracts, execution locations, and immutable `worker_input_path` references
+without embedding full dispatches.
+
+## Late Validation Quality
+
+Before expansion, the runtime checks Cargo benchmark target
+`required-features`, requires a repository canonical `just` benchmark recipe
+when one exists, checks non-isolated working directories against the captured
+current state, and rejects post-remediation-only evidence in a review-only
+source epoch.

--- a/agents/.agents/skills/review-graph/scripts/review_graph_plan.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_plan.py
@@ -2536,8 +2536,8 @@ def _native_nonempty_section_blockers(body: str, *, section: str) -> tuple[str, 
 
 def _native_records(body: str, label: str) -> tuple[tuple[str, str], ...]:
     lines = body.splitlines()
-    prefix = f"- {label}: "
-    positions = tuple(index for index, line in enumerate(lines) if line.startswith(prefix))
+    prefix = f"- {label}:"
+    positions = tuple(index for index, line in enumerate(lines) if line == prefix or line.startswith(prefix + " "))
     records: list[tuple[str, str]] = []
     for ordinal, position in enumerate(positions):
         end = positions[ordinal + 1] if ordinal + 1 < len(positions) else len(lines)

--- a/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
@@ -232,6 +232,7 @@ def _write_bytes_atomically_once(path: Path, content: bytes, *, mode: int) -> bo
     descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
     temporary_path = Path(temporary_name)
     created = False
+    completed = False
     try:
         with os.fdopen(descriptor, "wb") as stream:
             stream.write(content)
@@ -247,9 +248,12 @@ def _write_bytes_atomically_once(path: Path, content: bytes, *, mode: int) -> bo
                 raise ValueError(msg) from None
         if created:
             _fsync_directory(path.parent)
+        completed = True
         return created
     finally:
         temporary_path.unlink(missing_ok=True)
+        if created and not completed:
+            path.unlink(missing_ok=True)
 
 
 def _queue_materialized_write(pending: dict[Path, tuple[bytes, int]], path: Path, content: bytes, *, mode: int) -> None:
@@ -4238,6 +4242,8 @@ def _cargo_benchmark_options(arguments: list[str], subcommand_index: int) -> tup
     features: set[str] = set()
     all_features = False
     for argument_index, argument in enumerate(arguments[subcommand_index + 1 :], start=subcommand_index + 1):
+        if argument == "--":
+            break
         if argument == "--bench" and argument_index + 1 < len(arguments):
             target = arguments[argument_index + 1]
         elif argument.startswith("--bench="):
@@ -5059,6 +5065,27 @@ def _preflight_compile_destination(path: Path, content: bytes) -> None:
         raise ValueError(msg)
 
 
+def _rollback_compile_journal(path: Path, *, existing_size: int, remove_after_truncate: bool) -> None:
+    """Remove a failed append while preserving the pre-attempt journal prefix."""
+    with path.open("r+b") as stream:
+        stream.truncate(existing_size)
+        stream.flush()
+        os.fsync(stream.fileno())
+    if remove_after_truncate:
+        path.unlink()
+        _fsync_directory(path.parent)
+
+
+def _remove_attempt_created_files(paths: list[Path]) -> None:
+    """Remove only immutable files published by the current failed attempt."""
+    parents: set[Path] = set()
+    for path in reversed(paths):
+        path.unlink(missing_ok=True)
+        parents.add(path.parent)
+    for parent in parents:
+        _fsync_directory(parent)
+
+
 def _compile_node_from_files(document: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:  # noqa: C901, PLR0912, PLR0915
     plan, entry = _lifecycle_dispatch(document, args.dispatches, args.node_id)
     source_state = _state(document, "source_state")
@@ -5156,29 +5183,51 @@ def _compile_node_from_files(document: dict[str, Any], args: argparse.Namespace)
         try:
             try:
                 journal_content = args.journal.read_bytes()
+                journal_existed = True
             except FileNotFoundError:
                 journal_content = b""
+                journal_existed = False
             _events, lifecycle_state, _head = _read_execution_journal_content(journal_content, path=args.journal, plan=plan, source_state=source_state)
             _apply_journal_transition(plan, lifecycle_state, node_id=request.node_id, status=request.status)
             normalized = metadata.get("normalized_record")
             journal_limitations = tuple(cast("list[str]", normalized.get("limitations", []))) if isinstance(normalized, dict) else ()
             _new_journal_reason(request, journal_limitations)
-            _write_bytes_atomically_once(sealed_payload_path, payload_bytes, mode=0o444)
-            _write_bytes_once(artifact_path, content)
-            _write_bytes_once(metadata_path, metadata_bytes)
-            event, existing_size = _prepare_journal_event(args.journal, plan=plan, source_state=source_state, request=request, content=journal_content)
-            result = {
-                "artifact_path": str(artifact_path),
-                "journal_event": event,
-                "metadata_path": str(metadata_path),
-                "node_id": args.node_id,
-                "schema_version": 1,
-                "worker_payload_path": str(sealed_payload_path),
-            }
-            _write_text_once(operation_output_path, json.dumps(result, indent=2, sort_keys=True) + "\n")
-            with args.journal.open("ab") as journal_stream:
-                _persist_journal_event(journal_stream, args.journal, event, existing_size=existing_size)
-            return result
+            existing_size = len(journal_content)
+            created_paths: list[Path] = []
+            journal_append_started = False
+            completed = False
+            try:
+                for path, output_bytes in ((sealed_payload_path, payload_bytes), (artifact_path, content), (metadata_path, metadata_bytes)):
+                    if _write_bytes_atomically_once(path, output_bytes, mode=0o444):
+                        created_paths.append(path)
+                event, existing_size = _prepare_journal_event(args.journal, plan=plan, source_state=source_state, request=request, content=journal_content)
+                result = {
+                    "artifact_path": str(artifact_path),
+                    "journal_event": event,
+                    "metadata_path": str(metadata_path),
+                    "node_id": args.node_id,
+                    "schema_version": 1,
+                    "worker_payload_path": str(sealed_payload_path),
+                }
+                result_bytes = (json.dumps(result, indent=2, sort_keys=True) + "\n").encode()
+                if _write_bytes_atomically_once(operation_output_path, result_bytes, mode=0o444):
+                    created_paths.append(operation_output_path)
+                with args.journal.open("ab") as journal_stream:
+                    journal_stream.seek(0, os.SEEK_END)
+                    if journal_stream.tell() != existing_size:
+                        msg = f"execution journal changed during append: {args.journal}"
+                        raise ValueError(msg)
+                    journal_append_started = True
+                    _persist_journal_event(journal_stream, args.journal, event, existing_size=existing_size)
+                completed = True
+                return result
+            finally:
+                if not completed:
+                    try:
+                        if journal_append_started:
+                            _rollback_compile_journal(args.journal, existing_size=existing_size, remove_after_truncate=not journal_existed)
+                    finally:
+                        _remove_attempt_created_files(created_paths)
         finally:
             fcntl.flock(lock_stream.fileno(), fcntl.LOCK_UN)
 

--- a/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
@@ -12,6 +12,7 @@ import stat
 import subprocess
 import sys
 import tempfile
+import tomllib
 from collections import Counter
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
@@ -42,6 +43,7 @@ from review_graph_plan import (
     ValidationEvidenceExpectation,
     ValidationEvidenceMapping,
     ValidationExclusion,
+    ValidationRequirement,
     ValidationUnit,
     WorkerBudget,
     WorkerNode,
@@ -225,8 +227,8 @@ def _write_text_once(path: Path, content: str) -> None:
     _write_bytes_once(path, content.encode("utf-8"))
 
 
-def _write_bytes_atomically_once(path: Path, content: bytes, *, mode: int) -> None:
-    """Atomically create immutable content, permitting only an identical replay."""
+def _write_bytes_atomically_once(path: Path, content: bytes, *, mode: int) -> bool:
+    """Atomically create immutable content and report whether this call published it."""
     descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
     temporary_path = Path(temporary_name)
     created = False
@@ -245,8 +247,85 @@ def _write_bytes_atomically_once(path: Path, content: bytes, *, mode: int) -> No
                 raise ValueError(msg) from None
         if created:
             _fsync_directory(path.parent)
+        return created
     finally:
         temporary_path.unlink(missing_ok=True)
+
+
+def _queue_materialized_write(pending: dict[Path, tuple[bytes, int]], path: Path, content: bytes, *, mode: int) -> None:
+    """Queue one immutable materialization output without touching its final store."""
+    existing = pending.get(path)
+    candidate = (content, mode)
+    if existing is not None and existing != candidate:
+        msg = f"materialization produced conflicting content for immutable artifact: {path}"
+        raise ValueError(msg)
+    pending[path] = candidate
+
+
+def _publish_materialized_writes(artifact_store: Path, pending: dict[Path, tuple[bytes, int]]) -> bool:
+    """Stage a complete materialization and report whether a new store was published."""
+    artifact_store.parent.mkdir(parents=True, exist_ok=True)
+    staging_root = Path(tempfile.mkdtemp(prefix=f".{artifact_store.name}.materialize.", dir=artifact_store.parent))
+    try:
+        for final_path, (content, mode) in pending.items():
+            try:
+                relative = final_path.relative_to(artifact_store)
+            except ValueError:
+                msg = f"materialized artifact escapes its requested store: {final_path}"
+                raise ValueError(msg) from None
+            staged_path = staging_root / relative
+            staged_path.parent.mkdir(parents=True, exist_ok=True)
+            _write_bytes_atomically_once(staged_path, content, mode=mode)
+
+        if artifact_store.exists() and not artifact_store.is_dir():
+            msg = f"artifact_store is not a directory: {artifact_store}"
+            raise ValueError(msg)
+        # Check every conflict before publishing any new immutable output. This
+        # keeps corrected retries safe even when a prior store already exists.
+        for final_path, (content, _mode) in pending.items():
+            if final_path.exists() and _read_regular_file_no_follow(final_path) != content:
+                msg = f"refusing to overwrite non-identical immutable artifact: {final_path}"
+                raise ValueError(msg)
+
+        if not artifact_store.exists() or not any(artifact_store.iterdir()):
+            if artifact_store.exists():
+                artifact_store.rmdir()
+            staging_root.rename(artifact_store)
+            try:
+                _fsync_directory(artifact_store.parent)
+            except OSError:
+                artifact_store.rename(staging_root)
+                raise
+            return True
+        missing = tuple(final_path for final_path in pending if not final_path.exists())
+        if missing:
+            msg = "existing materialization store is incomplete; refusing a partial immutable publish: " + ", ".join(map(str, missing))
+            raise ValueError(msg)
+        return False
+    finally:
+        shutil.rmtree(staging_root, ignore_errors=True)
+
+
+def _publish_materialization_with_result(
+    artifact_store: Path, pending: dict[Path, tuple[bytes, int]], operation_output_path: Path, output: dict[str, Any]
+) -> None:
+    """Publish a CLI result and its immutable store as one rollback-safe operation."""
+    output_path = operation_output_path.absolute()
+    output_bytes = (json.dumps(output, indent=2, sort_keys=True) + "\n").encode()
+    _preflight_compile_destination(output_path, output_bytes)
+    resolved_output_path = output_path.resolve()
+    if resolved_output_path == artifact_store or resolved_output_path.is_relative_to(artifact_store):
+        msg = "materialize-dispatches operation-result path must be outside the artifact store"
+        raise ValueError(msg)
+    output_created = _write_bytes_atomically_once(output_path, output_bytes, mode=0o444)
+    materialization_completed = False
+    try:
+        _publish_materialized_writes(artifact_store, pending)
+        materialization_completed = True
+    finally:
+        if not materialization_completed and output_created:
+            output_path.unlink()
+            _fsync_directory(output_path.parent)
 
 
 def _required_text(item: dict[str, Any], name: str) -> str:
@@ -561,6 +640,11 @@ def _review_command_policy_blockers(dispatch: dict[str, Any], payload: dict[str,
     duplicates = tuple(command for command in commands if command in prohibited)
     if duplicates:
         return ("review payload executed commands owned by planned validators: " + ", ".join(duplicates),)
+    if dispatch.get("fresh_context") is True:
+        forbidden = _text_list(dispatch, "fresh_context_forbidden_artifacts")
+        violations = tuple(f"{command} -> {path}" for command in commands for path in forbidden if path in command)
+        if violations:
+            return ("fresh-context review read another node's worker/report/evidence artifact: " + "; ".join(violations),)
     return ()
 
 
@@ -997,17 +1081,20 @@ def _independent_findings(body: str, node_id: str, status: str) -> tuple[tuple[s
         msg = "independent Findings must contain ordered Finding records"
         raise ValueError(msg)
     output: list[tuple[str, dict[str, str]]] = []
+    blockers: list[str] = []
     labels = ("Severity", "Location", "Summary", "Evidence", "Impact", "Owner", "Remediation")
-    for ordinal, (_worker_identity, record_body) in enumerate(records, start=1):
-        fields, blockers = _native_record_fields(record_body, section=f"independent Finding {ordinal}", labels=labels)
-        if blockers:
-            msg = "; ".join(blockers)
-            raise ValueError(msg)
-        severity = fields["Severity"]
-        if severity not in _SEVERITIES:
-            msg = f"independent Finding {ordinal} has invalid severity {severity}"
-            raise ValueError(msg)
-        output.append((f"{node_id}-finding-{ordinal}", dict(fields)))
+    for ordinal, (worker_identity, record_body) in enumerate(records, start=1):
+        if not worker_identity:
+            blockers.append(f"independent Finding {ordinal} requires a non-empty value on the same line as - Finding:")
+        fields, field_blockers = _native_record_fields(record_body, section=f"independent Finding {ordinal}", labels=labels)
+        blockers.extend(field_blockers)
+        severity = fields.get("Severity")
+        if severity is not None and severity not in _SEVERITIES:
+            blockers.append(f"independent Finding {ordinal} has invalid severity {severity}; expected P0, P1, P2, or P3")
+        if not field_blockers and worker_identity and severity in _SEVERITIES:
+            output.append((f"{node_id}-finding-{ordinal}", dict(fields)))
+    if blockers:
+        raise ValueError("; ".join(blockers))
     return tuple(output)
 
 
@@ -1038,6 +1125,8 @@ def _independent_handoffs(body: str, node_id: str, dispatch: dict[str, Any]) -> 
         raise ValueError(msg)
     output: list[tuple[str, dict[str, Any]]] = []
     for ordinal, (catalog_id, record_body) in enumerate(records, start=1):
+        if len(catalog_id) >= 2 and catalog_id.startswith("`") and catalog_id.endswith("`"):
+            catalog_id = catalog_id[1:-1]
         fields, blockers = _native_record_fields(record_body, section=f"independent Handoff {ordinal}", labels=("Observed trigger", "Reason", "Scope"))
         if blockers:
             msg = "; ".join(blockers)
@@ -2917,7 +3006,7 @@ def persist_worker_payload(contract_document: dict[str, Any], candidate_path: Pa
 
 
 def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
-    document: dict[str, Any], *, preserved_entries: dict[str, dict[str, Any]] | None = None
+    document: dict[str, Any], *, preserved_entries: dict[str, dict[str, Any]] | None = None, operation_output_path: Path | None = None
 ) -> dict[str, Any]:
     """Derive exact per-node dispatch bases from one accepted graph plan."""
     raw_plan = document.get("plan")
@@ -2929,6 +3018,13 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
         msg = "cannot materialize dispatches from a blocked graph plan"
         raise ValueError(msg)
     source_state = _state(document, "source_state")
+    if source_state == ("scope", "worktree", "repository"):
+        planned_states = {unit.source_state for unit in plan.coalesced_validation_units}
+        if len(planned_states) > 1:
+            msg = "symbolic materialization source_state requires one unambiguous plan-bound fingerprint triple"
+            raise ValueError(msg)
+        if planned_states:
+            source_state = planned_states.pop()
     _verified_reused_sources(plan, source_state)
     repository_root_path = Path(_required_text(document, "repository_root"))
     if not repository_root_path.is_absolute() or not repository_root_path.is_dir():
@@ -2947,10 +3043,10 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
         raise ValueError(msg)
     state_command = _required_text(document, "state_verification_command")
     artifact_store = Path(_required_text(document, "artifact_store")).resolve()
-    artifact_store.mkdir(parents=True, exist_ok=True)
-    if not artifact_store.is_dir():
+    if artifact_store.exists() and not artifact_store.is_dir():
         msg = f"artifact_store is not a directory: {artifact_store}"
         raise ValueError(msg)
+    pending_writes: dict[Path, tuple[bytes, int]] = {}
     inspection_profile = document.get("inspection_profile", "shared-read-only")
     if inspection_profile not in {"independent-source", "shared-read-only"}:
         msg = "inspection_profile must be independent-source or shared-read-only"
@@ -2978,7 +3074,9 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
         _inspection_groups(plan, source_state, artifact_store, repository_root_path.resolve()) if inspection_profile == "shared-read-only" else {}
     )
     for record in {str(record["artifact_path"]): record for record in inspection_groups.values()}.values():
-        _write_text_once(Path(cast("str", record["artifact_path"])), json.dumps(record, indent=2, sort_keys=True) + "\n")
+        _queue_materialized_write(
+            pending_writes, Path(cast("str", record["artifact_path"])), (json.dumps(record, indent=2, sort_keys=True) + "\n").encode(), mode=0o444
+        )
     raw_duplicate_authorizations = document.get("duplicate_command_authorizations", {})
     if not isinstance(raw_duplicate_authorizations, dict) or any(
         not isinstance(node_id, str)
@@ -3112,7 +3210,9 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
             "schema_version": 1,
             "worker_payload_path": str(worker_payload_path),
         }
-        _write_text_once(worker_payload_contract_path, json.dumps(persistence_contract, indent=2, sort_keys=True) + "\n")
+        _queue_materialized_write(
+            pending_writes, worker_payload_contract_path, (json.dumps(persistence_contract, indent=2, sort_keys=True) + "\n").encode(), mode=0o444
+        )
         worker_input_path = artifact_store / f"{node.node_id}.worker-input.json"
         entry = {
             "artifact_path": str(artifact_path),
@@ -3128,10 +3228,14 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
             "worker_payload_path": str(worker_payload_path),
             "worker_prompt": _worker_prompt(contract, common),
         }
-        _write_bytes_atomically_once(worker_input_path, (json.dumps(entry, indent=2, sort_keys=True) + "\n").encode(), mode=0o444)
+        _queue_materialized_write(pending_writes, worker_input_path, (json.dumps(entry, indent=2, sort_keys=True) + "\n").encode(), mode=0o444)
         dispatches.append(entry)
     output: dict[str, Any] = {"dispatches": dispatches, "plan_digest": _plan_digest(plan), "schema_version": 1, "source_state": list(source_state)}
     output["dispatch_set_digest"] = _sha256_bytes(_canonical_json(output).encode())
+    if operation_output_path is None:
+        _publish_materialized_writes(artifact_store, pending_writes)
+    else:
+        _publish_materialization_with_result(artifact_store, pending_writes, operation_output_path, output)
     return output
 
 
@@ -3836,6 +3940,37 @@ def _persist_journal_event(stream: Any, path: Path, event: dict[str, Any], *, ex
     os.fsync(stream.fileno())
 
 
+def _prepare_journal_event(
+    path: Path, *, plan: GraphPlan, source_state: tuple[str, str, str], request: JournalEventRequest, content: bytes
+) -> tuple[dict[str, Any], int]:
+    """Validate and build a journal event without committing it."""
+    existing_size = len(content)
+    events, state, head_digest = _read_execution_journal_content(content, path=path, plan=plan, source_state=source_state)
+    node = next((candidate for candidate in plan.actual_worker_nodes if candidate.node_id == request.node_id), None)
+    if node is None:
+        msg = f"journal event references unknown node: {request.node_id}"
+        raise ValueError(msg)
+    if request.status not in _JOURNAL_STATUSES:
+        msg = f"invalid journal status {request.status}"
+        raise ValueError(msg)
+    evidence, limitations = _new_journal_evidence(request, plan=plan, node=node, source_state=source_state)
+    affected = _apply_journal_transition(plan, state, node_id=request.node_id, status=request.status)
+    event: dict[str, Any] = {
+        "affected_node_ids": list(affected),
+        "evidence": evidence,
+        "node_id": request.node_id,
+        "plan_digest": events[0]["plan_digest"] if events else _plan_digest(plan),
+        "previous_event_digest": head_digest,
+        "reason": _new_journal_reason(request, limitations),
+        "schema_version": 1,
+        "sequence": len(events) + 1,
+        "source_state": list(source_state),
+        "status": request.status,
+    }
+    event["event_digest"] = _sha256_bytes(_canonical_json(event).encode())
+    return event, existing_size
+
+
 def append_journal_event(path: Path, document: dict[str, Any], request: JournalEventRequest) -> dict[str, Any]:
     """Append one graph-validated lifecycle event and return its canonical record."""
     raw_plan = document.get("plan")
@@ -3855,30 +3990,7 @@ def append_journal_event(path: Path, document: dict[str, Any], request: JournalE
                 content = path.read_bytes()
             except FileNotFoundError:
                 content = b""
-            existing_size = len(content)
-            events, state, head_digest = _read_execution_journal_content(content, path=path, plan=plan, source_state=source_state)
-            node = next((candidate for candidate in plan.actual_worker_nodes if candidate.node_id == request.node_id), None)
-            if node is None:
-                msg = f"journal event references unknown node: {request.node_id}"
-                raise ValueError(msg)
-            if request.status not in _JOURNAL_STATUSES:
-                msg = f"invalid journal status {request.status}"
-                raise ValueError(msg)
-            evidence, limitations = _new_journal_evidence(request, plan=plan, node=node, source_state=source_state)
-            affected = _apply_journal_transition(plan, state, node_id=request.node_id, status=request.status)
-            event: dict[str, Any] = {
-                "affected_node_ids": list(affected),
-                "evidence": evidence,
-                "node_id": request.node_id,
-                "plan_digest": events[0]["plan_digest"] if events else _plan_digest(plan),
-                "previous_event_digest": head_digest,
-                "reason": _new_journal_reason(request, limitations),
-                "schema_version": 1,
-                "sequence": len(events) + 1,
-                "source_state": list(source_state),
-                "status": request.status,
-            }
-            event["event_digest"] = _sha256_bytes(_canonical_json(event).encode())
+            event, existing_size = _prepare_journal_event(path, plan=plan, source_state=source_state, request=request, content=content)
             with path.open("ab") as journal_stream:
                 _persist_journal_event(journal_stream, path, event, existing_size=existing_size)
             return event
@@ -4089,7 +4201,119 @@ def _fallback_to_coordinator_locked(document: dict[str, Any], args: argparse.Nam
     }
 
 
-def _expanded_validation_plan(document: dict[str, Any], plan: GraphPlan, records: list[dict[str, Any]], repository_root: Path) -> GraphPlan:
+def _just_recipe_names(repository_root: Path) -> set[str]:
+    justfile = repository_root / "justfile"
+    if not justfile.is_file():
+        return set()
+    recipe = re.compile(r"^([A-Za-z0-9_-]+)(?:\s+[^:]*)?:")
+    return {match.group(1) for line in justfile.read_text(encoding="utf-8").splitlines() if (match := recipe.match(line)) is not None}
+
+
+def _cargo_subcommand_index(arguments: list[str], subcommand: str) -> int | None:
+    """Locate a Cargo subcommand after any rustup selector and global options."""
+    if len(arguments) < 2:
+        return None
+    index = 1
+    if arguments[index].startswith("+") and len(arguments[index]) > 1:
+        index += 1
+    global_flags = {"--frozen", "--locked", "--offline", "--quiet", "--verbose", "-q", "-v"}
+    global_value_options = {"--color", "--config", "--explain", "-C", "-Z"}
+    attached_value_prefixes = ("--color=", "--config=", "--explain=", "-C", "-Z")
+    while index < len(arguments) and arguments[index] != subcommand:
+        argument = arguments[index]
+        if argument in global_flags or (argument.startswith("-v") and set(argument[1:]) == {"v"}):
+            index += 1
+        elif argument in global_value_options:
+            index += 2
+        elif argument.startswith(attached_value_prefixes):
+            index += 1
+        else:
+            return None
+    return index if index < len(arguments) and arguments[index] == subcommand else None
+
+
+def _cargo_benchmark_options(arguments: list[str], subcommand_index: int) -> tuple[str | None, set[str], bool]:
+    """Extract a targeted benchmark and its feature-selection options."""
+    target: str | None = None
+    features: set[str] = set()
+    all_features = False
+    for argument_index, argument in enumerate(arguments[subcommand_index + 1 :], start=subcommand_index + 1):
+        if argument == "--bench" and argument_index + 1 < len(arguments):
+            target = arguments[argument_index + 1]
+        elif argument.startswith("--bench="):
+            target = argument.partition("=")[2]
+        elif argument in {"--features", "-F"} and argument_index + 1 < len(arguments):
+            features.update(item for item in re.split(r"[\s,]+", arguments[argument_index + 1]) if item)
+        elif argument.startswith("--features="):
+            features.update(item for item in re.split(r"[\s,]+", argument.partition("=")[2]) if item)
+        elif argument.startswith("-F") and argument != "-F":
+            features.update(item for item in re.split(r"[\s,]+", argument[2:]) if item)
+        elif argument == "--all-features":
+            all_features = True
+    return target, features, all_features
+
+
+def _cargo_benchmark_identity(command: str) -> tuple[str, set[str], bool] | None:
+    try:
+        arguments = shlex.split(command)
+    except ValueError:
+        return None
+    if len(arguments) < 2 or Path(arguments[0]).name != "cargo":
+        return None
+    index = _cargo_subcommand_index(arguments, "bench")
+    if index is None:
+        return None
+    target, features, all_features = _cargo_benchmark_options(arguments, index)
+    return (target, features, all_features) if target else None
+
+
+def _late_validation_quality_blockers(  # noqa: C901
+    requirement: ValidationRequirement, *, repository_root: Path, authorization: str
+) -> tuple[str, ...]:
+    """Reject audit-authored proof obligations that cannot validate the captured epoch."""
+    blockers: list[str] = []
+    recipe_names = _just_recipe_names(repository_root)
+    cargo_manifest = repository_root / "Cargo.toml"
+    benches: dict[str, set[str]] = {}
+    if cargo_manifest.is_file():
+        manifest = tomllib.loads(cargo_manifest.read_text(encoding="utf-8"))
+        for raw in manifest.get("bench", []):
+            if isinstance(raw, dict) and isinstance(raw.get("name"), str):
+                required = raw.get("required-features", [])
+                if isinstance(required, list) and all(isinstance(item, str) for item in required):
+                    benches[raw["name"]] = set(cast("list[str]", required))
+    for command in requirement.commands:
+        identity = _cargo_benchmark_identity(command)
+        if identity is None:
+            continue
+        target, enabled, all_features = identity
+        required = benches.get(target, set())
+        canonical_name = f"bench-{target}"
+        canonical = f"just {canonical_name}" if canonical_name in recipe_names else None
+        missing = [] if all_features else sorted(required - enabled)
+        if missing:
+            detail = f"cargo benchmark target {target} is missing required features: {', '.join(missing)}"
+            if canonical is not None:
+                detail += f"; use the repository canonical recipe {canonical}"
+            blockers.append(detail)
+        elif canonical is not None and (requirement.commands != (canonical,) or requirement.canonical_recipe != canonical):
+            blockers.append(f"cargo benchmark target {target} must use the repository canonical recipe {canonical}")
+    if not requirement.requires_isolation:
+        blockers.extend(
+            f"working directory does not exist in the captured current state: {directory}"
+            for directory in requirement.working_directories
+            if not Path(directory).is_dir()
+        )
+    epoch_text = f"{requirement.request} {requirement.selection_reason} {requirement.expected_evidence}"
+    post_remediation = r"\b(?:post[- ]remediation|(?:after|following|once)\s+(?:the\s+)?(?:remediation|repair|fix(?:es|ed)?))\b"
+    if authorization == "review-only" and re.search(post_remediation, epoch_text, re.IGNORECASE):
+        blockers.append("review-only late validation cannot require post-remediation evidence from the unchanged source epoch")
+    return tuple(blockers)
+
+
+def _expanded_validation_plan(
+    document: dict[str, Any], plan: GraphPlan, records: list[dict[str, Any]], repository_root: Path, *, authorization: str
+) -> GraphPlan:
     reconciliation = _validation_reconciliation(plan, records)
     pending = {item["requirement_id"] for item in reconciliation["requirements"] if item["resolution"] != "planned"}
     raw_requirements = _records(document, "validation_requirements")
@@ -4099,6 +4323,10 @@ def _expanded_validation_plan(document: dict[str, Any], plan: GraphPlan, records
     existing = {requirement for unit in plan.coalesced_validation_units for requirement in unit.requirement_ids}
     source_state = _state(document, "source_state")
     for item in additions:
+        quality_blockers = _late_validation_quality_blockers(item, repository_root=repository_root, authorization=authorization)
+        if quality_blockers:
+            msg = f"late validation requirement {item.requirement_id} failed quality gate: " + "; ".join(quality_blockers)
+            raise ValueError(msg)
         if item.requirement_id not in pending or item.requirement_id in existing or item.source_state != source_state or not item.required:
             msg = f"late validation must be a new, required, source-matching discovered identity: {item.requirement_id}"
             raise ValueError(msg)
@@ -4172,7 +4400,7 @@ def reconcile_validation_requirements(document: dict[str, Any], args: argparse.N
         msg = "validation expansion requires an existing dispatch"
         raise ValueError(msg)
     sample = first_entry["dispatch"]
-    expanded = _expanded_validation_plan(document, plan, records, Path(sample["repository_root"]))
+    expanded = _expanded_validation_plan(document, plan, records, Path(sample["repository_root"]), authorization=_required_text(sample, "authorization"))
     if expanded == plan:
         return {"schema_version": 1, "status": "resolved", **reconciliation}
     store = Path(_required_text(document, "artifact_store")).resolve() / f"validation-expansion-{_plan_digest(expanded)[7:23]}"
@@ -4570,7 +4798,9 @@ def _argument_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     node_parser.add_argument("--journal", type=Path, required=True, help=_INITIAL_JOURNAL_HELP)
     node_parser.add_argument("--status", choices=sorted(_REVIEW_STATUSES))
     node_parser.add_argument("--limitation", action="append")
-    node_parser.add_argument("--output", type=Path, required=True)
+    node_parser.add_argument(
+        "--output", type=Path, required=True, help="operation-result JSON path; must be distinct from the compiled artifact and metadata paths"
+    )
     persist_parser = _runtime_subparser(subparsers, "persist-worker-payload", "validate and atomically publish one materialized worker payload")
     persist_parser.add_argument("--input", type=Path, required=True)
     persist_parser.add_argument("--payload", type=Path, required=True)
@@ -4584,7 +4814,7 @@ def _argument_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     routing_parser.add_argument("--skill-root", type=Path, action="append")
     dispatch_parser = _runtime_subparser(subparsers, "materialize-dispatches", "derive exact dispatch bases from a graph plan")
     dispatch_parser.add_argument("--input", type=Path, required=True)
-    dispatch_parser.add_argument("--output", type=Path, required=True)
+    dispatch_parser.add_argument("--output", type=Path, required=True, help="operation-result JSON path; must be outside the artifact store")
     snapshot_parser = _runtime_subparser(subparsers, "snapshot-workspace", "capture runtime-owned validation workspace evidence")
     snapshot_parser.add_argument("--input", type=Path, required=True)
     snapshot_parser.add_argument("--dispatches", type=Path, required=True)
@@ -4635,6 +4865,7 @@ def _argument_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     ready_parser.add_argument("--current-capture", type=Path, required=True)
     ready_parser.add_argument("--input", type=Path, required=True)
     ready_parser.add_argument("--journal", type=Path, required=True, help=_INITIAL_JOURNAL_HELP)
+    ready_parser.add_argument("--compact", action="store_true", help="return node IDs and immutable worker-input references without embedded dispatches")
     ready_output = ready_parser.add_mutually_exclusive_group(required=True)
     ready_output.add_argument("--output", type=Path)
     ready_output.add_argument(
@@ -4692,7 +4923,21 @@ def _next_ready_from_files(document: dict[str, Any], args: argparse.Namespace) -
         capture.get("repository_state_fingerprint"),
     ]
     journal_events, _state_view, _head_digest = read_execution_journal(args.journal, plan=plan, source_state=source_state)
-    return next_ready_nodes(document, journal_events=journal_events, dispatch_set=_read_json_object(args.dispatches))
+    result = next_ready_nodes(document, journal_events=journal_events, dispatch_set=_read_json_object(args.dispatches))
+    if not getattr(args, "compact", False):
+        return result
+    compact = dict(result)
+    compact["compact"] = True
+    compact["ready_dispatches"] = [
+        {
+            "execution_location": entry["dispatch"]["execution_location"],
+            "node_id": entry["node_id"],
+            "result_contract": entry["result_contract"],
+            "worker_input_path": entry["worker_input_path"],
+        }
+        for entry in result["ready_dispatches"]
+    ]
+    return compact
 
 
 def _with_current_capture(document: dict[str, Any], capture_path: Path) -> dict[str, Any]:
@@ -4750,10 +4995,30 @@ def _lifecycle_dispatch(document: dict[str, Any], dispatches_path: Path, node_id
     source_state = _state(document, "source_state")
     entries = _dispatches_by_node(_read_json_object(dispatches_path), plan=plan, source_state=source_state)
     try:
-        return plan, entries[node_id]
+        selected = json.loads(_canonical_json(entries[node_id]))
     except KeyError:
         msg = f"dispatch set has no planned node {node_id}"
         raise ValueError(msg) from None
+    dispatch = selected.get("dispatch")
+    if isinstance(dispatch, dict) and dispatch.get("fresh_context") is True:
+        forbidden: set[str] = set()
+        for other_id, entry in entries.items():
+            if other_id == node_id:
+                continue
+            for field in (
+                "artifact_path",
+                "metadata_path",
+                "worker_input_path",
+                "worker_payload_candidate_path",
+                "worker_payload_contract_path",
+                "worker_payload_path",
+            ):
+                value = entry.get(field)
+                if isinstance(value, str) and value:
+                    path = Path(value)
+                    forbidden.update((str(path), path.name))
+        dispatch["fresh_context_forbidden_artifacts"] = sorted(forbidden)
+    return plan, selected
 
 
 def _snapshot_workspace_from_files(document: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
@@ -4784,8 +5049,18 @@ def _workspace_records(path: Path, *, node_id: str, source_state: tuple[str, str
     return list(_records(snapshot, "records"))
 
 
+def _preflight_compile_destination(path: Path, content: bytes) -> None:
+    """Reject an immutable destination conflict before any compile output is published."""
+    if path.is_symlink():
+        msg = f"compile-node destination must not be a symlink: {path}"
+        raise ValueError(msg)
+    if path.exists() and _read_regular_file_no_follow(path) != content:
+        msg = f"refusing to overwrite non-identical artifact: {path}"
+        raise ValueError(msg)
+
+
 def _compile_node_from_files(document: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:  # noqa: C901, PLR0912, PLR0915
-    _plan, entry = _lifecycle_dispatch(document, args.dispatches, args.node_id)
+    plan, entry = _lifecycle_dispatch(document, args.dispatches, args.node_id)
     source_state = _state(document, "source_state")
     before_state = _capture_source_state(args.before_capture)
     after_state = _capture_source_state(args.after_capture)
@@ -4837,11 +5112,8 @@ def _compile_node_from_files(document: dict[str, Any], args: argparse.Namespace)
 
     artifact_path = Path(_required_text(entry, "artifact_path")).resolve()
     metadata_path = Path(_required_text(entry, "metadata_path")).resolve()
-    for parent in {artifact_path.parent, metadata_path.parent, payload_path.parent, args.journal.parent.resolve()}:
-        parent.mkdir(parents=True, exist_ok=True)
     worker_payload_digest = _sha256_bytes(payload_bytes)
     sealed_payload_path = payload_path.with_name(f"{payload_path.stem}.{worker_payload_digest.removeprefix('sha256:')}.sealed{payload_path.suffix}")
-    _write_bytes_atomically_once(sealed_payload_path, payload_bytes, mode=0o444)
     metadata = {
         **metadata,
         "worker_payload_byte_count": len(payload_bytes),
@@ -4849,8 +5121,7 @@ def _compile_node_from_files(document: dict[str, Any], args: argparse.Namespace)
         "worker_payload_path": str(sealed_payload_path),
         "worker_payload_staging_path": str(payload_path),
     }
-    _write_bytes_once(artifact_path, content)
-    _write_text_once(metadata_path, json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+    metadata_bytes = (json.dumps(metadata, indent=2, sort_keys=True) + "\n").encode()
     evidence = metadata.get("evidence")
     if not isinstance(evidence, dict):
         msg = "compiler metadata lacks evidence"
@@ -4858,17 +5129,58 @@ def _compile_node_from_files(document: dict[str, Any], args: argparse.Namespace)
     evidence_status = _required_text(evidence, "status")
     journal_status = "blocked" if evidence_status in {"blocked", "not-applicable"} else "accepted"
     source = {"artifact_path": str(artifact_path), "metadata_path": str(metadata_path)}
-    event = append_journal_event(
-        args.journal, document, JournalEventRequest(args.node_id, journal_status, source=source, reason="; ".join(args.limitation or ()) or None)
-    )
-    return {
-        "artifact_path": str(artifact_path),
-        "journal_event": event,
-        "metadata_path": str(metadata_path),
-        "node_id": args.node_id,
-        "schema_version": 1,
-        "worker_payload_path": str(sealed_payload_path),
+    operation_output_path = args.output.resolve()
+    destinations = {
+        "compiled artifact": artifact_path,
+        "compiled metadata": metadata_path,
+        "operation result": operation_output_path,
+        "sealed worker payload": sealed_payload_path,
     }
+    if len(set(destinations.values())) != len(destinations):
+        aliases = ", ".join(f"{label}={path}" for label, path in destinations.items())
+        msg = f"compile-node destinations must be distinct; --output is the operation-result path: {aliases}"
+        raise ValueError(msg)
+    if operation_output_path.exists() or operation_output_path.is_symlink():
+        msg = f"compile-node operation-result --output already exists: {operation_output_path}"
+        raise ValueError(msg)
+    _preflight_compile_destination(sealed_payload_path, payload_bytes)
+    _preflight_compile_destination(artifact_path, content)
+    _preflight_compile_destination(metadata_path, metadata_bytes)
+    for parent in {artifact_path.parent, metadata_path.parent, payload_path.parent, args.journal.parent.resolve(), operation_output_path.parent}:
+        parent.mkdir(parents=True, exist_ok=True)
+
+    request = JournalEventRequest(args.node_id, journal_status, source=source, reason="; ".join(args.limitation or ()) or None)
+    lock_path = args.journal.with_name(args.journal.name + ".lock")
+    with lock_path.open("a+b") as lock_stream:
+        fcntl.flock(lock_stream.fileno(), fcntl.LOCK_EX)
+        try:
+            try:
+                journal_content = args.journal.read_bytes()
+            except FileNotFoundError:
+                journal_content = b""
+            _events, lifecycle_state, _head = _read_execution_journal_content(journal_content, path=args.journal, plan=plan, source_state=source_state)
+            _apply_journal_transition(plan, lifecycle_state, node_id=request.node_id, status=request.status)
+            normalized = metadata.get("normalized_record")
+            journal_limitations = tuple(cast("list[str]", normalized.get("limitations", []))) if isinstance(normalized, dict) else ()
+            _new_journal_reason(request, journal_limitations)
+            _write_bytes_atomically_once(sealed_payload_path, payload_bytes, mode=0o444)
+            _write_bytes_once(artifact_path, content)
+            _write_bytes_once(metadata_path, metadata_bytes)
+            event, existing_size = _prepare_journal_event(args.journal, plan=plan, source_state=source_state, request=request, content=journal_content)
+            result = {
+                "artifact_path": str(artifact_path),
+                "journal_event": event,
+                "metadata_path": str(metadata_path),
+                "node_id": args.node_id,
+                "schema_version": 1,
+                "worker_payload_path": str(sealed_payload_path),
+            }
+            _write_text_once(operation_output_path, json.dumps(result, indent=2, sort_keys=True) + "\n")
+            with args.journal.open("ab") as journal_stream:
+                _persist_journal_event(journal_stream, args.journal, event, existing_size=existing_size)
+            return result
+        finally:
+            fcntl.flock(lock_stream.fileno(), fcntl.LOCK_UN)
 
 
 def _json_operation_output(document: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:  # noqa: PLR0911
@@ -4880,8 +5192,6 @@ def _json_operation_output(document: dict[str, Any], args: argparse.Namespace) -
         return build_synthesis_bundle(document)
     if args.operation == "routing-projection":
         return build_routing_projection_document(document, catalog_path=args.catalog, skill_roots=tuple(args.skill_root or (DEFAULT_SKILL_ROOT,)))
-    if args.operation == "materialize-dispatches":
-        return materialize_dispatches(document)
     if args.operation == "advance-after-mutation":
         return advance_after_mutation(document)
     if args.operation == "reconcile-handoffs":
@@ -4894,7 +5204,7 @@ def _json_operation_output(document: dict[str, Any], args: argparse.Namespace) -
     return finalize_proof(_finalize_document_from_files(document, args))
 
 
-def _run_operation(document: dict[str, Any], args: argparse.Namespace) -> int:
+def _run_operation(document: dict[str, Any], args: argparse.Namespace) -> int:  # noqa: C901
     if args.operation == "persist-worker-payload":
         print(_canonical_json(persist_worker_payload(document, args.payload)))
         return 0
@@ -4915,6 +5225,12 @@ def _run_operation(document: dict[str, Any], args: argparse.Namespace) -> int:
     if args.operation == "journal-append":
         event = append_journal_event(args.journal, document, _journal_request_from_args(args))
         print(_canonical_json(event))
+        return 0
+    if args.operation == "compile-node":
+        _compile_node_from_files(document, args)
+        return 0
+    if args.operation == "materialize-dispatches":
+        materialize_dispatches(document, operation_output_path=args.output)
         return 0
     output = _json_operation_output(document, args)
     output_path = args.output

--- a/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
@@ -2265,6 +2265,58 @@ def test_compile_node_destination_error_cannot_publish_evidence_or_acceptance(tm
     assert not tuple(Path(entry["worker_payload_path"]).parent.glob("*.sealed.json"))
 
 
+def test_compile_node_partial_journal_failure_rolls_back_outputs_and_retries(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    document, dispatches = _worker_input_fixture(tmp_path)
+    entry = next(item for item in dispatches["dispatches"] if item["result_contract"] == "compact-review")
+    candidate = Path(entry["worker_payload_candidate_path"])
+    candidate.write_text(json.dumps(_compact_audit_payload(entry)), encoding="utf-8")
+    persist_worker_payload(json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8")), candidate)
+    lifecycle_path, dispatch_path, capture_path = _compile_cli_paths(tmp_path, document, dispatches)
+    journal = tmp_path / "execution.jsonl"
+    output_path = tmp_path / "compile-result.json"
+    arguments = [
+        "compile-node",
+        "--input",
+        str(lifecycle_path),
+        "--dispatches",
+        str(dispatch_path),
+        "--node-id",
+        entry["node_id"],
+        "--before-capture",
+        str(capture_path),
+        "--after-capture",
+        str(capture_path),
+        "--journal",
+        str(journal),
+        "--output",
+        str(output_path),
+    ]
+
+    def fail_during_append(stream: Any, _path: Path, _event: dict[str, Any], *, existing_size: int) -> None:
+        stream.seek(existing_size)
+        stream.write(b'{"partial":')
+        stream.flush()
+        message = "simulated journal append failure"
+        raise OSError(message)
+
+    with monkeypatch.context() as patch:
+        patch.setattr("review_graph_runtime._persist_journal_event", fail_during_append)
+        assert main(arguments) == 2
+
+    assert "simulated journal append failure" in capsys.readouterr().err
+    assert not journal.exists()
+    assert not output_path.exists()
+    assert not Path(entry["artifact_path"]).exists()
+    assert not Path(entry["metadata_path"]).exists()
+    assert not tuple(Path(entry["worker_payload_path"]).parent.glob("*.sealed.json"))
+
+    assert main(arguments) == 0
+    assert output_path.is_file()
+    assert len(journal.read_text(encoding="utf-8").splitlines()) == 1
+
+
 def test_fresh_context_compile_rejects_reads_of_sibling_worker_evidence(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     document, dispatches = _worker_input_fixture(tmp_path)
     audits = [item for item in dispatches["dispatches"] if item["result_contract"] == "compact-review"]
@@ -3776,6 +3828,14 @@ def test_late_validation_quality_gate_rejects_incomplete_benchmark_and_post_reme
         blockers = _late_validation_quality_blockers(noncanonical, repository_root=repository, authorization="review-only")
         assert not any("missing required features" in blocker for blocker in blockers)
         assert any("canonical recipe just bench-exact" in blocker for blocker in blockers)
+
+    harness_only = replace(
+        requirement,
+        commands=("cargo bench --bench exact -- --features proptest --all-features",),
+        expected_evidence="benchmark records current captured behavior",
+    )
+    harness_blockers = _late_validation_quality_blockers(harness_only, repository_root=repository, authorization="review-only")
+    assert any("missing required features: proptest" in blocker for blocker in harness_blockers)
 
 
 def _late_validation_plan() -> dict[str, Any]:

--- a/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
@@ -21,6 +21,7 @@ from review_graph_bootstrap import bootstrap_document, main as bootstrap_main
 from review_graph_plan import (
     GraphPlan,
     ValidationArtifact,
+    ValidationRequirement,
     ValidationUnit,
     expand_compact_routing,
     graph_plan_digest,
@@ -36,10 +37,12 @@ from review_graph_runtime import (
     _argument_parser,
     _git_path_status,
     _graph_plan,
+    _late_validation_quality_blockers,
     _planned_validation_digest,
     _reconciled_handoffs,
     _schema_reference,
     _validation_workspace_audit,
+    _worker_prompt,
     _workspace_content_digest,
     _write_bytes_atomically_once,
     _write_bytes_once,
@@ -67,6 +70,7 @@ RUST_ERROR_SKILL = SKILL_ROOT / "rust-error-variants" / "SKILL.md"
 VALIDATOR_SKILL = SKILL_ROOT / "review-validator" / "SKILL.md"
 VALIDATOR_CONTRACT = SKILL_ROOT / "review-validator" / "references" / "graph-dispatch.md"
 INDEPENDENT_NATIVE_EXAMPLE = SKILL_ROOT / "repository-independent-review" / "references" / "native-example.md"
+INDEPENDENT_NATIVE_POSITIVE_EXAMPLE = SKILL_ROOT / "repository-independent-review" / "references" / "native-positive-example.md"
 SCHEMA_ROOT = Path(__file__).resolve().parents[1] / "references" / "schemas"
 STATE_FIXTURE = "agents/.agents/skills/review-graph/scripts/fixtures/state.rs"
 ORDINARY_PROMPT_WORD_BUDGET = 2400
@@ -2151,6 +2155,41 @@ def _worker_input_fixture(tmp_path: Path) -> tuple[dict[str, Any], dict[str, Any
     return document, materialize_dispatches(document)
 
 
+def _compact_audit_payload(entry: dict[str, Any], *, commands: tuple[str, ...] = ()) -> dict[str, Any]:
+    return {
+        "changes": [],
+        "command_policy_attested": True,
+        "commands_executed": list(commands),
+        "files_inspected": entry["dispatch"]["owned_paths"],
+        "findings": [],
+        "handoffs": [],
+        "limitations": [],
+        "nearby_contract_owners": [],
+        "scope_limitations": [],
+        "status": "no-findings",
+        "validation_requirements": [],
+    }
+
+
+def _compile_cli_paths(tmp_path: Path, document: dict[str, Any], dispatches: dict[str, Any]) -> tuple[Path, Path, Path]:
+    lifecycle_path = tmp_path / "lifecycle.json"
+    dispatch_path = tmp_path / "dispatches.json"
+    capture_path = tmp_path / "capture.json"
+    lifecycle_path.write_text(json.dumps({"plan": document["plan"], "source_state": document["source_state"]}), encoding="utf-8")
+    dispatch_path.write_text(json.dumps(dispatches), encoding="utf-8")
+    capture_path.write_text(
+        json.dumps(
+            {
+                "captured_worktree_fingerprint": document["source_state"][1],
+                "repository_state_fingerprint": document["source_state"][2],
+                "scope_fingerprint": document["source_state"][0],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return lifecycle_path, dispatch_path, capture_path
+
+
 def test_worker_publishes_payload_from_only_runtime_emitted_input(tmp_path: Path) -> None:
     document, dispatches = _worker_input_fixture(tmp_path)
     ready = next_ready_nodes({**document, "current_source_state": document["source_state"]}, journal_events=(), dispatch_set=dispatches)
@@ -2189,6 +2228,82 @@ subprocess.run(persistence["command"], check=True, timeout=30)
     assert not list(worker_directory.iterdir())
 
 
+def test_compile_node_destination_error_cannot_publish_evidence_or_acceptance(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    document, dispatches = _worker_input_fixture(tmp_path)
+    entry = next(item for item in dispatches["dispatches"] if item["result_contract"] == "compact-review")
+    candidate = Path(entry["worker_payload_candidate_path"])
+    candidate.write_text(json.dumps(_compact_audit_payload(entry)), encoding="utf-8")
+    persist_worker_payload(json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8")), candidate)
+    lifecycle_path, dispatch_path, capture_path = _compile_cli_paths(tmp_path, document, dispatches)
+    journal = tmp_path / "execution.jsonl"
+
+    result = main(
+        [
+            "compile-node",
+            "--input",
+            str(lifecycle_path),
+            "--dispatches",
+            str(dispatch_path),
+            "--node-id",
+            entry["node_id"],
+            "--before-capture",
+            str(capture_path),
+            "--after-capture",
+            str(capture_path),
+            "--journal",
+            str(journal),
+            "--output",
+            entry["artifact_path"],
+        ]
+    )
+
+    assert result == 2
+    assert "operation-result path" in capsys.readouterr().err
+    assert not Path(entry["artifact_path"]).exists()
+    assert not Path(entry["metadata_path"]).exists()
+    assert not journal.exists()
+    assert not tuple(Path(entry["worker_payload_path"]).parent.glob("*.sealed.json"))
+
+
+def test_fresh_context_compile_rejects_reads_of_sibling_worker_evidence(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    document, dispatches = _worker_input_fixture(tmp_path)
+    audits = [item for item in dispatches["dispatches"] if item["result_contract"] == "compact-review"]
+    assert len(audits) >= 2
+    entry, sibling = audits[:2]
+    command = f"cat {sibling['worker_payload_path']}"
+    candidate = Path(entry["worker_payload_candidate_path"])
+    candidate.write_text(json.dumps(_compact_audit_payload(entry, commands=(command,))), encoding="utf-8")
+    persist_worker_payload(json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8")), candidate)
+    lifecycle_path, dispatch_path, capture_path = _compile_cli_paths(tmp_path, document, dispatches)
+    journal = tmp_path / "execution.jsonl"
+
+    result = main(
+        [
+            "compile-node",
+            "--input",
+            str(lifecycle_path),
+            "--dispatches",
+            str(dispatch_path),
+            "--node-id",
+            entry["node_id"],
+            "--before-capture",
+            str(capture_path),
+            "--after-capture",
+            str(capture_path),
+            "--journal",
+            str(journal),
+            "--output",
+            str(tmp_path / "compile-result.json"),
+        ]
+    )
+
+    assert result == 2
+    assert "fresh-context review read another node" in capsys.readouterr().err
+    assert not Path(entry["artifact_path"]).exists()
+    assert not Path(entry["metadata_path"]).exists()
+    assert not journal.exists()
+
+
 @pytest.mark.parametrize("tamper", ["content", "missing", "symlink"])
 def test_ready_nodes_reject_missing_or_substituted_worker_inputs(tmp_path: Path, tamper: str) -> None:
     document, dispatches = _worker_input_fixture(tmp_path)
@@ -2220,6 +2335,126 @@ def test_worker_input_publication_is_immutable_and_replayable(tmp_path: Path) ->
     with pytest.raises(ValueError, match="refusing to overwrite non-identical immutable artifact"):
         materialize_dispatches(document)
     assert worker_input.read_bytes() == b"preexisting different input\n"
+
+
+def test_public_symbolic_source_state_materializes_from_the_plan_bound_capture(tmp_path: Path) -> None:
+    plan = _sparse_plan()
+    captured = ("captured-scope", "captured-worktree", "captured-repository")
+    plan = replace(plan, coalesced_validation_units=tuple(replace(unit, source_state=captured) for unit in plan.coalesced_validation_units))
+    example = json.loads((SKILL_ROOT / "review-graph" / "references" / "runtime-operation-examples-v1.json").read_text(encoding="utf-8"))
+    source_state = example["materialize-dispatches"]["source_state"]
+
+    materialized = materialize_dispatches(
+        {
+            "artifact_store": str(tmp_path / "proof"),
+            "authorization": "review-only",
+            "plan": _json_plan(plan),
+            "repository_root": str(SKILL_ROOT.parents[2]),
+            "source_state": source_state,
+            "state_verification_command": "capture_scope.py --mode baseline",
+        }
+    )
+
+    assert materialized["source_state"] == list(captured)
+    assert all(entry["dispatch"]["source_state"] == list(captured) for entry in materialized["dispatches"])
+
+
+def test_failed_materialization_leaves_store_empty_and_corrected_retry_succeeds(tmp_path: Path) -> None:
+    plan = _sparse_plan()
+    artifact_store = tmp_path / "proof"
+    request = {
+        "artifact_store": str(artifact_store),
+        "authorization": "review-only",
+        "plan": _json_plan(plan),
+        "repository_root": str(SKILL_ROOT.parents[2]),
+        "source_state": ["wrong-scope", "wrong-worktree", "wrong-repository"],
+        "state_verification_command": "capture_scope.py --mode baseline",
+    }
+
+    with pytest.raises(ValueError, match="validation unit source state differs"):
+        materialize_dispatches(request)
+
+    assert not artifact_store.exists()
+    corrected = materialize_dispatches({**request, "source_state": ["scope", "worktree", "repository"]})
+    assert corrected["dispatches"]
+    assert artifact_store.is_dir()
+
+
+def test_materialize_cli_output_failure_leaves_no_store_and_corrected_retry_succeeds(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    artifact_store = tmp_path / "proof"
+    request = {
+        "artifact_store": str(artifact_store),
+        "authorization": "review-only",
+        "plan": _json_plan(_sparse_plan()),
+        "repository_root": str(SKILL_ROOT.parents[2]),
+        "source_state": ["scope", "worktree", "repository"],
+        "state_verification_command": "capture_scope.py --mode baseline",
+    }
+    input_path = tmp_path / "input.json"
+    input_path.write_text(json.dumps(request), encoding="utf-8")
+
+    assert main(["materialize-dispatches", "--input", str(input_path), "--output", str(artifact_store)]) == 2
+    assert "operation-result path must be outside" in capsys.readouterr().err
+    assert not artifact_store.exists()
+
+    output_path = tmp_path / "materialized.json"
+    assert main(["materialize-dispatches", "--input", str(input_path), "--output", str(output_path)]) == 0
+    assert json.loads(output_path.read_text(encoding="utf-8"))["dispatches"]
+    assert artifact_store.is_dir()
+
+
+def test_materialize_cli_store_failure_rolls_back_new_operation_result(tmp_path: Path) -> None:
+    artifact_store = tmp_path / "proof"
+    artifact_store.mkdir()
+    sentinel = artifact_store / "preexisting.txt"
+    sentinel.write_text("preserve me\n", encoding="utf-8")
+    request = {
+        "artifact_store": str(artifact_store),
+        "authorization": "review-only",
+        "plan": _json_plan(_sparse_plan()),
+        "repository_root": str(SKILL_ROOT.parents[2]),
+        "source_state": ["scope", "worktree", "repository"],
+        "state_verification_command": "capture_scope.py --mode baseline",
+    }
+    input_path = tmp_path / "input.json"
+    output_path = tmp_path / "materialized.json"
+    input_path.write_text(json.dumps(request), encoding="utf-8")
+
+    assert main(["materialize-dispatches", "--input", str(input_path), "--output", str(output_path)]) == 2
+    assert not output_path.exists()
+    assert tuple(artifact_store.iterdir()) == (sentinel,)
+    assert sentinel.read_text(encoding="utf-8") == "preserve me\n"
+
+
+def test_late_materialization_failure_publishes_nothing_before_retry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    artifact_store = tmp_path / "proof"
+    request = {
+        "artifact_store": str(artifact_store),
+        "authorization": "review-only",
+        "plan": _json_plan(_sparse_plan()),
+        "repository_root": str(SKILL_ROOT.parents[2]),
+        "source_state": ["scope", "worktree", "repository"],
+        "state_verification_command": "capture_scope.py --mode baseline",
+    }
+    calls = 0
+
+    def fail_after_one_dispatch(contract: str, dispatch: dict[str, Any]) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            message = "simulated late materialization failure"
+            raise ValueError(message)
+        return _worker_prompt(contract, dispatch)
+
+    monkeypatch.setattr("review_graph_runtime._worker_prompt", fail_after_one_dispatch)
+    with pytest.raises(ValueError, match="simulated late materialization failure"):
+        materialize_dispatches(request)
+
+    assert not artifact_store.exists()
+    monkeypatch.undo()
+    corrected = materialize_dispatches(request)
+    assert corrected["dispatches"]
+    assert artifact_store.is_dir()
 
 
 def test_validator_prompt_exposes_nested_required_shape_and_minimal_response_compiles(tmp_path: Path) -> None:
@@ -2350,6 +2585,41 @@ def test_first_next_ready_accepts_missing_or_zero_byte_journal(tmp_path: Path, c
     assert journal_path.exists() is precreate_zero_byte_journal
     if precreate_zero_byte_journal:
         assert journal_path.read_bytes() == b""
+
+
+def test_next_ready_compact_references_worker_inputs_without_embedding_dispatches(tmp_path: Path) -> None:
+    document, dispatch_set = _worker_input_fixture(tmp_path)
+    lifecycle_path, dispatch_path, capture_path = _compile_cli_paths(tmp_path, document, dispatch_set)
+    output_path = tmp_path / "next-ready.json"
+
+    assert (
+        main(
+            [
+                "next-ready",
+                "--input",
+                str(lifecycle_path),
+                "--journal",
+                str(tmp_path / "missing.jsonl"),
+                "--dispatches",
+                str(dispatch_path),
+                "--current-capture",
+                str(capture_path),
+                "--compact",
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+    result = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert result["compact"] is True
+    assert result["ready_dispatches"]
+    assert {tuple(entry) for entry in result["ready_dispatches"]} == {("execution_location", "node_id", "result_contract", "worker_input_path")}
+    for entry in result["ready_dispatches"]:
+        bound = json.loads(Path(entry["worker_input_path"]).read_text(encoding="utf-8"))
+        assert entry["node_id"] == bound["node_id"]
+        assert entry["result_contract"] == bound["result_contract"]
 
 
 def test_execution_journal_rejects_blank_record_but_accepts_zero_bytes(tmp_path: Path) -> None:
@@ -2620,6 +2890,127 @@ def test_independent_native_example_compiles_verbatim_and_aggregates_contract_er
     assert "platform seams" in diagnostic
     assert "must contain Catalog ID records" in diagnostic
     assert "native state proof failed validation" in diagnostic
+
+
+def test_positive_independent_example_persists_compiles_and_journals_verbatim(tmp_path: Path) -> None:
+    git = shutil.which("git")
+    assert git is not None
+    repository = SKILL_ROOT.parents[2]
+    document = _sparse_plan_document()
+    document.update({"change_target": f"git diff -- {STATE_FIXTURE}", "concrete_change_target": True, "scope_mode": "baseline"})
+    capture = _scope_data(git, repository, "baseline", None, (STATE_FIXTURE,))
+    planning = bootstrap_document(capture, document)
+    plan = plan_from_document(planning, catalog_path=ROUTING_CATALOG, skill_roots=(SKILL_ROOT,), repository_root=repository)
+    source_state = cast(
+        "tuple[str, str, str]", tuple(capture[field] for field in ("scope_fingerprint", "captured_worktree_fingerprint", "repository_state_fingerprint"))
+    )
+    lifecycle = {"plan": _json_plan(plan), "source_state": list(source_state)}
+    materialized = materialize_dispatches(
+        {
+            **lifecycle,
+            "artifact_store": str(tmp_path / "proof"),
+            "authorization": "review-only",
+            "repository_root": str(repository),
+            "state_verification_command": "capture_scope.py --mode baseline",
+        }
+    )
+    entry = next(item for item in materialized["dispatches"] if item["result_contract"] == "native-independent-review")
+    candidate = Path(entry["worker_payload_candidate_path"])
+    native = INDEPENDENT_NATIVE_POSITIVE_EXAMPLE.read_bytes()
+    for symbolic, actual in zip((b"scope", b"worktree", b"repository"), source_state, strict=True):
+        native = native.replace(b"fingerprint: " + symbolic, b"fingerprint: " + actual.encode())
+    candidate.write_bytes(native)
+    persist_worker_payload(json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8")), candidate)
+    lifecycle_path = tmp_path / "lifecycle.json"
+    dispatches_path = tmp_path / "dispatches.json"
+    capture_path = tmp_path / "capture.json"
+    journal_path = tmp_path / "execution.jsonl"
+    output_path = tmp_path / "compile-result.json"
+    lifecycle_path.write_text(json.dumps(lifecycle), encoding="utf-8")
+    dispatches_path.write_text(json.dumps(materialized), encoding="utf-8")
+    capture_path.write_text(json.dumps(capture), encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "compile-node",
+                "--input",
+                str(lifecycle_path),
+                "--dispatches",
+                str(dispatches_path),
+                "--node-id",
+                entry["node_id"],
+                "--before-capture",
+                str(capture_path),
+                "--after-capture",
+                str(capture_path),
+                "--journal",
+                str(journal_path),
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+    result = json.loads(output_path.read_text(encoding="utf-8"))
+    compiled = Path(result["artifact_path"]).read_bytes()
+    metadata = json.loads(Path(result["metadata_path"]).read_text(encoding="utf-8"))
+    events, state, _head = read_execution_journal(journal_path, plan=plan, source_state=source_state)
+
+    assert metadata["native_input_digest"] == "sha256:" + hashlib.sha256(native).hexdigest()
+    assert b"- ID: " in compiled
+    assert metadata["normalized_record"]["findings"][0]["severity"] == "P2"
+    assert metadata["normalized_record"]["handoffs"][0]["catalog_id"] == "rust.errors"
+    assert events[-1]["status"] == "accepted"
+    assert state[entry["node_id"]] == "accepted"
+
+
+def test_positive_independent_finding_reports_all_structural_errors_together() -> None:
+    dispatch = {
+        "adversarial_checks": [],
+        "after_state": ["scope", "worktree", "repository"],
+        "artifact_id": "artifact://independent-positive-errors",
+        "authorization": "review-only",
+        "before_state": ["scope", "worktree", "repository"],
+        "change_target": f"git diff -- {STATE_FIXTURE}",
+        "evidence_id": "review:independent-positive-errors",
+        "execution_location": "worker",
+        "execution_profile": "grouped",
+        "fresh_context": True,
+        "handoff_catalog_ids": ["rust.errors"],
+        "mode": "independent-review",
+        "node_id": "independent-positive-errors",
+        "planned_path_line_bounds": [[STATE_FIXTURE, 3]],
+        "planned_paths": [STATE_FIXTURE],
+        "reference_paths": [],
+        "requirement_ids": ["repo.independent"],
+        "selection_reason": "concrete change target",
+        "skill_id": "repository-independent-review",
+        "skill_path": str(SKILL_ROOT / "repository-independent-review" / "SKILL.md"),
+        "source_state": ["scope", "worktree", "repository"],
+        "worker_created": True,
+    }
+    documented = INDEPENDENT_NATIVE_POSITIVE_EXAMPLE.read_bytes()
+    _content, metadata = compile_independent_review({"dispatch": dispatch, "limitations": [], "status": "completed"}, documented)
+
+    assert metadata["native_input_digest"] == "sha256:" + hashlib.sha256(documented).hexdigest()
+    assert metadata["normalized_record"]["findings"][0]["severity"] == "P2"
+    assert metadata["normalized_record"]["handoffs"][0]["catalog_id"] == "rust.errors"
+    assert metadata["normalized_record"]["findings"][0]["summary"] == "The changed transition accepts an invalid state."
+
+    malformed = (
+        documented.replace(b"- Finding: unchecked state transition", b"- Finding:")
+        .replace(b"  - Severity: P2", b"  - Severity: medium")
+        .replace(b"  - Summary: The changed transition accepts an invalid state.\n", b"")
+    )
+
+    with pytest.raises(ValueError, match="contract validation") as raised:
+        compile_independent_review({"dispatch": dispatch, "limitations": [], "status": "completed"}, malformed)
+
+    diagnostic = str(raised.value)
+    assert "non-empty value on the same line" in diagnostic
+    assert "invalid severity medium" in diagnostic
+    assert "Summary is missing" in diagnostic
 
 
 @pytest.mark.parametrize("writer", ["direct", "atomic"])
@@ -3342,6 +3733,49 @@ def _late_validation_requirement() -> dict[str, Any]:
         "expected_evidence": "sdist and wheel install cleanly",
         "dependency_policy": "stop-on-failure",
     }
+
+
+def test_late_validation_quality_gate_rejects_incomplete_benchmark_and_post_remediation_evidence(tmp_path: Path) -> None:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    (repository / "Cargo.toml").write_text('[[bench]]\nname = "exact"\nrequired-features = ["proptest"]\n', encoding="utf-8")
+    (repository / "justfile").write_text("bench-exact:\n    cargo bench --bench exact --features proptest\n", encoding="utf-8")
+    requirement = ValidationRequirement(
+        requirement_id="rust.bench.exact",
+        source_state=("scope", "worktree", "repository"),
+        commands=("cargo bench --bench exact",),
+        working_directories=(str(repository),),
+        environment="captured repository",
+        toolchain="stable Rust",
+        features=(),
+        platform="current platform",
+        artifact_owner="review-validator",
+        mutation_lock="validation-only",
+        expected_evidence="benchmark passes after remediation",
+    )
+
+    blockers = _late_validation_quality_blockers(requirement, repository_root=repository, authorization="review-only")
+
+    assert any("missing required features: proptest" in blocker for blocker in blockers)
+    assert any("canonical recipe just bench-exact" in blocker for blocker in blockers)
+    assert any("post-remediation evidence" in blocker for blocker in blockers)
+    canonical = replace(
+        requirement, commands=("just bench-exact",), canonical_recipe="just bench-exact", expected_evidence="benchmark records current captured behavior"
+    )
+    assert _late_validation_quality_blockers(canonical, repository_root=repository, authorization="review-only") == ()
+
+    toolchain_prefixed = replace(
+        requirement, commands=("cargo +nightly -vv --config net.retry=2 bench --bench exact",), expected_evidence="benchmark records current captured behavior"
+    )
+    toolchain_blockers = _late_validation_quality_blockers(toolchain_prefixed, repository_root=repository, authorization="review-only")
+    assert any("missing required features: proptest" in blocker for blocker in toolchain_blockers)
+    assert any("canonical recipe just bench-exact" in blocker for blocker in toolchain_blockers)
+
+    for command in ("cargo bench -F proptest --bench exact", "cargo --locked bench --all-features --bench exact"):
+        noncanonical = replace(requirement, commands=(command,), expected_evidence="benchmark records current captured behavior")
+        blockers = _late_validation_quality_blockers(noncanonical, repository_root=repository, authorization="review-only")
+        assert not any("missing required features" in blocker for blocker in blockers)
+        assert any("canonical recipe just bench-exact" in blocker for blocker in blockers)
 
 
 def _late_validation_plan() -> dict[str, Any]:

--- a/justfile
+++ b/justfile
@@ -208,8 +208,8 @@ python-ci: python-check test-python
     @echo "Python checks complete!"
 
 python-fix: _ensure-uv
-    uv run --locked ruff check {{ python_paths }} --fix
-    uv run --locked ruff format {{ python_paths }}
+    uv run --locked ruff check {{ python_primary_paths }} --fix
+    uv run --locked ruff format {{ python_primary_paths }}
 
 python-fixture-lint: _ensure-uv
     uv run --locked ruff check {{ python_fixture_paths }}

--- a/justfile
+++ b/justfile
@@ -5,11 +5,13 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 
 export UV_CACHE_DIR := env_var_or_default("UV_CACHE_DIR", ".uv-cache")
 
-python_paths := "agents/.agents/skills scripts"
-dprint_version := "0.57.0"
+python_fixture_paths := "tests/semgrep"
+python_primary_paths := "agents/.agents/skills scripts"
+python_paths := python_primary_paths + " " + python_fixture_paths
+dprint_version := "0.57.1"
 just_version := "1.58.0"
-rumdl_version := "0.2.62"
-uv_version := "0.12.8"
+rumdl_version := "0.2.64"
+uv_version := "0.12.9"
 zizmor_version := "1.30.0"
 
 _ensure-actionlint:
@@ -139,7 +141,7 @@ check-skills: _ensure-uv
     fi
     echo "Skill checks complete!"
 
-ci: check
+ci: check python-fixture-lint
     @echo "CI checks complete!"
 
 fix: justfile-fmt python-fix yaml-fix markdown-fix
@@ -197,9 +199,9 @@ macos-defaults:
 macos-defaults-rectangle-pro:
     bin/macos-defaults.sh --rectangle-pro-takeover
 
-python-check: _ensure-uv
+python-check: _ensure-uv python-fixture-lint
     uv run --locked ruff format --check {{ python_paths }}
-    uv run --locked ruff check {{ python_paths }}
+    uv run --locked ruff check {{ python_primary_paths }}
     just python-typecheck
 
 python-ci: python-check test-python
@@ -208,6 +210,9 @@ python-ci: python-check test-python
 python-fix: _ensure-uv
     uv run --locked ruff check {{ python_paths }} --fix
     uv run --locked ruff format {{ python_paths }}
+
+python-fixture-lint: _ensure-uv
+    uv run --locked ruff check {{ python_fixture_paths }}
 
 python-lint: python-check
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,14 @@ select = [
   "E",
   "F",
   "W",
+  "ANN001",
+  "ANN002",
+  "ANN003",
   "ANN201",
   "ANN202",
   "ANN204",
+  "ANN205",
+  "ANN206",
   "C90",
   "I",
   "N",
@@ -112,6 +117,12 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "**/scripts/test_*.py" = ["S101", "SLF001", "D101", "D102", "D103"]
+"tests/semgrep/review_graph/runtime_patterns.py" = [
+  # Semgrep needs the literal raise and intermediate return assignments as
+  # deliberate negative and positive compiler-boundary fixtures.
+  "EM101",
+  "RET504",
+]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/scripts/test_python_policy.py
+++ b/scripts/test_python_policy.py
@@ -1,0 +1,40 @@
+"""Regression tests for the repository-wide Python validation policy."""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any, cast
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def just_dump() -> dict[str, Any]:
+    """Return Just's parsed representation of the repository command graph."""
+    just_executable = shutil.which("just")
+    assert just_executable is not None
+    result = subprocess.run(  # noqa: S603 - the resolved executable and arguments are repository-controlled.
+        [just_executable, "--justfile", str(REPOSITORY_ROOT / "justfile"), "--dump", "--dump-format", "json"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=REPOSITORY_ROOT,
+    )
+    return cast("dict[str, Any]", json.loads(result.stdout))
+
+
+def test_ci_directly_requires_python_fixture_lint() -> None:
+    """The canonical CI recipe cannot bypass fixture linting."""
+    dependencies = just_dump()["recipes"]["ci"]["dependencies"]
+
+    assert "python-fixture-lint" in {dependency["recipe"] for dependency in dependencies}
+
+
+def test_python_fixture_lint_uses_the_complete_ruff_configuration() -> None:
+    """Fixture linting must not narrow the configured Ruff rule selection."""
+    document = just_dump()
+    recipe = document["recipes"]["python-fixture-lint"]
+    command = recipe["body"][0]
+
+    assert document["assignments"]["python_fixture_paths"]["value"] == "tests/semgrep"
+    assert command == ["uv run --locked ruff check ", [["variable", "python_fixture_paths"]]]

--- a/scripts/test_python_policy.py
+++ b/scripts/test_python_policy.py
@@ -38,3 +38,13 @@ def test_python_fixture_lint_uses_the_complete_ruff_configuration() -> None:
 
     assert document["assignments"]["python_fixture_paths"]["value"] == "tests/semgrep"
     assert command == ["uv run --locked ruff check ", [["variable", "python_fixture_paths"]]]
+
+
+def test_python_fix_excludes_deliberately_invalid_semgrep_fixtures() -> None:
+    """The fixer must not rewrite deliberate negative-analysis fixtures."""
+    commands = just_dump()["recipes"]["python-fix"]["body"]
+
+    assert commands == [
+        ["uv run --locked ruff check ", [["variable", "python_primary_paths"]], " --fix"],
+        ["uv run --locked ruff format ", [["variable", "python_primary_paths"]]],
+    ]

--- a/uv.lock
+++ b/uv.lock
@@ -19,14 +19,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.14.2"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/9a/c15a60547004a3f3cea20296c934f827ddd7bdba225a2e7e9fcb5ec48c80/anyio-4.15.0.tar.gz", hash = "sha256:b5c620ed540725e2579c31b17bb995b3bf02c9281c9cace04c7d186380bab85e", size = 276504, upload-time = "2026-09-02T21:46:36.957Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/2b21ce5ebe4d8938a247c9b0dbb7271566ae559b01795c83ea4bb2660ed7/anyio-4.15.0-py3-none-any.whl", hash = "sha256:7ecd9937369ffce8bba0b5ccb9b3a9507b101b0ed50256aecfbab27e6c2acb99", size = 131908, upload-time = "2026-09-02T21:46:35.485Z" },
 ]
 
 [[package]]
@@ -380,14 +381,14 @@ wheels = [
 
 [[package]]
 name = "googleapis-common-protos"
-version = "1.75.2"
+version = "1.75.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/90/fb8f1c84537fbf210c1f53a53ae473a805f6599c5a40b93c1bbadd211f7a/googleapis_common_protos-1.75.2.tar.gz", hash = "sha256:8829a3d1e4508c5b7b9a6b9525f7fccff611f8531644579a76466c29295d4bb2", size = 154083, upload-time = "2026-08-25T19:19:13.028Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c5/4353a188e2c335aee33269e8b654af228278cca8e5f0b4b5f11e5d0e9adb/googleapis_common_protos-1.75.3.tar.gz", hash = "sha256:57c435ac2c68b108999b6db075d9053e4d7a936ba57b4a3d45667b1346f1738a", size = 153905, upload-time = "2026-09-03T22:31:21.869Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/5b/1c9e55363c3b1890a98cae813de5b4ea327845756cd8fb7ee690140c7eac/googleapis_common_protos-1.75.2-py3-none-any.whl", hash = "sha256:6b83302f554ea93a0f48409c7fc2050f954bcbcddb7e3a9c76d4a823cb22920e", size = 307002, upload-time = "2026-08-25T19:18:08.927Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7a/7d79170c6ce6f12e109df2b3879d6b934010cf4f99aea8de8b7e5408c174/googleapis_common_protos-1.75.3-py3-none-any.whl", hash = "sha256:a018d2bf098ca9fb6faa08d5bb780e2a2c2f73c566f069761331386c9596d3f2", size = 306984, upload-time = "2026-09-03T22:30:45.133Z" },
 ]
 
 [[package]]
@@ -1247,15 +1248,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.4.8"
+version = "3.4.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f8/00/b42a44342a054d58cb1115d7c8aa9cb4290dd9442f9c1b91a4b8173dba22/sse_starlette-3.4.8.tar.gz", hash = "sha256:ed89ffbb75cbf78a5fe2f2109cd584792ee7f9dfac96f791db546df8f15f3f9c", size = 32548, upload-time = "2026-08-05T11:19:49.982Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/e1/8a41e88e825ea26c44333897c7ffe35fe60153a2cfc097a5bd1d209ad281/sse_starlette-3.4.10.tar.gz", hash = "sha256:c6c87280d8feb4e55a8d79633782766b9cac6a26da5c79a145d00aa404117a86", size = 33720, upload-time = "2026-09-03T09:36:24.08Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dd/3a/764912c58293d95b6dcdf4cc255f9d10de310580ced547b082eb9d72018c/sse_starlette-3.4.8-py3-none-any.whl", hash = "sha256:6e82314c786709a3cd9520f2285cf9fff90e181e598e8a357b0cf80f66afba0d", size = 16516, upload-time = "2026-08-05T11:19:48.748Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3c/96018a51c7301a64f7b0579d9ce8f9b69dd39ca8ed5aa100ba3feadee503/sse_starlette-3.4.10-py3-none-any.whl", hash = "sha256:710f5f5b0527409903a22a91699db02f76f4c2eb9204e882e4ee7cada76bdf75", size = 17120, upload-time = "2026-09-03T09:36:22.56Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- make dispatch materialization and node compilation retry-safe
- strengthen source-bound worker, finding, and late-validation contracts
- enforce complete Ruff policy coverage for Python fixtures
- refresh pinned development tools and locked dependencies

Closes #50
Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved review processing with stricter finding validation, clearer parsing, and safer handling of worker inputs and generated results.
  - Failed artifact or compilation operations now avoid publishing partial outputs.
  - Added safeguards for benchmark configuration, working-directory state, and review evidence timing.
  - Added compact readiness output and support for externally stored operation results.

- **Documentation**
  - Expanded review guidance with finding-format requirements, positive examples, planning rules, and runtime-safety information.

- **Chores**
  - Updated quality checks and fixture-specific linting, including stronger annotation checks and pinned tool versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->