### PR TITLE
fix(skills): align review payload safety with dispatch scope

### DIFF
--- a/agents/.agents/skills/review-graph/SKILL.md
+++ b/agents/.agents/skills/review-graph/SKILL.md
@@ -60,10 +60,10 @@ validation or synthesis.
 
 ## Execute Review Nodes
 
-Dispatch each selected leaf with its exact skill and owned paths. The worker
-writes only the `ReviewPayload` to the dispatch-bound candidate path, invokes
-the runtime-owned `persist-worker-payload` operation to validate and atomically
-publish it, and returns those same bytes. It does not author
+Dispatch selected leaves with exact skills and owned paths. Workers stream
+`ReviewPayload` bytes through dispatch-bound review and persistence
+commands; the runtime validates before writing, binds approval retries, and
+atomically publishes. They return the same bytes and do not author
 fingerprints, digests, evidence IDs, execution metadata, canonical Markdown,
 or machine-evidence JSON. Materialize exact dispatch bases from the accepted
 plan with `review_graph_runtime.py materialize-dispatches`; do not reconstruct
@@ -104,7 +104,7 @@ retains their per-requirement provenance.
 Run each coalesced unit once through `review-validator`. Validator workers also
 use `fork_turns: "none"`, read only its compact graph-dispatch reference, and
 publish a schema-valid `ValidationPayload` without artifact records or digests
-through `persist-worker-payload` before returning it. Invoke
+through the same reviewed persistence flow before returning it. Invoke
 `snapshot-workspace` immediately before and after execution, then compile the
 node from its bound payload path with both runtime-owned snapshots. Cache/build
 manifests bind metadata for every immediate entry. Accept only when both gates pass.

--- a/agents/.agents/skills/review-graph/references/runtime-contract.md
+++ b/agents/.agents/skills/review-graph/references/runtime-contract.md
@@ -101,10 +101,9 @@ instructions. Exclude coordinator conclusions, routing, and journals. Shared
 observations do not replace independent judgment. Reviews attest to commands;
 validator-command duplicates need explicit authorization and reusable evidence.
 
-Return only `ReviewPayload`. Write its exact bytes to the candidate, then execute
-`worker_payload_persistence.command` unchanged. Its complete argv includes the
-executable, script, and bound paths; it validates and atomically publishes
-`worker_payload_path`.
+Return only `ReviewPayload`. Follow `worker_prompt`'s publication example:
+serialize once, review over stdin, then persist identical bytes with
+`--approval-identity`. Approval binds the entire contract and payload.
 
 Use the materialized payload schema; planned needs reference dispatched
 validation IDs/digests.
@@ -139,7 +138,7 @@ findings, and catalog handoffs; assigns identities; appends the envelope and
 Machine Evidence; and emits journal-compatible metadata.
 
 Coalesced validators read only `review-validator/references/graph-dispatch.md`,
-publish through `persist-worker-payload`, and return identical bytes. Snapshot
+use the same reviewed persistence flow, and return identical bytes. Snapshot
 the workspace immediately before and after commands; the runtime derives
 artifact records, digest modes, command/environment identities, mappings, and
 ledger evidence. `ignored` artifacts require a tracked `.gitignore`; other

--- a/agents/.agents/skills/review-graph/references/runtime-operation-examples-v1.json
+++ b/agents/.agents/skills/review-graph/references/runtime-operation-examples-v1.json
@@ -77,7 +77,14 @@
     "source_state": ["scope", "worktree", "repository"]
   },
   "persist-worker-payload": {
-    "candidate_path": "/tmp/review-proof/audit.worker-payload.candidate.json",
+    "mode": "audit",
+    "node_id": "audit",
+    "owned_paths": ["src/lib.py"],
+    "result_contract": "compact-review",
+    "schema_version": 1,
+    "worker_payload_path": "/tmp/review-proof/audit.worker-payload.json"
+  },
+  "review-worker-payload-write": {
     "mode": "audit",
     "node_id": "audit",
     "owned_paths": ["src/lib.py"],

--- a/agents/.agents/skills/review-graph/references/runtime-safety.md
+++ b/agents/.agents/skills/review-graph/references/runtime-safety.md
@@ -22,6 +22,45 @@ compiled artifact. All destinations must be distinct. The runtime preflights
 them, publishes compiled evidence and the operation result, then appends the
 journal event as the final acceptance commit.
 
+## Artifact Write Review And Approval Retry
+
+Before publishing a worker payload, pass its exact bytes over standard input to
+the dispatch-bound review command. The runtime validates the schema and semantics
+without an artifact write. For audits, `scope_limitations` must equal the omitted
+`owned_paths`; `nearby_contract_owners` is inspected context provenance, not
+omitted scope, and narrative `limitations` never expand the write set. Only the
+published payload path is a durable artifact target; atomic publication uses a
+runtime-owned temporary sibling. The stdin contract contains no candidate path.
+Legacy `--payload` inputs retain a separate candidate-bearing schema for saved
+dispatches.
+
+The persistence receipt and any publication-failure diagnostic carry the same
+`artifact_write_review`: exact byte digest/count, bound paths, path-role summary,
+and a canonical digest of the entire validated persistence contract, including
+mode, owned paths, and schema version. The `approval_identity` binds the bytes,
+target, input mode, and contract digest. Both the stdin CLI and Python publication
+API require this identity; it identifies the reviewed write and does not grant
+environment permission. If the environment requires
+explicit approval, keep the reviewed bytes unchanged and retry with
+`--approval-identity <approved identity>`. The runtime rejects changed bytes or
+paths or contract fields instead of treating a different write as approved.
+
+## Live Worker Publication Smoke Test
+
+After publication-contract changes, complement deterministic tests with one
+fresh worker (`fork_turns: "none"`) and an external temporary proof store. Give
+it only a materialized audit dispatch, its skill/instructions, a small owned
+source fixture, and a nearby context fixture. Ask it to inspect both and publish
+its own payload through the generated prompt. Record the context boundary as a
+narrative limitation; let the worker classify path ownership and scope omissions.
+
+Observe the actual tool/approval outcome, compare returned and persisted bytes,
+and compile the payload through `compile-node` to journal acceptance. Record the
+contract identity, any approval request, compiler result, and journal status in
+the external test evidence. A subprocess or mocked filesystem test does not
+establish the live approval outcome. This is a bounded publication test, not a
+complete repository review.
+
 ## Isolation And Compact Readiness
 
 For `fresh_context: true`, compilation rejects a command ledger that names

--- a/agents/.agents/skills/review-graph/references/schemas/review-payload-v1.schema.json
+++ b/agents/.agents/skills/review-graph/references/schemas/review-payload-v1.schema.json
@@ -20,7 +20,11 @@
     },
     "command_policy_attested": {"const": true},
     "commands_executed": {"items": {"type": "string"}, "type": "array"},
-    "files_inspected": {"items": {"type": "string"}, "type": "array"},
+    "files_inspected": {
+      "description": "Paths actually inspected by the worker (dispatch-owned for audits); these are read provenance, not artifact write targets.",
+      "items": {"type": "string"},
+      "type": "array"
+    },
     "findings": {
       "items": {
         "additionalProperties": false,
@@ -50,8 +54,13 @@
       },
       "type": "array"
     },
