### PR TITLE
fix(skills): reject malformed and duplicate frontmatter

### DIFF
--- a/agents/.agents/skills/repository-docs-review/SKILL.md
+++ b/agents/.agents/skills/repository-docs-review/SKILL.md
@@ -90,6 +90,9 @@ Check each applicable document for:
 Distinguish intentional historical examples, versioned migration notes, and archive
 content from stale current guidance. Do not perform blind version or name replacement.
 
+When reviewing README entry points or links reused in generated documentation and
+package pages, read [README navigation](references/readme-navigation.md).
+
 ## Specialist Handoffs
 
 Keep ownership explicit and select only specialists required by the files and claims:

--- a/agents/.agents/skills/repository-docs-review/references/readme-navigation.md
+++ b/agents/.agents/skills/repository-docs-review/references/readme-navigation.md
@@ -1,0 +1,17 @@
+# README Discovery and Published Navigation
+
+- Keep README entry points easy to find: a copyable quickstart, brief capability
+  descriptions, and direct links to fuller examples and contracts. Preserve useful
+  detail in its canonical guide when shortening an overview; do not silently discard
+  limitations or impose a fixed section layout or table size across repositories.
+- Prefer the project's generated reference site for API documentation and worked
+  API examples when that site supports them. Keep repository-owned development,
+  operational, and scientific-background documents at their established repository
+  or documentation-site destinations rather than duplicating the entire suite.
+- When a README is also embedded in generated documentation or a package page,
+  validate links and heading anchors in each actual rendering context. Relative
+  repository paths can resolve against the wrong site base; use explicit URLs or
+  the project's supported link transformation where needed.
+- Check the intended version or revision of each destination and distinguish local
+  rendering evidence from published availability. Route ecosystem-specific build,
+  release, and API-link details to the relevant documentation specialist.

--- a/agents/.agents/skills/rust-api-docs/SKILL.md
+++ b/agents/.agents/skills/rust-api-docs/SKILL.md
@@ -74,8 +74,11 @@ Flag:
 
 - bare type names that should be linked
 - broken intra-doc links
-- raw URLs to docs.rs when an intra-doc link is available
+- raw URLs to docs.rs in Rust doc comments when an intra-doc link is available
 - linkified prose that obscures readability with backticks where plain words would do
+
+Check links against the selected feature set so optional items do not break
+default-feature documentation.
 
 ### 4. Crate- and module-level docs
 
@@ -91,6 +94,9 @@ Flag:
 - missing crate-level docs on a published library
 - modules whose purpose is unclear from the docs
 - feature-gated APIs whose feature requirement is invisible in the rendered docs
+
+For published crates with shared README and rustdoc learning paths, read
+[published navigation](references/published-navigation.md).
 
 ### 5. API-supporting private helper docs
 

--- a/agents/.agents/skills/rust-api-docs/references/published-navigation.md
+++ b/agents/.agents/skills/rust-api-docs/references/published-navigation.md
@@ -1,0 +1,18 @@
+# Published README and Rustdoc Navigation
+
+- Prefer docs.rs destinations for API references and worked API examples. Detailed
+  composition examples can live in crate/module docs or focused documentation-only
+  guides, following the repository's existing structure. Keep a useful quickstart
+  and capability summaries in README, with direct links to the detailed material.
+- Keep repository-owned background and operational guides at their canonical
+  destinations. If README is included with `include_str!`, inspect the rendered
+  links: paths such as `docs/workflows.md` do not automatically point to GitHub from
+  docs.rs. Use absolute repository URLs for the intended revision when needed.
+- Use intra-doc links within Rust documentation where the target is available;
+  use links that work on both GitHub and rustdoc in shared README content.
+- Choose `latest` intentionally for current guidance and explicit versions for
+  release-specific contracts. docs.rs builds crates published to crates.io; a merge
+  alone does not publish new pages. Inspect locally generated destinations and
+  anchors; a successful `cargo doc` build alone does not verify explicit URLs or
+  current docs.rs availability. Do not publish or bump a version merely to make a
+  documentation link live without maintainer authorization.

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ python_primary_paths := "agents/.agents/skills scripts"
 python_paths := python_primary_paths + " " + python_fixture_paths
 dprint_version := "0.57.4"
 just_version := "1.58.0"
-rumdl_version := "0.2.67"
+rumdl_version := "0.2.68"
 uv_version := "0.12.10"
 zizmor_version := "1.30.0"
 

--- a/scripts/skill_validate.py
+++ b/scripts/skill_validate.py
@@ -4,10 +4,13 @@
 import argparse
 import re
 import sys
+from collections.abc import Hashable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import yaml
+from yaml.constructor import ConstructorError
+from yaml.nodes import MappingNode, Node, ScalarNode, SequenceNode
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -17,8 +20,50 @@ MAX_SKILL_NAME_LENGTH = 64
 MIN_SHORT_DESCRIPTION_LENGTH = 25
 MAX_SHORT_DESCRIPTION_LENGTH = 64
 ALLOWED_FRONTMATTER_KEYS = frozenset({"name", "description", "license", "allowed-tools", "metadata"})
-FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---(?:\n|\Z)", re.DOTALL)
 SKILL_NAME_RE = re.compile(r"^[a-z0-9-]+$")
+_YAML_MERGE_KEY = object()
+
+
+def construct_scalar_mapping_key(node: ScalarNode, loader: yaml.SafeLoader) -> Hashable:
+    """Construct a key identity without flattening away explicit duplicates."""
+    if node.tag == "tag:yaml.org,2002:merge":
+        # A merge directive is distinct from a literal quoted '<<' key.
+        key = _YAML_MERGE_KEY
+    elif node.tag == "tag:yaml.org,2002:value":
+        # SafeLoader normalizes this mapping-context tag to a string.
+        key = node.value
+    else:
+        key = loader.construct_object(node, deep=True)
+    if not isinstance(key, Hashable):
+        raise ConstructorError(None, None, "found unhashable key", node.start_mark)
+    return key
+
+
+def find_duplicate_mapping_key(node: Node | None, loader: yaml.SafeLoader) -> str | None:
+    """Return the first repeated scalar mapping key in a YAML node tree."""
+    if node is None:
+        return None
+    pending = [node]
+    visited: set[int] = set()
+    while pending:
+        current = pending.pop()
+        if id(current) in visited:
+            continue
+        visited.add(id(current))
+        if isinstance(current, MappingNode):
+            seen: set[object] = set()
+            for key_node, value_node in current.value:
+                if isinstance(key_node, ScalarNode):
+                    key_value = cast("str", key_node.value)
+                    key_identity = construct_scalar_mapping_key(key_node, loader)
+                    if key_identity in seen:
+                        return key_value
+                    seen.add(key_identity)
+                pending.extend((key_node, value_node))
+        elif isinstance(current, SequenceNode):
+            pending.extend(current.value)
+    return None
 
 
 def load_frontmatter(skill_path: Path | str) -> tuple[dict[str, object] | None, str]:
@@ -49,6 +94,13 @@ def read_frontmatter_text(skill_path: Path | str) -> tuple[str | None, str]:
 def parse_frontmatter(frontmatter_text: str) -> tuple[dict[str, object] | None, str]:
     """Parse and validate the raw YAML frontmatter shape."""
     try:
+        loader = yaml.SafeLoader(frontmatter_text)
+        try:
+            duplicate_key = find_duplicate_mapping_key(loader.get_single_node(), loader)
+        finally:
+            loader.dispose()
+        if duplicate_key is not None:
+            return None, f"Duplicate key in frontmatter: {duplicate_key}"
         loaded_frontmatter: Any = yaml.safe_load(frontmatter_text)
     except yaml.YAMLError as exc:
         return None, f"Invalid YAML in frontmatter: {exc}"

--- a/scripts/test_skill_validate.py
+++ b/scripts/test_skill_validate.py
@@ -3,12 +3,12 @@
 
 from typing import TYPE_CHECKING
 
+import pytest
+
 import skill_validate
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    import pytest
 
 
 def write_skill(skill_dir: Path, frontmatter: str, *, include_openai_metadata: bool = True) -> None:
@@ -44,6 +44,127 @@ def test_validate_skill_rejects_missing_skill_file(tmp_path: Path) -> None:
 
     assert not valid
     assert message == "SKILL.md not found"