-    "limitations": {"items": {"type": "string"}, "type": "array"},
+    "limitations": {
+      "description": "Narrative caveats. Path mentions here do not declare omitted audit scope or artifact write targets.",
+      "items": {"type": "string"},
+      "type": "array"
+    },
     "scope_limitations": {
+      "description": "For audits only: exactly the omitted dispatch-owned paths and one reason per path. Never use for nearby context paths.",
       "items": {
         "additionalProperties": false,
         "properties": {
@@ -63,7 +72,11 @@
       },
       "type": "array"
     },
-    "nearby_contract_owners": {"items": {"type": "string"}, "type": "array"},
+    "nearby_contract_owners": {
+      "description": "Inspected read-only dependency or context provenance. Paths may be outside dispatch ownership and are neither omitted audit scope nor artifact write targets.",
+      "items": {"type": "string"},
+      "type": "array"
+    },
     "status": {"enum": ["completed", "no-findings", "blocked"]},
     "validation_requirements": {
       "items": {

--- a/agents/.agents/skills/review-graph/references/schemas/runtime-operation-inputs-v1.schema.json
+++ b/agents/.agents/skills/review-graph/references/schemas/runtime-operation-inputs-v1.schema.json
@@ -142,6 +142,22 @@
       "type": "object"
     },
     "persist-worker-payload": {
+      "oneOf": [{"$ref": "#/$defs/stdinWorkerPayloadContract"}, {"$ref": "#/$defs/legacyWorkerPayloadContract"}]
+    },
+    "stdinWorkerPayloadContract": {
+      "additionalProperties": false,
+      "properties": {
+        "mode": {"enum": ["audit", "fix", "independent-review", "revalidation", "synthesis", "validation"]},
+        "node_id": {"minLength": 1, "type": "string"},
+        "owned_paths": {"$ref": "#/$defs/stringArray"},
+        "result_contract": {"enum": ["compact-review", "compact-validation", "native-independent-review"]},
+        "schema_version": {"const": 1},
+        "worker_payload_path": {"minLength": 1, "type": "string"}
+      },
+      "required": ["mode", "node_id", "owned_paths", "result_contract", "schema_version", "worker_payload_path"],
+      "type": "object"
+    },
+    "legacyWorkerPayloadContract": {
       "additionalProperties": false,
       "properties": {
         "candidate_path": {"minLength": 1, "type": "string"},
@@ -155,6 +171,7 @@
       "required": ["candidate_path", "mode", "node_id", "owned_paths", "result_contract", "schema_version", "worker_payload_path"],
       "type": "object"
     },
+    "review-worker-payload-write": {"$ref": "#/$defs/stdinWorkerPayloadContract"},
     "reconcile-handoffs": {
       "additionalProperties": false,
       "properties": {

--- a/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
@@ -175,6 +175,15 @@ class JournalEventRequest:
     reason: str | None = None
 
 
+class WorkerPayloadWriteError(OSError):
+    """Preserve the validated payload identity when artifact publication fails."""
+
+    def __init__(self, message: str, artifact_write_review: dict[str, Any]) -> None:
+        """Attach the deterministic safety review to the publication failure."""
+        super().__init__(message)
+        self.artifact_write_review = artifact_write_review
+
+
 def _canonical_json(value: object) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
 
@@ -2922,13 +2931,40 @@ def _worker_prompt(contract: str, dispatch: dict[str, Any]) -> str:
         msg = "worker dispatch lacks its runtime-owned payload persistence contract"
         raise ValueError(msg)
     persistence_input = _required_text(persistence, "input_path")
-    persistence_candidate = _required_text(persistence, "candidate_path")
     persistence_command = _text_list(persistence, "command", required=True)
-    persistence_text = (
-        f" Before returning, write the exact result bytes to temporary sibling {persistence_candidate}, then invoke the runtime-owned "
-        f"persistence command unchanged: {shlex.join(persistence_command)}. Its bound input is {persistence_input} and candidate is {persistence_candidate}. "
-        f"Only after it atomically publishes {worker_payload_path} may you return those same bytes."
-    )
+    review_command = _text_list(persistence, "review_command")
+    if persistence.get("input_mode") == "stdin" and review_command:
+        persistence_text = (
+            " Before returning, hold the exact result bytes in memory. Stream them on standard input to the runtime-owned "
+            f"safety-review command unchanged: {shlex.join(review_command)}. It validates the bound contract at {persistence_input} before any artifact write "
+            "and returns an approval_identity. Then stream the identical bytes to the persistence command "
+            f"{shlex.join(persistence_command)} with --approval-identity <reviewed identity>. "
+            f"Only {worker_payload_path} is an artifact write target; path strings "
+            "inside the payload are evidence. If publication is blocked and the user approves that identity, retry identical bytes and the same command; never "
+            f"rewrite evidence to obtain approval. Only after the runtime atomically publishes {worker_payload_path} may you return those same bytes. "
+            "Serialize payload_bytes once and retain them for both calls and any retry. Python example (dispatch is the supplied dispatch object):\n"
+            "```python\n"
+            "import json\n"
+            "import subprocess\n"
+            "p = dispatch['worker_payload_persistence']\n"
+            "review = subprocess.run(p['review_command'], input=payload_bytes, capture_output=True, check=True)\n"
+            "identity = json.loads(review.stdout)['approval_identity']\n"
+            "subprocess.run([*p['command'], '--approval-identity', identity], input=payload_bytes, capture_output=True, check=True)\n"
+            "```\n"
+        )
+    else:
+        persistence_candidate = _required_text(persistence, "candidate_path")
+        persistence_text = (
+            f" Before returning, write the exact result bytes to temporary sibling {persistence_candidate}, then invoke the runtime-owned "
+            f"persistence command unchanged: {shlex.join(persistence_command)}. "
+            f"Its bound input is {persistence_input} and candidate is {persistence_candidate}. "
+            f"Only {persistence_candidate} and {worker_payload_path} are artifact write targets; path strings inside the payload are evidence. "
+            "The persistence receipt or a publication-block diagnostic supplies an approval_identity bound to the exact bytes and both paths. "
+            "If publication is blocked and the user approves that identity, preserve the candidate bytes and retry the same command with "
+            "--approval-identity <approved identity>; "
+            "never rewrite evidence to obtain approval. "
+            f"Only after it atomically publishes {worker_payload_path} may you return those same bytes."
+        )
     if contract == "native-independent-review":
         return (
             "Perform only the dispatched repository-independent-review in fresh context. Return the six canonical native sections "
@@ -2939,15 +2975,22 @@ def _worker_prompt(contract: str, dispatch: dict[str, Any]) -> str:
     validation_text = (
         " Omit artifacts: the runtime captures workspace status and artifact digests before and after execution." if contract == "compact-validation" else ""
     )
+    audit_scope_text = (
+        " For audit payloads, files_inspected names dispatch-owned reads; nearby_contract_owners names inspected read-only dependency/context provenance and "
+        "may be outside dispatch ownership; scope_limitations is reserved exclusively for omitted dispatch-owned paths and must equal owned_paths minus "
+        "files_inspected. Narrative limitations do not create omitted scope or artifact write targets."
+        if dispatch.get("mode") == "audit"
+        else ""
+    )
     return (
         f"Return only the canonical {contract} payload using field names from {schema_text}. "
         "Every field shown in payload_schema.required_shape is required whenever its parent object is present. "
         "Do not author fingerprints, evidence IDs, artifact IDs, or digests. "
-        f"Command policy: {command_policy}{validation_text}{persistence_text}{shared_text}"
+        f"Command policy: {command_policy}{validation_text}{audit_scope_text}{persistence_text}{shared_text}"
     )
 
 
-def _validate_worker_payload_bytes(contract_document: dict[str, Any], payload_bytes: bytes) -> None:
+def _validate_worker_payload_bytes(contract_document: dict[str, Any], payload_bytes: bytes) -> dict[str, Any] | None:
     """Reject incomplete worker output before it can replace a persisted payload."""
     contract = _required_text(contract_document, "result_contract")
     if contract in {"compact-review", "compact-validation"}:
@@ -2962,18 +3005,123 @@ def _validate_worker_payload_bytes(contract_document: dict[str, Any], payload_by
             if blockers:
                 msg = "worker payload failed owned-scope validation: " + "; ".join(blockers)
                 raise ValueError(msg)
-        return
+        return payload
     if contract == "native-independent-review":
         _independent_input_sections(payload_bytes)
-        return
+        return None
     msg = f"unsupported worker payload result contract: {contract}"
     raise ValueError(msg)
 
 
-def persist_worker_payload(contract_document: dict[str, Any], candidate_path: Path) -> dict[str, Any]:
-    """Validate and atomically publish one dispatch-bound worker payload."""
+def review_worker_payload_write(contract_document: dict[str, Any], payload_bytes: bytes, *, candidate_is_write_target: bool = False) -> dict[str, Any]:
+    """Validate bytes and bind their publication to the complete persistence contract."""
+    definition = "legacyWorkerPayloadContract" if candidate_is_write_target else "stdinWorkerPayloadContract"
+    require_schema_definition(contract_document, _RUNTIME_OPERATION_INPUT_SCHEMA, definition)
     node_id = _required_text(contract_document, "node_id")
     result_contract = _required_text(contract_document, "result_contract")
+    target = Path(_required_text(contract_document, "worker_payload_path")).resolve()
+    target_path = str(target)
+    payload = _validate_worker_payload_bytes(contract_document, payload_bytes)
+    payload_digest = _sha256_bytes(payload_bytes)
+    identity_record: dict[str, object] = {
+        "contract_digest": _sha256_bytes(_canonical_json(contract_document).encode()),
+        "node_id": node_id,
+        "payload_byte_count": len(payload_bytes),
+        "payload_digest": payload_digest,
+        "payload_input": "candidate-path" if candidate_is_write_target else "stdin",
+        "result_contract": result_contract,
+        "worker_payload_path": target_path,
+    }
+    write_targets = [target_path]
+    if candidate_is_write_target:
+        candidate = Path(_required_text(contract_document, "candidate_path")).resolve()
+        if candidate == target or candidate.parent != target.parent:
+            msg = "worker payload candidate binding must be a distinct sibling of the materialized target"
+            raise ValueError(msg)
+        candidate_path = str(candidate)
+        identity_record["candidate_path"] = candidate_path
+        write_targets.insert(0, candidate_path)
+    review: dict[str, Any] = {
+        "approval_identity": _sha256_bytes(_canonical_json(identity_record).encode()),
+        "artifact_write_targets": write_targets,
+        "decision": "valid-bound-artifact-write",
+        **identity_record,
+    }
+    if result_contract == "compact-review" and contract_document.get("mode") == "audit" and payload is not None:
+        owned_paths = _text_list(contract_document, "owned_paths", required=True)
+        inspected_paths = _text_list(payload, "files_inspected")
+        inspected = set(inspected_paths)
+        review["audit_path_roles"] = {
+            "dispatch_owned_paths": list(owned_paths),
+            "inspected_dispatch_owned_paths": list(inspected_paths),
+            "nearby_context_paths": list(_text_list(payload, "nearby_contract_owners")),
+            "omitted_dispatch_owned_paths": [path for path in owned_paths if path not in inspected],
+            "scope_limitation_paths": [path for path, _reason in _scope_limitation_records(payload)],
+        }
+        review["payload_field_semantics"] = {
+            "limitations": "narrative-only",
+            "nearby_contract_owners": "inspected-context-only",
+            "scope_limitations": "omitted-dispatch-owned-only",
+        }
+    return review
+
+
+def _approved_worker_payload_write(
+    contract_document: dict[str, Any], payload_bytes: bytes, approval_identity: str | None, *, candidate_is_write_target: bool = True
+) -> dict[str, Any]:
+    artifact_write_review = review_worker_payload_write(contract_document, payload_bytes, candidate_is_write_target=candidate_is_write_target)
+    if approval_identity is not None:
+        _sha256_digest(approval_identity, "worker payload approval identity")
+        if approval_identity != artifact_write_review["approval_identity"]:
+            msg = "worker payload differs from the explicitly approved artifact write"
+            raise ValueError(msg)
+    return artifact_write_review
+
+
+def _worker_payload_receipt(contract_document: dict[str, Any], payload_bytes: bytes, artifact_write_review: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "node_id": _required_text(contract_document, "node_id"),
+        "result_contract": _required_text(contract_document, "result_contract"),
+        "schema_version": 1,
+        "worker_payload_byte_count": len(payload_bytes),
+        "worker_payload_digest": _sha256_bytes(payload_bytes),
+        "worker_payload_path": str(Path(_required_text(contract_document, "worker_payload_path")).resolve()),
+        "artifact_write_review": artifact_write_review,
+    }
+
+
+def persist_worker_payload_bytes(contract_document: dict[str, Any], payload_bytes: bytes, *, approval_identity: str) -> dict[str, Any]:
+    """Validate and atomically publish payload bytes received without a staging write."""
+    _sha256_digest(approval_identity, "worker payload approval identity")
+    target_path = Path(_required_text(contract_document, "worker_payload_path")).resolve()
+    if not target_path.parent.is_dir():
+        msg = f"worker payload target directory does not exist: {target_path.parent}"
+        raise ValueError(msg)
+    artifact_write_review = _approved_worker_payload_write(contract_document, payload_bytes, approval_identity, candidate_is_write_target=False)
+    temporary_path: Path | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f".{target_path.name}.", suffix=".tmp", dir=target_path.parent)
+        temporary_path = Path(temporary_name)
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload_bytes)
+            stream.flush()
+            os.fsync(stream.fileno())
+        temporary_path.replace(target_path)
+        _fsync_directory(target_path.parent)
+        if target_path.read_bytes() != payload_bytes:
+            msg = f"atomically published worker payload bytes differ from the validated input: {target_path}"
+            raise ValueError(msg)
+    except OSError as error:
+        msg = f"worker payload artifact publication failed: {error}"
+        raise WorkerPayloadWriteError(msg, artifact_write_review) from error
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+    return _worker_payload_receipt(contract_document, payload_bytes, artifact_write_review)
+
+
+def persist_worker_payload(contract_document: dict[str, Any], candidate_path: Path, *, approval_identity: str | None = None) -> dict[str, Any]:
+    """Validate and atomically publish one dispatch-bound worker payload."""
     target_path = Path(_required_text(contract_document, "worker_payload_path")).resolve()
     expected_candidate = Path(_required_text(contract_document, "candidate_path")).resolve()
     candidate = candidate_path.resolve()
@@ -2992,21 +3140,18 @@ def persist_worker_payload(contract_document: dict[str, Any], candidate_path: Pa
 
     with candidate.open("rb+") as stream:
         payload_bytes = stream.read()
-        _validate_worker_payload_bytes(contract_document, payload_bytes)
+        artifact_write_review = _approved_worker_payload_write(contract_document, payload_bytes, approval_identity)
         stream.flush()
         os.fsync(stream.fileno())
-    candidate.replace(target_path)
+    try:
+        candidate.replace(target_path)
+    except OSError as error:
+        msg = f"worker payload artifact publication failed: {error}"
+        raise WorkerPayloadWriteError(msg, artifact_write_review) from error
     if target_path.read_bytes() != payload_bytes:
         msg = f"atomically published worker payload bytes differ from the validated candidate: {target_path}"
         raise ValueError(msg)
-    return {
-        "node_id": node_id,
-        "result_contract": result_contract,
-        "schema_version": 1,
-        "worker_payload_byte_count": len(payload_bytes),
-        "worker_payload_digest": _sha256_bytes(payload_bytes),
-        "worker_payload_path": str(target_path),
-    }
+    return _worker_payload_receipt(contract_document, payload_bytes, artifact_write_review)
 
 
 def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
@@ -3110,16 +3255,21 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
         metadata_path = artifact_store / f"{node.node_id}.evidence.json"
         worker_payload_suffix = "md" if node.mode == "independent-review" else "json"
         worker_payload_path = artifact_store / f"{node.node_id}.worker-payload.{worker_payload_suffix}"
-        worker_payload_candidate_path = artifact_store / f"{node.node_id}.worker-payload.candidate.{worker_payload_suffix}"
         worker_payload_contract_path = artifact_store / f"{node.node_id}.worker-payload-contract.json"
-        worker_payload_persistence_command = [
+        worker_payload_command_prefix = [
             str(Path(sys.executable).resolve()),
             str(Path(__file__).resolve()),
             "persist-worker-payload",
             "--input",
             str(worker_payload_contract_path),
-            "--payload",
-            str(worker_payload_candidate_path),
+            "--payload-stdin",
+        ]
+        worker_payload_review_command = [
+            str(Path(sys.executable).resolve()),
+            str(Path(__file__).resolve()),
+            "review-worker-payload-write",
+            "--input",
+            str(worker_payload_contract_path),
         ]
         instruction_paths = _applicable_instruction_paths(repository_root_path.resolve(), node.coverage, node.instruction_paths)
         authorized_duplicates = tuple(sorted(set(raw_duplicate_authorizations.get(node.node_id, ()))))
@@ -3153,10 +3303,11 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
             "state_verification_command": state_command,
             "worker_payload_path": str(worker_payload_path),
             "worker_payload_persistence": {
-                "candidate_path": str(worker_payload_candidate_path),
-                "command": worker_payload_persistence_command,
+                "command": worker_payload_command_prefix,
+                "input_mode": "stdin",
                 "input_path": str(worker_payload_contract_path),
                 "operation": "persist-worker-payload",
+                "review_command": worker_payload_review_command,
             },
             "worker_created": location == "worker",
         }
@@ -3206,7 +3357,6 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
                 common["payload_schema"] = review_schema
                 contract = "compact-review"
         persistence_contract = {
-            "candidate_path": str(worker_payload_candidate_path),
             "mode": node.mode,
             "node_id": node.node_id,
             "owned_paths": list(node.coverage),
@@ -3227,7 +3377,6 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
             "node_id": node.node_id,
             "result_contract": contract,
             "worker_input_path": str(worker_input_path),
-            "worker_payload_candidate_path": str(worker_payload_candidate_path),
             "worker_payload_contract_path": str(worker_payload_contract_path),
             "worker_payload_path": str(worker_payload_path),
             "worker_prompt": _worker_prompt(contract, common),
@@ -4170,7 +4319,11 @@ def _fallback_to_coordinator_locked(document: dict[str, Any], args: argparse.Nam
     if original["dispatch"]["execution_location"] != "worker":
         msg = f"fallback node is not assigned to a worker: {node_id}"
         raise ValueError(msg)
-    if any(Path(original[field]).exists() for field in ("artifact_path", "metadata_path", "worker_payload_path", "worker_payload_candidate_path")):
+    if any(
+        Path(original[field]).exists()
+        for field in ("artifact_path", "metadata_path", "worker_payload_path", "worker_payload_candidate_path")
+        if field in original
+    ):
         msg = f"fallback node already has execution output: {node_id}"
         raise ValueError(msg)
     identity = _sha256_bytes(_canonical_json({"dispatch_set_digest": dispatch_set["dispatch_set_digest"], "node_id": node_id, "journal_head": head}).encode())
@@ -4809,7 +4962,16 @@ def _argument_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     )
     persist_parser = _runtime_subparser(subparsers, "persist-worker-payload", "validate and atomically publish one materialized worker payload")
     persist_parser.add_argument("--input", type=Path, required=True)
-    persist_parser.add_argument("--payload", type=Path, required=True)
+    payload_source = persist_parser.add_mutually_exclusive_group(required=True)
+    payload_source.add_argument("--payload", type=Path, help="legacy materialized candidate path")
+    payload_source.add_argument("--payload-stdin", action="store_true", help="read candidate bytes from standard input before any artifact write")
+    persist_parser.add_argument(
+        "--approval-identity", help="bind an explicitly approved retry to the exact validated payload bytes, input mode, and materialized target"
+    )
+    review_write_parser = _runtime_subparser(
+        subparsers, "review-worker-payload-write", "validate standard-input worker payload bytes and emit their artifact-write review without publishing"
+    )
+    review_write_parser.add_argument("--input", type=Path, required=True)
     synthesis_parser = _runtime_subparser(subparsers, "synthesis-bundle", "build a compact synthesis bundle")
     synthesis_parser.add_argument("--input", type=Path, required=True)
     synthesis_parser.add_argument("--output", type=Path, required=True)
@@ -5253,10 +5415,25 @@ def _json_operation_output(document: dict[str, Any], args: argparse.Namespace) -
     return finalize_proof(_finalize_document_from_files(document, args))
 
 
-def _run_operation(document: dict[str, Any], args: argparse.Namespace) -> int:  # noqa: C901
-    if args.operation == "persist-worker-payload":
-        print(_canonical_json(persist_worker_payload(document, args.payload)))
+def _run_worker_payload_operation(document: dict[str, Any], args: argparse.Namespace) -> int:
+    if args.operation == "review-worker-payload-write":
+        payload_bytes = sys.stdin.buffer.read()
+        print(_canonical_json(review_worker_payload_write(document, payload_bytes, candidate_is_write_target=False)))
         return 0
+    if args.payload_stdin:
+        if args.approval_identity is None:
+            msg = "persist-worker-payload --payload-stdin requires the artifact-write review approval identity"
+            raise ValueError(msg)
+        payload_bytes = sys.stdin.buffer.read()
+        print(_canonical_json(persist_worker_payload_bytes(document, payload_bytes, approval_identity=args.approval_identity)))
+        return 0
+    print(_canonical_json(persist_worker_payload(document, args.payload, approval_identity=args.approval_identity)))
+    return 0
+
+
+def _run_operation(document: dict[str, Any], args: argparse.Namespace) -> int:  # noqa: C901
+    if args.operation in {"persist-worker-payload", "review-worker-payload-write"}:
+        return _run_worker_payload_operation(document, args)
     if args.operation in {"compile-independent-review", "compile-review", "compile-validation"}:
         if args.operation in {"compile-review", "compile-validation"}:
             payload = document.get("payload")
@@ -5312,7 +5489,10 @@ def main(argv: list[str] | None = None) -> int:
         require_schema_definition(operation_document, _RUNTIME_OPERATION_INPUT_SCHEMA, args.operation)
         return _run_operation(operation_document, args)
     except (OSError, UnicodeError, json.JSONDecodeError, TypeError, ValueError) as error:
-        if isinstance(error, SchemaValidationError):
+        if isinstance(error, WorkerPayloadWriteError):
+            output = {"artifact_write_review": error.artifact_write_review, "error": "artifact-write-blocked", "message": str(error)}
+            print(_canonical_json(output), file=sys.stderr)
+        elif isinstance(error, SchemaValidationError):
             attempt = document.get("handoff_attempt", 1) if isinstance(document, dict) else 1
             retry_allowed = isinstance(attempt, int) and not isinstance(attempt, bool) and attempt == 1
             output = {**error.as_dict(), "handoff_attempt": attempt, "maximum_handoff_attempts": 2, "retry_allowed": retry_allowed}

--- a/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
@@ -1,6 +1,7 @@
 """Tests for compact review-graph runtime compilation."""
 
 import hashlib
+import io
 import json
 import os
 import shlex
@@ -58,9 +59,10 @@ from review_graph_runtime import (
     main,
     materialize_dispatches,
     next_ready_nodes,
-    persist_worker_payload,
+    persist_worker_payload_bytes,
     read_execution_journal,
     reconcile_handoffs,
+    review_worker_payload_write,
 )
 from review_graph_schema import SchemaValidationError, require_schema, require_schema_definition
 
@@ -2071,6 +2073,27 @@ def _assert_planned_validation_policy(audit_dispatch: dict[str, Any], validation
     }
 
 
+def _assert_materialized_worker_persistence(entry: dict[str, Any]) -> None:
+    worker_input = Path(entry["worker_input_path"])
+    assert worker_input.is_absolute()
+    assert json.loads(worker_input.read_text(encoding="utf-8")) == entry
+    assert worker_input.stat().st_mode & 0o777 == 0o444
+    persistence = entry["dispatch"]["worker_payload_persistence"]
+    command = persistence["command"]
+    assert Path(command[0]).is_absolute()
+    assert Path(command[0]).is_file()
+    assert command[1] == str(Path(__file__).resolve().with_name("review_graph_runtime.py"))
+    assert command[2:] == ["persist-worker-payload", "--input", entry["worker_payload_contract_path"], "--payload-stdin"]
+    assert persistence["input_mode"] == "stdin"
+    assert "candidate_path" not in persistence
+    assert "worker_payload_candidate_path" not in entry
+    contract = json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8"))
+    assert "candidate_path" not in contract
+    assert persistence["review_command"] == [command[0], command[1], "review-worker-payload-write", "--input", entry["worker_payload_contract_path"]]
+    assert shlex.join(command) in entry["worker_prompt"]
+    assert shlex.join(persistence["review_command"]) in entry["worker_prompt"]
+
+
 def test_dispatch_materialization_and_ready_nodes_are_plan_derived(tmp_path: Path) -> None:
     plan = _sparse_plan()
     result = materialize_dispatches(
@@ -2108,17 +2131,7 @@ def test_dispatch_materialization_and_ready_nodes_are_plan_derived(tmp_path: Pat
     assert all("persist-worker-payload" in entry["worker_prompt"] for entry in result["dispatches"])
     assert all(Path(entry["worker_payload_contract_path"]).is_file() for entry in result["dispatches"])
     for entry in result["dispatches"]:
-        worker_input = Path(entry["worker_input_path"])
-        assert worker_input.is_absolute()
-        assert json.loads(worker_input.read_text(encoding="utf-8")) == entry
-        assert worker_input.stat().st_mode & 0o777 == 0o444
-        persistence = entry["dispatch"]["worker_payload_persistence"]
-        command = persistence["command"]
-        assert Path(command[0]).is_absolute()
-        assert Path(command[0]).is_file()
-        assert command[1] == str(Path(__file__).resolve().with_name("review_graph_runtime.py"))
-        assert command[2:] == ["persist-worker-payload", "--input", entry["worker_payload_contract_path"], "--payload", entry["worker_payload_candidate_path"]]
-        assert shlex.join(command) in entry["worker_prompt"]
+        _assert_materialized_worker_persistence(entry)
 
     lifecycle_document = {
         "current_source_state": ["scope", "worktree", "repository"],
@@ -2210,9 +2223,10 @@ payload = {
     "findings": [], "validation_requirements": [], "handoffs": [],
     "limitations": [], "scope_limitations": [], "status": "no-findings"
 }
-persistence = dispatch["worker_payload_persistence"]
-Path(persistence["candidate_path"]).write_text(json.dumps(payload))
-subprocess.run(persistence["command"], check=True, timeout=30)
+payload_bytes = (json.dumps(payload, sort_keys=True) + "\\n").encode()
+example = entry["worker_prompt"].split("```python\\n", 1)[1].split("```", 1)[0]
+exec(example)
+sys.stdout.buffer.write(payload_bytes)
 """
 
     result = subprocess.run(  # noqa: S603 - isolated protocol fixture, no review/validation commands executed.
@@ -2220,20 +2234,29 @@ subprocess.run(persistence["command"], check=True, timeout=30)
     )
 
     assert result.returncode == 0, result.stderr
-    receipt = json.loads(result.stdout)
-    assert receipt["worker_payload_path"] == entry["worker_payload_path"]
-    payload = json.loads(Path(receipt["worker_payload_path"]).read_text(encoding="utf-8"))
+    assert result.stdout.encode() == Path(entry["worker_payload_path"]).read_bytes()
+    payload = json.loads(result.stdout)
     assert payload["files_inspected"] == entry["dispatch"]["owned_paths"]
     assert payload["status"] == "no-findings"
+    assert not list(Path(entry["worker_payload_path"]).parent.glob("*.candidate.*"))
     assert not list(worker_directory.iterdir())
+
+
+def _publish_worker_bytes(entry: dict[str, Any], payload_bytes: bytes) -> dict[str, Any]:
+    """Exercise the materialized stdin protocol for compiler and lifecycle fixtures."""
+    persistence = entry["dispatch"]["worker_payload_persistence"]
+    review = subprocess.run(persistence["review_command"], input=payload_bytes, capture_output=True, check=True, timeout=30)  # noqa: S603
+    identity = json.loads(review.stdout)["approval_identity"]
+    published = subprocess.run(  # noqa: S603 - runtime-materialized commands for this test's proof store.
+        [*persistence["command"], "--approval-identity", identity], input=payload_bytes, capture_output=True, check=True, timeout=30
+    )
+    return json.loads(published.stdout)
 
 
 def test_compile_node_destination_error_cannot_publish_evidence_or_acceptance(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     document, dispatches = _worker_input_fixture(tmp_path)
     entry = next(item for item in dispatches["dispatches"] if item["result_contract"] == "compact-review")
-    candidate = Path(entry["worker_payload_candidate_path"])
-    candidate.write_text(json.dumps(_compact_audit_payload(entry)), encoding="utf-8")
-    persist_worker_payload(json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8")), candidate)
+    _publish_worker_bytes(entry, json.dumps(_compact_audit_payload(entry)).encode())
     lifecycle_path, dispatch_path, capture_path = _compile_cli_paths(tmp_path, document, dispatches)
     journal = tmp_path / "execution.jsonl"
 
@@ -2270,9 +2293,7 @@ def test_compile_node_partial_journal_failure_rolls_back_outputs_and_retries(
 ) -> None:
     document, dispatches = _worker_input_fixture(tmp_path)
     entry = next(item for item in dispatches["dispatches"] if item["result_contract"] == "compact-review")
-    candidate = Path(entry["worker_payload_candidate_path"])
-    candidate.write_text(json.dumps(_compact_audit_payload(entry)), encoding="utf-8")
-    persist_worker_payload(json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8")), candidate)
+    _publish_worker_bytes(entry, json.dumps(_compact_audit_payload(entry)).encode())
     lifecycle_path, dispatch_path, capture_path = _compile_cli_paths(tmp_path, document, dispatches)
     journal = tmp_path / "execution.jsonl"
     output_path = tmp_path / "compile-result.json"
@@ -2323,9 +2344,7 @@ def test_fresh_context_compile_rejects_reads_of_sibling_worker_evidence(tmp_path
     assert len(audits) >= 2
     entry, sibling = audits[:2]
     command = f"cat {sibling['worker_payload_path']}"
-    candidate = Path(entry["worker_payload_candidate_path"])
-    candidate.write_text(json.dumps(_compact_audit_payload(entry, commands=(command,))), encoding="utf-8")
-    persist_worker_payload(json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8")), candidate)
+    _publish_worker_bytes(entry, json.dumps(_compact_audit_payload(entry, commands=(command,))).encode())
     lifecycle_path, dispatch_path, capture_path = _compile_cli_paths(tmp_path, document, dispatches)
     journal = tmp_path / "execution.jsonl"
 
@@ -2967,12 +2986,10 @@ def test_positive_independent_example_persists_compiles_and_journals_verbatim(tm
         }
     )
     entry = next(item for item in materialized["dispatches"] if item["result_contract"] == "native-independent-review")
-    candidate = Path(entry["worker_payload_candidate_path"])
     native = INDEPENDENT_NATIVE_POSITIVE_EXAMPLE.read_bytes()
     for symbolic, actual in zip((b"scope", b"worktree", b"repository"), source_state, strict=True):
         native = native.replace(b"fingerprint: " + symbolic, b"fingerprint: " + actual.encode())
-    candidate.write_bytes(native)
-    persist_worker_payload(json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8")), candidate)
+    _publish_worker_bytes(entry, native)
     lifecycle_path = tmp_path / "lifecycle.json"
     dispatches_path = tmp_path / "dispatches.json"
     capture_path = tmp_path / "capture.json"
@@ -3105,7 +3122,7 @@ def _legacy_plan_digest(plan: GraphPlan) -> str:
 
 
 @pytest.mark.parametrize("legacy_digest", [False, True])
-def test_compile_node_survives_context_compaction_by_reading_bound_worker_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, legacy_digest: bool) -> None:  # noqa: PLR0915
+def test_compile_node_survives_context_compaction_by_reading_bound_worker_payload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, legacy_digest: bool) -> None:
     if legacy_digest:
         monkeypatch.setattr("review_graph_runtime.graph_plan_digest", _legacy_plan_digest)
     plan = _sparse_plan()
@@ -3146,14 +3163,12 @@ def test_compile_node_survives_context_compaction_by_reading_bound_worker_payloa
     dispatch_path = tmp_path / "dispatches.json"
     capture_path = tmp_path / "capture.json"
     payload_path = Path(entry["worker_payload_path"])
-    payload_candidate_path = Path(entry["worker_payload_candidate_path"])
     output_path = tmp_path / "compile.json"
     journal_path = tmp_path / "journal" / "execution.jsonl"
     lifecycle_path.write_text(json.dumps(lifecycle), encoding="utf-8")
     dispatch_path.write_text(json.dumps(dispatch_set), encoding="utf-8")
     capture_path.write_text(json.dumps(capture), encoding="utf-8")
-    payload_candidate_path.write_bytes(payload_bytes)
-    assert main(["persist-worker-payload", "--input", entry["worker_payload_contract_path"], "--payload", str(payload_candidate_path)]) == 0
+    _publish_worker_bytes(entry, payload_bytes)
     journal_path.parent.mkdir()
     append_journal_event(journal_path, lifecycle, JournalEventRequest(entry["node_id"], "in-flight"))
     original_journal = journal_path.read_bytes()
@@ -3200,14 +3215,13 @@ def test_compile_node_survives_context_compaction_by_reading_bound_worker_payloa
     build_synthesis_bundle({"source_state": source_state, "sources": [source]})
 
     replacement_bytes = (json.dumps({**payload, "limitations": ["late replacement"]}, indent=2) + "\n").encode()
-    payload_candidate_path.write_bytes(replacement_bytes)
-    assert main(["persist-worker-payload", "--input", entry["worker_payload_contract_path"], "--payload", str(payload_candidate_path)]) == 0
+    _publish_worker_bytes(entry, replacement_bytes)
     assert payload_path.read_bytes() == replacement_bytes
     assert sealed_payload_path.read_bytes() == payload_bytes
     build_synthesis_bundle({"source_state": source_state, "sources": [source]})
 
 
-def test_persist_worker_payload_preserves_valid_target_when_validation_or_publication_fails(
+def test_legacy_candidate_persistence_preserves_valid_target_when_validation_or_publication_fails(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     plan = _sparse_plan()
@@ -3223,7 +3237,11 @@ def test_persist_worker_payload_preserves_valid_target_when_validation_or_public
     )
     entry = next(candidate for candidate in dispatch_set["dispatches"] if candidate["result_contract"] == "compact-review")
     target = Path(entry["worker_payload_path"])
-    candidate = Path(entry["worker_payload_candidate_path"])
+    candidate = target.with_suffix(".candidate.json")
+    legacy_contract_path = tmp_path / "legacy-contract.json"
+    legacy_contract = json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8"))
+    legacy_contract["candidate_path"] = str(candidate)
+    legacy_contract_path.write_text(json.dumps(legacy_contract), encoding="utf-8")
     valid_payload = {
         "changes": [],
         "command_policy_attested": True,
@@ -3239,7 +3257,7 @@ def test_persist_worker_payload_preserves_valid_target_when_validation_or_public
     }
     valid_bytes = (json.dumps(valid_payload, indent=2) + "\n").encode()
     candidate.write_bytes(valid_bytes)
-    command = ["persist-worker-payload", "--input", entry["worker_payload_contract_path"], "--payload", str(candidate)]
+    command = ["persist-worker-payload", "--input", str(legacy_contract_path), "--payload", str(candidate)]
     assert main(command) == 0
     capsys.readouterr()
 
@@ -3262,13 +3280,180 @@ def test_persist_worker_payload_preserves_valid_target_when_validation_or_public
     assert candidate.is_file()
 
 
-def test_baseline_audit_rejects_changed_only_no_findings_before_publication(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_standard_input_persistence_requires_the_reviewed_identity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    _document, dispatches = _worker_input_fixture(tmp_path)
+    entry = next(item for item in dispatches["dispatches"] if item["result_contract"] == "compact-review")
+    payload_bytes = (json.dumps(_compact_audit_payload(entry), sort_keys=True) + "\n").encode()
+    with monkeypatch.context() as patch:
+        patch.setattr(sys, "stdin", io.TextIOWrapper(io.BytesIO(payload_bytes), encoding="utf-8"))
+        result = main(["persist-worker-payload", "--input", entry["worker_payload_contract_path"], "--payload-stdin"])
+
+    assert result == 2
+    assert "requires the artifact-write review approval identity" in capsys.readouterr().err
+    assert not Path(entry["worker_payload_path"]).exists()
+
+
+@pytest.mark.parametrize("approval_arguments", [{}, {"approval_identity": None}, {"approval_identity": ""}])
+def test_python_stdin_publication_requires_an_identity_before_any_write(tmp_path: Path, approval_arguments: dict[str, Any]) -> None:
+    _document, dispatches = _worker_input_fixture(tmp_path)
+    entry = next(item for item in dispatches["dispatches"] if item["result_contract"] == "compact-review")
+    contract = json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8"))
+    payload_bytes = json.dumps(_compact_audit_payload(entry)).encode()
+    store = Path(entry["worker_payload_path"]).parent
+    before = set(store.iterdir())
+
+    with pytest.raises((TypeError, ValueError), match=r"approval[_ ]identity"):
+        cast("Any", persist_worker_payload_bytes)(contract, payload_bytes, **approval_arguments)
+
+    assert set(store.iterdir()) == before
+
+
+@pytest.mark.parametrize("changed_field", ["mode", "owned_paths", "node_id", "worker_payload_path", "schema_version", "result_contract"])
+def test_stdin_approval_rejects_changed_contract_before_replacing_target(tmp_path: Path, changed_field: str) -> None:
+    _document, dispatches = _worker_input_fixture(tmp_path)
+    entry = next(item for item in dispatches["dispatches"] if item["result_contract"] == "compact-review")
+    contract = json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8"))
+    payload = {**_compact_audit_payload(entry), "status": "blocked", "limitations": ["fixture inspection blocked"]}
+    payload_bytes = json.dumps(payload).encode()
+    review = review_worker_payload_write(contract, payload_bytes)
+    persist_worker_payload_bytes(contract, payload_bytes, approval_identity=review["approval_identity"])
+    target = Path(entry["worker_payload_path"])
+    alternative_target = target.with_name("another-worker.json")
+    alternative_target.write_bytes(b"existing unrelated evidence")
+    changed_values = {
+        "mode": "revalidation",
+        "owned_paths": [*contract["owned_paths"], "newly-owned.rs"],
+        "node_id": "another-node",
+        "worker_payload_path": str(alternative_target),
+        "schema_version": 2,
+        "result_contract": "compact-validation",
+    }
+    changed_contract = {**contract, changed_field: changed_values[changed_field]}
+    before = {path: path.read_bytes() for path in target.parent.iterdir() if path.is_file()}
+
+    with pytest.raises((ValueError, SchemaValidationError)):
+        persist_worker_payload_bytes(changed_contract, payload_bytes, approval_identity=review["approval_identity"])
+
+    assert {path: path.read_bytes() for path in target.parent.iterdir() if path.is_file()} == before
+
+
+def test_stdin_review_binds_canonical_contract_and_rejects_legacy_candidate(tmp_path: Path) -> None:
+    _document, dispatches = _worker_input_fixture(tmp_path)
+    entry = next(item for item in dispatches["dispatches"] if item["result_contract"] == "compact-review")
+    contract = json.loads(Path(entry["worker_payload_contract_path"]).read_text(encoding="utf-8"))
+    payload_bytes = json.dumps(_compact_audit_payload(entry)).encode()
+    review = review_worker_payload_write(contract, payload_bytes)
+    reordered = dict(reversed(list(contract.items())))
+    assert review_worker_payload_write(reordered, payload_bytes) == review
+    receipt = persist_worker_payload_bytes(reordered, payload_bytes, approval_identity=review["approval_identity"])
+    assert receipt["artifact_write_review"] == review
+    canonical_contract = json.dumps(contract, sort_keys=True, separators=(",", ":"))
+    assert review["contract_digest"] == "sha256:" + hashlib.sha256(canonical_contract.encode()).hexdigest()
+    legacy_contract = {**contract, "candidate_path": str(tmp_path / "unused.candidate.json")}
+    with pytest.raises(SchemaValidationError):
+        review_worker_payload_write(legacy_contract, payload_bytes)
+
+
+def test_nearby_audit_context_persists_compiles_and_journals_with_stable_approval_identity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    document, dispatches = _worker_input_fixture(tmp_path)
+    entry = next(item for item in dispatches["dispatches"] if item["result_contract"] == "compact-review")
+    payload = {
+        **_compact_audit_payload(entry),
+        "limitations": ["Nearby tests were inspected as context but are outside this audit's owned paths."],
+        "nearby_contract_owners": ["tests/prelude_exports.rs", "tests/proptest_interval.rs"],
+    }
+    payload_bytes = (json.dumps(payload, indent=2, sort_keys=True) + "\n").encode()
+    persistence_command = ["persist-worker-payload", "--input", entry["worker_payload_contract_path"], "--payload-stdin"]
+    review_command = ["review-worker-payload-write", "--input", entry["worker_payload_contract_path"]]
+
+    with monkeypatch.context() as patch:
+        patch.setattr(sys, "stdin", io.TextIOWrapper(io.BytesIO(payload_bytes), encoding="utf-8"))
+        assert main(review_command) == 0
+
+    write_review = json.loads(capsys.readouterr().out)
+    assert (write_review["decision"], write_review["payload_input"]) == ("valid-bound-artifact-write", "stdin")
+    assert write_review["payload_digest"] == "sha256:" + hashlib.sha256(payload_bytes).hexdigest()
+    assert write_review["artifact_write_targets"] == [entry["worker_payload_path"]]
+    assert write_review["audit_path_roles"] == {
+        "dispatch_owned_paths": entry["dispatch"]["owned_paths"],
+        "inspected_dispatch_owned_paths": entry["dispatch"]["owned_paths"],
+        "nearby_context_paths": ["tests/prelude_exports.rs", "tests/proptest_interval.rs"],
+        "omitted_dispatch_owned_paths": [],
+        "scope_limitation_paths": [],
+    }
+    assert write_review["payload_field_semantics"]["nearby_contract_owners"] == "inspected-context-only"
+    assert not list(Path(entry["worker_payload_path"]).parent.glob("*.candidate.*"))
+    assert not Path(entry["worker_payload_path"]).exists()
+
+    def require_approval(_source: Path, _target: Path) -> Path:
+        message = "simulated artifact approval required"
+        raise PermissionError(message)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "replace", require_approval)
+        patch.setattr(sys, "stdin", io.TextIOWrapper(io.BytesIO(payload_bytes), encoding="utf-8"))
+        assert main([*persistence_command, "--approval-identity", write_review["approval_identity"]]) == 2
+
+    diagnostic = json.loads(capsys.readouterr().err)
+    assert diagnostic["error"] == "artifact-write-blocked"
+    assert diagnostic["artifact_write_review"] == write_review
+    assert not Path(entry["worker_payload_path"]).exists()
+
+    changed_bytes = (json.dumps({**payload, "limitations": ["changed after approval"]}, sort_keys=True) + "\n").encode()
+    with monkeypatch.context() as patch:
+        patch.setattr(sys, "stdin", io.TextIOWrapper(io.BytesIO(changed_bytes), encoding="utf-8"))
+        assert main([*persistence_command, "--approval-identity", write_review["approval_identity"]]) == 2
+    assert "differs from the explicitly approved artifact write" in capsys.readouterr().err
+    assert not Path(entry["worker_payload_path"]).exists()
+
+    with monkeypatch.context() as patch:
+        patch.setattr(sys, "stdin", io.TextIOWrapper(io.BytesIO(payload_bytes), encoding="utf-8"))
+        assert main([*persistence_command, "--approval-identity", write_review["approval_identity"]]) == 0
+    receipt = json.loads(capsys.readouterr().out)
+    assert receipt["artifact_write_review"] == write_review
+    assert Path(receipt["worker_payload_path"]).read_bytes() == payload_bytes
+
+    lifecycle_path, dispatch_path, capture_path = _compile_cli_paths(tmp_path, document, dispatches)
+    journal_path = tmp_path / "execution.jsonl"
+    operation_output_path = tmp_path / "compile-result.json"
+    assert (
+        main(
+            [
+                "compile-node",
+                "--input",
+                str(lifecycle_path),
+                "--dispatches",
+                str(dispatch_path),
+                "--node-id",
+                entry["node_id"],
+                "--before-capture",
+                str(capture_path),
+                "--after-capture",
+                str(capture_path),
+                "--journal",
+                str(journal_path),
+                "--output",
+                str(operation_output_path),
+            ]
+        )
+        == 0
+    )
+    events, lifecycle_state, _head = read_execution_journal(
+        journal_path, plan=_graph_plan(document["plan"]), source_state=cast("tuple[str, str, str]", tuple(document["source_state"]))
+    )
+    assert len(events) == 1
+    assert lifecycle_state[entry["node_id"]] == "accepted"
+    metadata = json.loads(Path(entry["metadata_path"]).read_text(encoding="utf-8"))
+    assert metadata["normalized_record"]["nearby_contract_owners"] == payload["nearby_contract_owners"]
+    assert metadata["normalized_record"]["scope_limitations"] == []
+
+
+def test_baseline_audit_rejects_changed_only_no_findings_before_publication(tmp_path: Path) -> None:
     target = tmp_path / "audit.worker-payload.json"
-    candidate = tmp_path / "audit.worker-payload.candidate.json"
-    contract_path = tmp_path / "audit.worker-payload-contract.json"
     owned_paths = ["README.md", "REFERENCES.md"]
     contract = {
-        "candidate_path": str(candidate),
         "mode": "audit",
         "node_id": "audit-docs",
         "owned_paths": owned_paths,
@@ -3289,17 +3474,25 @@ def test_baseline_audit_rejects_changed_only_no_findings_before_publication(tmp_
         "status": "no-findings",
         "validation_requirements": [],
     }
-    contract_path.write_text(json.dumps(contract), encoding="utf-8")
-    candidate.write_text(json.dumps(payload), encoding="utf-8")
-
-    assert main(["persist-worker-payload", "--input", str(contract_path), "--payload", str(candidate)]) == 2
-    assert "requires inspection of every owned path" in capsys.readouterr().err
+    with pytest.raises(ValueError, match="requires inspection of every owned path"):
+        review_worker_payload_write(contract, json.dumps(payload).encode())
     assert not target.exists()
-    assert candidate.exists()
+
+    invalid_nearby_limitation = {
+        **payload,
+        "files_inspected": owned_paths,
+        "nearby_contract_owners": ["tests/context.rs"],
+        "scope_limitations": [{"path": "tests/context.rs", "reason": "nearby context is not dispatch-owned"}],
+        "status": "completed",
+    }
+    with pytest.raises(ValueError, match=r"must name omitted owned paths: tests/context\.rs"):
+        review_worker_payload_write(contract, json.dumps(invalid_nearby_limitation).encode())
+    assert not target.exists()
 
     accepted = {**payload, "scope_limitations": [{"path": "REFERENCES.md", "reason": "upstream bibliography was unavailable"}], "status": "completed"}
-    candidate.write_text(json.dumps(accepted), encoding="utf-8")
-    assert main(["persist-worker-payload", "--input", str(contract_path), "--payload", str(candidate)]) == 0
+    accepted_bytes = json.dumps(accepted).encode()
+    review = review_worker_payload_write(contract, accepted_bytes)
+    persist_worker_payload_bytes(contract, accepted_bytes, approval_identity=review["approval_identity"])
     assert target.exists()
 
 
@@ -4044,9 +4237,7 @@ def test_bundle_only_synthesis_persists_and_compiles_without_reading_source(tmp_
         "limitations": [],
         "scope_limitations": [],
     }
-    candidate = Path(entry["worker_payload_candidate_path"])
-    candidate.write_text(json.dumps(payload), encoding="utf-8")
-    persist_worker_payload(json.loads(Path(entry["worker_payload_contract_path"]).read_text()), candidate)
+    _publish_worker_bytes(entry, json.dumps(payload).encode())
     dispatch = {**entry["dispatch"], "before_state": materialized["source_state"], "after_state": materialized["source_state"]}
     content, metadata = compile_review({"dispatch": dispatch, "payload": json.loads(Path(entry["worker_payload_path"]).read_text())})
     assert metadata["normalized_record"]["files_inspected"] == []

--- a/agents/.agents/skills/review-validator/SKILL.md
+++ b/agents/.agents/skills/review-validator/SKILL.md
@@ -27,8 +27,8 @@ Honor placement and the coalesced unit. Do not re-plan, split or broaden it,
 create another worker, or inspect implementation semantics. The coordinator
 owns before/after snapshots and all evidence identities and digests.
 
-Write the recursive payload to the dispatched candidate path, publish it through
-the runtime-owned `persist-worker-payload` operation, and return those bytes.
+Stream the payload through the dispatch-bound review and persistence commands;
+return identical bytes after publication. Skip candidate writes.
 
 ## Universal Boundaries
 

--- a/agents/.agents/skills/review-validator/references/graph-dispatch.md
+++ b/agents/.agents/skills/review-validator/references/graph-dispatch.md
@@ -38,10 +38,9 @@ discovery.
    approved artifact paths. Put unexecuted target cells and the boundary of any
    emulation in `limitations`.
 5. Repeat the source-state check. Complete the payload, including `exit_code`,
-   `elapsed`, and `artifact_paths` for every execution. Write its exact bytes to
-   the dispatched candidate path, invoke the runtime-owned
-   `persist-worker-payload` operation, and return those same bytes only after it
-   succeeds.
+   `elapsed`, and `artifact_paths` for every execution. Follow `worker_prompt`'s
+   publication example: serialize once, review over stdin, then persist identical
+   bytes with `--approval-identity` from the review. Return those bytes once published.
 6. The coordinator invokes the runtime-owned
    post-execution snapshot immediately afterward.
 

--- a/justfile
+++ b/justfile
@@ -8,10 +8,10 @@ export UV_CACHE_DIR := env_var_or_default("UV_CACHE_DIR", ".uv-cache")
 python_fixture_paths := "tests/semgrep"
 python_primary_paths := "agents/.agents/skills scripts"
 python_paths := python_primary_paths + " " + python_fixture_paths
-dprint_version := "0.57.1"
+dprint_version := "0.57.4"
 just_version := "1.58.0"
-rumdl_version := "0.2.64"
-uv_version := "0.12.9"
+rumdl_version := "0.2.67"
+uv_version := "0.12.10"
 zizmor_version := "1.30.0"
 
 _ensure-actionlint:

--- a/uv.lock
+++ b/uv.lock
@@ -19,15 +19,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.15.0"
+version = "4.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "typing-extensions", marker = "python_full_version < '3.15'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/9a/c15a60547004a3f3cea20296c934f827ddd7bdba225a2e7e9fcb5ec48c80/anyio-4.15.0.tar.gz", hash = "sha256:b5c620ed540725e2579c31b17bb995b3bf02c9281c9cace04c7d186380bab85e", size = 276504, upload-time = "2026-09-02T21:46:36.957Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/d2/f4d173e22df740bc37b1db102b386ba719b66e95b0f0d751f556b387e6d2/anyio-4.15.1.tar.gz", hash = "sha256:9f28306018cbd6d329e64a36d58256edff76dd996fe423bc957326e578b82a94", size = 276966, upload-time = "2026-09-05T10:42:39.44Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/a6/2b21ce5ebe4d8938a247c9b0dbb7271566ae559b01795c83ea4bb2660ed7/anyio-4.15.0-py3-none-any.whl", hash = "sha256:7ecd9937369ffce8bba0b5ccb9b3a9507b101b0ed50256aecfbab27e6c2acb99", size = 131908, upload-time = "2026-09-02T21:46:35.485Z" },
+    { url = "https://files.pythonhosted.org/packages/12/b8/4bd346e22b28902df4d651910f5242c28d84e4a5c2435ca5c3f797ed7e2e/anyio-4.15.1-py3-none-any.whl", hash = "sha256:6152fdbbf9a77fdec97731721bebf7c4c44f7c29b424b0065826173efc7ed101", size = 132079, upload-time = "2026-09-05T10:42:37.923Z" },
 ]
 
 [[package]]
@@ -1248,15 +1248,15 @@ wheels = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.4.10"
+version = "3.4.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/e1/8a41e88e825ea26c44333897c7ffe35fe60153a2cfc097a5bd1d209ad281/sse_starlette-3.4.10.tar.gz", hash = "sha256:c6c87280d8feb4e55a8d79633782766b9cac6a26da5c79a145d00aa404117a86", size = 33720, upload-time = "2026-09-03T09:36:24.08Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/54/6767bb789b2f2fed6e0f953df949cd39dc263a384c1b65a95232598621d6/sse_starlette-3.4.11.tar.gz", hash = "sha256:1bae716c02f3e6f294be41ff333220692dae7c3cbab077c900f159676719dade", size = 34972, upload-time = "2026-09-05T12:11:04.607Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/3c/96018a51c7301a64f7b0579d9ce8f9b69dd39ca8ed5aa100ba3feadee503/sse_starlette-3.4.10-py3-none-any.whl", hash = "sha256:710f5f5b0527409903a22a91699db02f76f4c2eb9204e882e4ee7cada76bdf75", size = 17120, upload-time = "2026-09-03T09:36:22.56Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6a/2ba3ed4a69babf3afdddf7d8314a48d87562c0a442206bbc2a1b50d5efc0/sse_starlette-3.4.11-py3-none-any.whl", hash = "sha256:c7b2244bdff016fe7f64e10075e89a3e6bbf899649cc89b0fe884b5545042453", size = 17122, upload-time = "2026-09-05T12:11:03.195Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Distinguish nearby context and narrative limitations from omitted scope.
- Review and atomically publish worker payloads through stdin.
- Bind approval retries to exact bytes, destinations, and full contracts.
- Preserve legacy candidate-file persistence for existing dispatches.
- Refresh development tool pins and locked dependencies.

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Improved review and validation workflows to publish approved results atomically and consistently.
  - Approval retries now verify that the content and approval identity remain unchanged.
  - Added clearer diagnostics when artifact publication fails.

- **Compatibility**
  - Preserved support for legacy payload publication workflows while introducing the newer reviewed flow.

- **Documentation**
  - Expanded guidance for artifact-write reviews, approval retries, audit scope, and publication verification.

- **Maintenance**
  - Updated pinned versions of formatting, linting, and environment tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->