+
+
+def test_validate_skill_rejects_malformed_closing_delimiter(tmp_path: Path) -> None:
+    """The frontmatter closing delimiter must occupy its complete line."""
+    skill_dir = tmp_path / "example-skill"
+    write_skill(skill_dir, 'name: example-skill\ndescription: "Use for tests."')
+    (skill_dir / "SKILL.md").write_text('---\nname: example-skill\ndescription: "Use for tests."\n---garbage\n', encoding="utf-8")
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert message == "Invalid frontmatter format"
+
+
+def test_validate_skill_rejects_duplicate_frontmatter_key(tmp_path: Path) -> None:
+    """Repeated YAML keys must not be resolved with last-key-wins semantics."""
+    skill_dir = tmp_path / "example-skill"
+    write_skill(skill_dir, 'name: ignored\nname: example-skill\ndescription: "Use for tests."')
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert message == "Duplicate key in frontmatter: name"
+
+
+def test_validate_skill_rejects_equivalent_nested_frontmatter_keys(tmp_path: Path) -> None:
+    """Constructed YAML keys that compare equally must be rejected at any depth."""
+    skill_dir = tmp_path / "example-skill"
+    write_skill(skill_dir, 'name: example-skill\ndescription: "Use for tests."\nmetadata:\n  nested:\n    yes: first\n    true: second')
+
+    valid, message = skill_validate.validate_skill(skill_dir)
+
+    assert not valid
+    assert message == "Duplicate key in frontmatter: true"
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected"),
+    [
+        ("{<<: {owner: inherited}, revision: 1}", {"owner": "inherited", "revision": 1}),
+        ("{owner: explicit, <<: {owner: inherited}}", {"owner": "explicit"}),
+        ("{<<: [{owner: first}, {owner: second, revision: 1}]}", {"owner": "first", "revision": 1}),
+        ('{<<: {owner: inherited}, "<<": literal}', {"owner": "inherited", "<<": "literal"}),
+        ("{=: literal}", {"=": "literal"}),
+    ],
+)
+def test_parse_frontmatter_preserves_mapping_key_semantics(metadata: str, expected: dict[str, object]) -> None:
+    """Merges, explicit overrides, and mapping-context tags retain YAML semantics."""
+    frontmatter, message = skill_validate.parse_frontmatter(f"name: example-skill\ndescription: Use for tests.\nmetadata: {metadata}")
+
+    assert message == ""
+    assert frontmatter is not None
+    assert frontmatter["metadata"] == expected
+
+
+@pytest.mark.parametrize(
+    ("metadata", "duplicate"),
+    [
+        ("{<<: {owner: first, owner: second}}", "owner"),
+        ("{<<: [{owner: first}, {revision: 1, revision: 2}]}", "revision"),
+        ("{<<: {owner: inherited}, owner: first, owner: second}", "owner"),
+        ("{<<: {owner: first}, <<: {revision: 1}}", "<<"),
+        ('{=: first, "=": second}', "="),
+        ("[{owner: first, owner: second}]", "owner"),
+        ("!!pairs [{? {owner: first, owner: second}: value}]", "owner"),
+        ("!!omap [{? {owner: first, owner: second}: value}]", "owner"),
+    ],
+)
+def test_parse_frontmatter_rejects_explicit_duplicates(metadata: str, duplicate: str) -> None:
+    """Merge handling must not hide explicit duplicates in source mappings."""
+    frontmatter, message = skill_validate.parse_frontmatter(f"name: example-skill\ndescription: Use for tests.\nmetadata: {metadata}")
+
+    assert frontmatter is None
+    assert message == f"Duplicate key in frontmatter: {duplicate}"
+
+
+def test_parse_frontmatter_accepts_recursive_aliases() -> None:
+    """The duplicate scan terminates while preserving recursive YAML values."""
+    frontmatter, message = skill_validate.parse_frontmatter("name: example-skill\ndescription: Use for tests.\nmetadata: &metadata {self: *metadata}")
+
+    assert message == ""
+    assert frontmatter is not None
+    metadata = frontmatter["metadata"]
+    assert isinstance(metadata, dict)
+    assert metadata["self"] is metadata
+
+
+@pytest.mark.parametrize("key", ["!!map invalid", "!!seq invalid", "!!set invalid", "[unhashable]"])
+def test_parse_frontmatter_rejects_malformed_keys(key: str) -> None:
+    """Invalid constructed keys return a validation error rather than an exception."""
+    frontmatter, message = skill_validate.parse_frontmatter(f"name: example-skill\ndescription: Use for tests.\nmetadata: {{{key}: value}}")
+
+    assert frontmatter is None
+    assert message.startswith("Invalid YAML in frontmatter:")
+
+
+def test_main_accepts_merged_frontmatter(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Valid merged metadata retains successful CLI output and exit status."""
+    skill_dir = tmp_path / "example-skill"
+    write_skill(skill_dir, "name: example-skill\ndescription: Use for tests.\nmetadata: {<<: {owner: inherited}, owner: explicit}")
+
+    code = skill_validate.main([str(skill_dir)])
+
+    captured = capsys.readouterr()
+    assert code == 0
+    assert captured.out == "Skill is valid!\n"
+    assert captured.err == ""
+
+
+def test_main_reports_malformed_tagged_key(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Malformed tagged keys produce a concise CLI failure without a traceback."""
+    skill_dir = tmp_path / "example-skill"
+    write_skill(skill_dir, "name: example-skill\ndescription: Use for tests.\nmetadata: {!!map invalid: value}")
+
+    code = skill_validate.main([str(skill_dir)])
+
+    captured = capsys.readouterr()
+    assert code == 1
+    assert captured.out == ""
+    assert captured.err.startswith("Invalid YAML in frontmatter:")
+    assert "Traceback" not in captured.err
 
 
 def test_validate_skill_rejects_missing_openai_metadata(tmp_path: Path) -> None:


### PR DESCRIPTION
- Require complete closing delimiters and reject duplicate YAML keys.
- Preserve YAML merges, explicit overrides, and recursive aliases.
- Clarify README and rustdoc navigation across publishing contexts.
- Update the rumdl pin to 0.2.68.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved guidance for reviewing README navigation, published documentation, Rust API links, version selection, and cross-platform compatibility.
  - Added recommendations for validating documentation links across rendering contexts and feature sets.

- **Bug Fixes**
  - Strengthened skill metadata validation for malformed frontmatter, duplicate keys, aliases, merges, and invalid YAML structures.
  - Improved error reporting for invalid metadata during command-line validation.

- **Chores**
  - Updated the pinned Markdown validation tool to version 0.2.68.

- **Tests**
  - Added coverage for frontmatter parsing, duplicate detection, aliases, merges, malformed keys, and command-line validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->