### PR TITLE
fix(skills): preserve review reuse and reconcile readiness

### DIFF
--- a/agents/.agents/skills/cpp-production-review/SKILL.md
+++ b/agents/.agents/skills/cpp-production-review/SKILL.md
@@ -106,6 +106,14 @@ For every finding, provide file and line evidence, the failure scenario, why it 
 
 ## Final Report
 
+In graph synthesis mode, return the dispatched
+[SynthesisPayload](../review-graph/references/schemas/synthesis-payload-v1.schema.json):
+typed `readiness_verdict` (`ready`, `not-ready`, `blocked`) and `verdict_reasons`,
+canonical findings with owner/disposition/source references, predecessor
+coverage, routing closure, validation reconciliation, and cross-surface risks.
+Remaining actionable findings mean `not-ready`; missing required evidence
+means `blocked`. Keep readiness separate from graph completion and validator success.
+
 Lead with unresolved P0/P1 findings. Include:
 
 - release-readiness verdict

--- a/agents/.agents/skills/python-production-review/SKILL.md
+++ b/agents/.agents/skills/python-production-review/SKILL.md
@@ -122,10 +122,12 @@ and current native evidence is reconciled.
 
 In orchestrated mode, synthesize specialist outcomes, remove duplicate findings, identify cross-cutting blockers, and name residual risk. In standalone mode, lead with findings ordered by severity and list focused skills or checklist sections used. Always report validation performed, reused ledger evidence, and meaningful limitations.
 
-In a `review-graph` synthesis node, return table-ready fields for `Findings`,
-`Exact Blockers`, `Validator Results`, `Reused Ledger Evidence`, and
-`Readiness Verdict`. Use the dedicated `Readiness Verdict` field for one of:
-
-- **PASS**: no actionable production-readiness issue remains in scope.
-- **NEEDS IMPROVEMENT**: only non-blocking weaknesses or deferred strengthening remain.
-- **FAIL**: a correctness, security, compatibility, data-loss, or release blocker remains.
+In a `review-graph` synthesis node, use the dispatched
+[SynthesisPayload schema](../review-graph/references/schemas/synthesis-payload-v1.schema.json).
+Return `readiness_verdict`: `ready` when required evidence reconciles and no
+actionable finding remains, `not-ready` when findings remain, or `blocked` when
+required evidence or routing is incomplete. Put exact reasons in
+`verdict_reasons`; preserve finding ownership, dispositions, and source-finding
+references, predecessor coverage, routing closure, validation results, and
+cross-surface risks in their dedicated fields. A completed review and passing
+validators do not imply repository readiness.

--- a/agents/.agents/skills/repository-production-review/SKILL.md
+++ b/agents/.agents/skills/repository-production-review/SKILL.md
@@ -50,18 +50,26 @@ an unresolved applicability handoff. Never infer that omitted work passed.
 
 ## Result Contract
 
-Return:
+Return the dispatched
+[SynthesisPayload](../review-graph/references/schemas/synthesis-payload-v1.schema.json),
+using these dedicated fields:
 
-- `Predecessor Coverage`: every requirement, node/report, and disposition
-- `Routing Closure`: consulted routers, exhaustive-ledger status, exclusions,
+- `predecessor_coverage`: every accepted evidence ID, requirement, and disposition
+- `routing_closure`: exhaustive-ledger status, exclusions,
   reuse, and unresolved handoffs
-- `Canonical Findings`: severity, owner, evidence, duplicates, and disposition
-- `Validation Reconciliation`: each requirement, actual executor platform,
+- `findings`: severity, owner, evidence, disposition, and `source_findings`
+  references retaining every predecessor finding, including disagreements
+- `validation_reconciliation`: each requirement, actual executor platform,
   native or emulated mode, unexecuted cells, and its accepted validator or exact
   reuse evidence
-- `Cross-Surface Risks`: conflicts, shared-file ownership, contradictory native
+- `cross_surface_risks`: conflicts, shared-file ownership, contradictory native
   CI, and residual gaps
-- `Repository Verdict`: `ready`, `not-ready`, or `blocked`, with exact reasons
+- `readiness_verdict`: `ready`, `not-ready`, or `blocked`, with exact reasons in
+  `verdict_reasons`
+
+Use `not-ready` when actionable findings remain, even with successful validators
+and a complete graph proof. Use `blocked` for incomplete required evidence or
+routing. Never encode these required fields only as narrative limitations.
 
 Do not create subagents or recursively invoke `review-graph`.
 Do not request or load complete predecessor artifacts; the proof verifier owns

--- a/agents/.agents/skills/review-graph/SKILL.md
+++ b/agents/.agents/skills/review-graph/SKILL.md
@@ -61,7 +61,7 @@ validation or synthesis.
 ## Execute Review Nodes
 
 Dispatch selected leaves with exact skills and owned paths. Workers stream
-`ReviewPayload` bytes through dispatch-bound review and persistence
+`ReviewPayload` audit bytes or `SynthesisPayload` synthesis bytes through dispatch-bound review and persistence
 commands; the runtime validates before writing, binds approval retries, and
 atomically publishes. They return the same bytes and do not author
 fingerprints, digests, evidence IDs, execution metadata, canonical Markdown,
@@ -126,10 +126,15 @@ runtime-managed `--output-dir` generations. Reconcile accepted handoffs before
 expansion; only genuinely new triggers reroute. After an authorized repair use
 `advance-after-mutation` to record the serialized repair epoch, recapture once,
 move stale nodes to `awaiting-replan`, and materialize the replacement graph.
+For external staging with unchanged
+content, use `resume-after-external-metadata` and its returned continuation;
+preserve both Git captures and the user's index. See the runtime contract for
+partition dependencies, Git-sensitive revalidation, and source provenance.
 Run `finalize-proof` with the signed dispatch set and journal after every
 applicable review and validation requirement has accepted non-stale evidence.
 It derives the mappings, manifest, and `RepositoryReviewProof`; report complete
-only when its verifier returns `complete`.
+only when its verifier returns `complete`. Report repository readiness from
+typed synthesis separately from proof completeness and validation success.
 
 The default user report is compact: findings, changes, validation, blockers,
 selected skills, proof status, final repository state, and artifact-manifest

--- a/agents/.agents/skills/review-graph/references/planning-contract.md
+++ b/agents/.agents/skills/review-graph/references/planning-contract.md
@@ -102,6 +102,14 @@ scheduling isolated execution.
 
 ## Worker Budget And Epochs
 
+Coverage partitions do not remove specialist requirements. A delta audit retains
+the original owned surface in the plan; runtime-bound `audit_delta_reviews`
+combines exact reused unit coverage with fresh inspection of affected paths.
+See [runtime-contract.md](runtime-contract.md#mutation-handoffs-and-proof) for
+partition dependencies, findings provenance, and external staging continuation.
+External metadata transitions preserve original source identity and actual
+observed captures separately, without creating an agent repair epoch.
+
 Adaptive grouped execution does not require a lifetime worker budget. Schedule
 the complete dependency graph and use workers opportunistically without
 changing selected coverage.

--- a/agents/.agents/skills/review-graph/references/runtime-contract.md
+++ b/agents/.agents/skills/review-graph/references/runtime-contract.md
@@ -9,6 +9,7 @@ Public contracts:
 
 - `schemas/planning-input-v1.schema.json`
 - `schemas/review-payload-v1.schema.json`
+- `schemas/synthesis-payload-v1.schema.json`
 - `schemas/validation-payload-v2.schema.json`
 - `schemas/runtime-operation-inputs-v1.schema.json`
 - `runtime-operation-examples-v1.json`
@@ -101,7 +102,7 @@ instructions. Exclude coordinator conclusions, routing, and journals. Shared
 observations do not replace independent judgment. Reviews attest to commands;
 validator-command duplicates need explicit authorization and reusable evidence.
 
-Return only `ReviewPayload`. Follow `worker_prompt`'s publication example:
+Return `ReviewPayload` for audits or `SynthesisPayload` for synthesis. Follow `worker_prompt`'s publication example:
 serialize once, review over stdin, then persist identical bytes with
 `--approval-identity`. Approval binds the entire contract and payload.
 
@@ -119,6 +120,14 @@ A completed audit may omit an owned path only with exactly one path-specific
 persistence and compilation both enforce this.
 Bundle-only synthesis allows empty `files_inspected`, but requires predecessor
 evidence. Never invent source reads.
+Its dedicated schema requires `readiness_verdict` (`ready`, `not-ready`, or
+`blocked`), `verdict_reasons`, `predecessor_coverage`, `routing_closure`,
+`validation_reconciliation`, and `cross_surface_risks`. Each canonical finding
+has an `owner`, `disposition` (`fixed`, `remaining`, `accepted-risk`, `blocked`),
+and `source_findings` references to supplied evidence/finding IDs. These are
+references to existing identities, not worker-created IDs. `compile-node`
+reconciles these fields with the accepted predecessor bundle. Remaining
+findings or failed/unexecuted validation cannot produce `ready`.
 The compiler rejects validator-owned
 commands and non-catalog handoffs. One schema mismatch permits one retry using
 field diagnostics; a second mismatch blocks the node. For authorized fixes,
@@ -158,32 +167,11 @@ exact reuse, requirement/validator mappings, and handoff reconciliation in
 
 ## Mutation, Handoffs, And Proof
 
-Accepted late validation requirements block synthesis/proof until exactly planned
-or explicitly user-excluded. Run
-`reconcile-validation-requirements --input <request.json> --journal <journal>
---dispatches <dispatches.json> --current-capture <capture.json> --output <result.json>`.
-Supply `plan` and `source_state` to inspect discoveries. Expand with
-`validation_requirements` (planning-schema objects) and `artifact_store`, or
-`user_exclusions` bound to returned origin, requirement ID/digest, and reason.
-Follow returned lifecycle/journal/dispatch paths. Source state and accepted
-audits/CI remain; synthesis inputs refresh. Wait for active workers before expansion.
-Details: [planning-contract.md](planning-contract.md#late-validation-expansion).
-
-Run `reconcile-handoffs` before expansion. Selected, exactly reused, or user-excluded
-catalog entries resolve handoffs; only `new_routing_triggers` expand routing.
-Final proof classification uses typed catalog mappings reparsed from accepted
-evidence, never caller-provided resolved IDs.
-
-After authorized repairs, run `advance-after-mutation` with the immediately
-preceding `previous_capture`, `new_capture`, and their exact `changed_paths`
-content delta. Invalidation follows owners and downstream dependencies. Supply
-accepted `sources` for verified unchanged-input audit reuse; validators,
-independent reviews, syntheses, and unproven audits rerun. Follow returned
-`lifecycle_input_path`, `dispatches_path`, `journal_path`, and `capture_path`;
-old artifacts remain unchanged. `preserved_evidence` contains only proven reuse.
-Per-node `reuse_decisions` explain disposition and reason code, distinguishing
-`coverage-limitations` from `unclassified-limitations`. Untyped caveats prevent
-reuse, never inferred informational exemptions.
+For repairs, external staging, or late validation/routing changes, read
+[state-transitions.md](state-transitions.md). It defines `advance-after-mutation`,
+`resume-after-external-metadata`, coverage partitions, and requirement
+reconciliation. Follow runtime-returned continuation paths; preserve original
+artifacts and both captures.
 
 Persist all capture, plan, payload, compiled evidence, journal, synthesis,
 invalidation, manifest, and proof artifacts outside the reviewed repository.
@@ -194,3 +182,6 @@ Blocked events without evidence produce an incomplete proof with their reason,
 not nonexistent-artifact reads. Report `repository_validation_status`
 separately from `graph_proof_status`; structural independent-evidence
 acceptance does not imply semantic agreement or adjudicated recall.
+Report `repository_readiness` separately as well: graph proof may be complete
+and validation passed while canonical findings still make the repository
+`not-ready`.

--- a/agents/.agents/skills/review-graph/references/runtime-operation-examples-v1.json
+++ b/agents/.agents/skills/review-graph/references/runtime-operation-examples-v1.json
@@ -1,4 +1,17 @@
 {
+  "resume-after-external-metadata": {
+    "artifact_store": "/tmp/review-resume",
+    "dispatches_path": "/tmp/review/dispatches.json",
+    "journal_path": "/tmp/review/execution.jsonl",
+    "plan": {},
+    "source_state": [
+      "scope",
+      "worktree",
+      "repository"
+    ],
+    "previous_capture": {},
+    "new_capture": {}
+  },
   "advance-after-mutation": {
     "artifact_store": "/tmp/review-proof",
     "authorization_after": "review-and-fix",

--- a/agents/.agents/skills/review-graph/references/schemas/review-payload-v1.schema.json
+++ b/agents/.agents/skills/review-graph/references/schemas/review-payload-v1.schema.json
@@ -3,6 +3,54 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "additionalProperties": false,
   "properties": {
+    "coverage_units": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "unit_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "owned_paths": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            },
+            "minItems": 1
+          },
+          "dependency_paths": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "dependency_uncertainty": {
+            "type": "string"
+          },
+          "finding_indices": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "minimum": 1
+            }
+          }
+        },
+        "required": [
+          "unit_id",
+          "owned_paths",
+          "dependency_paths",
+          "dependency_uncertainty",
+          "finding_indices"
+        ]
+      }
+    },
+    "git_sensitive": {
+      "type": "boolean"
+    },
     "changes": {
       "items": {
         "additionalProperties": false,

--- a/agents/.agents/skills/review-graph/references/schemas/runtime-operation-inputs-v1.schema.json
+++ b/agents/.agents/skills/review-graph/references/schemas/runtime-operation-inputs-v1.schema.json
@@ -3,9 +3,60 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Review Graph Runtime Operation Inputs v1",
   "$defs": {
+    "resume-after-external-metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifact_store",
+        "dispatches_path",
+        "journal_path",
+        "plan",
+        "source_state",
+        "previous_capture",
+        "new_capture"
+      ],
+      "properties": {
+        "artifact_store": {
+          "type": "string",
+          "minLength": 1
+        },
+        "dispatches_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "journal_path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "plan": {
+          "type": "object"
+        },
+        "source_state": {
+          "$ref": "#/$defs/sourceState"
+        },
+        "previous_capture": {
+          "type": "object"
+        },
+        "new_capture": {
+          "type": "object"
+        },
+        "external_metadata_transitions": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
     "advance-after-mutation": {
       "additionalProperties": false,
       "properties": {
+        "external_metadata_transitions": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
         "artifact_store": {"minLength": 1, "type": "string"},
         "authorization_after": {"const": "review-and-fix"},
         "authorization_before": {"enum": ["review-only", "review-and-fix"]},
@@ -49,6 +100,12 @@
     "compile-node": {
       "additionalProperties": false,
       "properties": {
+        "external_metadata_transitions": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
         "current_source_state": {"$ref": "#/$defs/sourceState"},
         "plan": {"type": "object"},
         "source_state": {"$ref": "#/$defs/sourceState"}
@@ -92,6 +149,12 @@
     "finalize-proof": {
       "additionalProperties": false,
       "properties": {
+        "external_metadata_transitions": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
         "current_source_state": {"$ref": "#/$defs/sourceState"},
         "manifest_id": {"minLength": 1, "type": "string"},
         "plan": {"type": "object"},
@@ -107,6 +170,12 @@
     "journal-append": {
       "additionalProperties": false,
       "properties": {
+        "external_metadata_transitions": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
         "current_source_state": {"$ref": "#/$defs/sourceState"},
         "plan": {"type": "object"},
         "source_state": {"$ref": "#/$defs/sourceState"}
@@ -134,6 +203,12 @@
     "next-ready": {
       "additionalProperties": false,
       "properties": {
+        "external_metadata_transitions": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
         "current_source_state": {"$ref": "#/$defs/sourceState"},
         "plan": {"type": "object"},
         "source_state": {"$ref": "#/$defs/sourceState"}
@@ -147,6 +222,7 @@
     "stdinWorkerPayloadContract": {
       "additionalProperties": false,
       "properties": {
+        "coverage_reuse": {"type": "object"},
         "mode": {"enum": ["audit", "fix", "independent-review", "revalidation", "synthesis", "validation"]},
         "node_id": {"minLength": 1, "type": "string"},
         "owned_paths": {"$ref": "#/$defs/stringArray"},
@@ -160,6 +236,7 @@
     "legacyWorkerPayloadContract": {
       "additionalProperties": false,
       "properties": {
+        "coverage_reuse": {"type": "object"},
         "candidate_path": {"minLength": 1, "type": "string"},
         "mode": {"enum": ["audit", "fix", "independent-review", "revalidation", "synthesis", "validation"]},
         "node_id": {"minLength": 1, "type": "string"},
@@ -223,6 +300,12 @@
     "snapshot-workspace": {
       "additionalProperties": false,
       "properties": {
+        "external_metadata_transitions": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
         "current_source_state": {"$ref": "#/$defs/sourceState"},
         "plan": {"type": "object"},
         "source_state": {"$ref": "#/$defs/sourceState"}
@@ -253,6 +336,12 @@
     "synthesis-bundle": {
       "additionalProperties": false,
       "properties": {
+        "external_metadata_transitions": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
         "plan": {"type": "object"},
         "source_state": {"$ref": "#/$defs/sourceState"},
         "sources": {"items": {"$ref": "#/$defs/sourceRecord"}, "type": "array"}

--- a/agents/.agents/skills/review-graph/references/schemas/synthesis-payload-v1.schema.json
+++ b/agents/.agents/skills/review-graph/references/schemas/synthesis-payload-v1.schema.json
@@ -1,0 +1,439 @@
+{
+  "$id": "https://openai.com/codex/review-graph/synthesis-payload-v1.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "changes": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "contract_preserved": {
+            "type": "string"
+          },
+          "files": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "finding_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "what_changed": {
+            "type": "string"
+          },
+          "why": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "finding_ids",
+          "files",
+          "what_changed",
+          "why",
+          "contract_preserved"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "command_policy_attested": {
+      "const": true
+    },
+    "commands_executed": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "files_inspected": {
+      "description": "Paths actually inspected by the worker (dispatch-owned for audits); these are read provenance, not artifact write targets.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "findings": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "evidence": {
+            "type": "string"
+          },
+          "location": {
+            "type": "string"
+          },
+          "remediation": {
+            "type": "string"
+          },
+          "severity": {
+            "enum": [
+              "P0",
+              "P1",
+              "P2",
+              "P3"
+            ]
+          },
+          "summary": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string",
+            "minLength": 1
+          },
+          "disposition": {
+            "enum": [
+              "fixed",
+              "remaining",
+              "accepted-risk",
+              "blocked"
+            ]
+          },
+          "source_findings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "evidence_id": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "finding_id": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": [
+                "evidence_id",
+                "finding_id"
+              ]
+            }
+          }
+        },
+        "required": [
+          "severity",
+          "location",
+          "summary",
+          "evidence",
+          "remediation",
+          "owner",
+          "disposition",
+          "source_findings"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "handoffs": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "catalog_id": {
+            "type": "string"
+          },
+          "observed_trigger": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "scope": {
+            "items": {
+              "type": "string"
+            },
+            "minItems": 1,
+            "type": "array"
+          }
+        },
+        "required": [
+          "catalog_id",
+          "observed_trigger",
+          "reason",
+          "scope"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "limitations": {
+      "description": "Narrative caveats. Path mentions here do not declare omitted audit scope or artifact write targets.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "scope_limitations": {
+      "description": "For audits only: exactly the omitted dispatch-owned paths and one reason per path. Never use for nearby context paths.",
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "path": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "reason": {
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "reason"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "nearby_contract_owners": {
+      "description": "Inspected read-only dependency or context provenance. Paths may be outside dispatch ownership and are neither omitted audit scope nor artifact write targets.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "status": {
+      "enum": [
+        "completed",
+        "no-findings",
+        "blocked"
+      ]
+    },
+    "validation_requirements": {
+      "items": {
+        "oneOf": [
+          {
+            "additionalProperties": false,
+            "properties": {
+              "commands": {
+                "items": {
+                  "type": "string"
+                },
+                "minItems": 1,
+                "type": "array"
+              },
+              "dependency_policy": {
+                "enum": [
+                  "stop-on-failure",
+                  "continue-independent"
+                ]
+              },
+              "environment": {
+                "type": "string"
+              },
+              "expected_evidence": {
+                "type": "string"
+              },
+              "owner": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "requirement_id": {
+                "type": "string"
+              },
+              "working_directory": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "requirement_id",
+              "owner",
+              "reason",
+              "commands",
+              "working_directory",
+              "environment",
+              "expected_evidence",
+              "dependency_policy"
+            ],
+            "type": "object"
+          },
+          {
+            "additionalProperties": false,
+            "properties": {
+              "expected_evidence": {
+                "type": "string"
+              },
+              "owner": {
+                "type": "string"
+              },
+              "planned_validation_digest": {
+                "pattern": "^sha256:[0-9a-f]{64}$",
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "requirement_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "requirement_id",
+              "planned_validation_digest",
+              "owner",
+              "reason",
+              "expected_evidence"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "type": "array"
+    },
+    "readiness_verdict": {
+      "enum": [
+        "ready",
+        "not-ready",
+        "blocked"
+      ]
+    },
+    "verdict_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      },
+      "minItems": 1
+    },
+    "predecessor_coverage": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "evidence_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "requirement_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "disposition": {
+            "enum": [
+              "accepted",
+              "reused",
+              "blocked"
+            ]
+          }
+        },
+        "required": [
+          "evidence_id",
+          "requirement_ids",
+          "disposition"
+        ]
+      }
+    },
+    "routing_closure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "complete": {
+          "type": "boolean"
+        },
+        "unresolved_handoff_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "user_excluded_catalog_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "required": [
+        "complete",
+        "unresolved_handoff_ids",
+        "user_excluded_catalog_ids"
+      ]
+    },
+    "validation_reconciliation": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "evidence_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "requirement_ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "result": {
+            "enum": [
+              "passed",
+              "failed",
+              "blocked",
+              "reused",
+              "not-applicable"
+            ]
+          },
+          "platform": {
+            "type": "string",
+            "minLength": 1
+          },
+          "execution_mode": {
+            "enum": [
+              "native",
+              "emulated",
+              "unexecuted"
+            ]
+          }
+        },
+        "required": [
+          "evidence_id",
+          "requirement_ids",
+          "result",
+          "platform",
+          "execution_mode"
+        ]
+      }
+    },
+    "cross_surface_risks": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "required": [
+    "status",
+    "files_inspected",
+    "nearby_contract_owners",
+    "findings",
+    "validation_requirements",
+    "handoffs",
+    "changes",
+    "limitations",
+    "scope_limitations",
+    "commands_executed",
+    "command_policy_attested",
+    "readiness_verdict",
+    "verdict_reasons",
+    "predecessor_coverage",
+    "routing_closure",
+    "validation_reconciliation",
+    "cross_surface_risks"
+  ],
+  "title": "Review Graph SynthesisPayload v1",
+  "type": "object"
+}

--- a/agents/.agents/skills/review-graph/references/state-transitions.md
+++ b/agents/.agents/skills/review-graph/references/state-transitions.md
@@ -1,0 +1,74 @@
+# Review State Transitions
+
+Load for content repairs, external staging, or late validation/routing changes.
+
+Accepted late validation requirements block synthesis/proof until exactly planned
+or explicitly user-excluded. Run
+`reconcile-validation-requirements --input <request.json> --journal <journal>
+--dispatches <dispatches.json> --current-capture <capture.json> --output <result.json>`.
+Supply `plan` and `source_state` to inspect discoveries. Expand with
+`validation_requirements` (planning-schema objects) and `artifact_store`, or
+`user_exclusions` bound to returned origin, requirement ID/digest, and reason.
+Follow returned lifecycle/journal/dispatch paths. Source state and accepted
+audits/CI remain; synthesis inputs refresh. Wait for active workers before expansion.
+Details: [planning-contract.md](planning-contract.md#late-validation-expansion).
+
+Run `reconcile-handoffs` before expansion. Selected, exactly reused, or user-excluded
+catalog entries resolve handoffs; only `new_routing_triggers` expand routing.
+Final proof classification uses typed catalog mappings reparsed from accepted
+evidence, never caller-provided resolved IDs.
+
+After authorized repairs, run `advance-after-mutation` with the immediately
+preceding `previous_capture`, `new_capture`, and their exact `changed_paths`
+content delta. Invalidation follows owners and downstream dependencies. Supply
+accepted `sources` for verified unchanged-input audit reuse; validators,
+independent reviews, syntheses, and unproven audits rerun. Follow returned
+`lifecycle_input_path`, `dispatches_path`, `journal_path`, and `capture_path`;
+old artifacts remain unchanged. `preserved_evidence` contains only proven reuse.
+Per-node `reuse_decisions` explain disposition and reason code, distinguishing
+`coverage-limitations` from `unclassified-limitations`. Untyped caveats prevent
+reuse, never inferred informational exemptions.
+
+For broad audits, optionally partition `owned_paths` into `coverage_units`.
+Each unit declares a local `unit_id`, `owned_paths`, concrete `dependency_paths`,
+`dependency_uncertainty` (empty only when dependencies are understood), and
+one-based `finding_indices`. Partition every owned path and finding exactly
+once; account for every nearby dependency. Shared manifests belong in each
+unit's dependencies when their contract affects its judgments. Do not infer
+independence just because implementation bytes are unchanged.
+
+`advance-after-mutation` reports `coverage_reuse_decisions` for each partition.
+Its plan-bound `coverage_reuse` dispatch retains original artifacts, captures,
+findings, and instruction identities. Inspect only units marked `recheck`;
+`files_inspected` records those actual reads. The compiler combines this with
+proved reused coverage, carries original finding provenance forward, and keeps
+historical rechecked findings visible. Reconcile original validation needs and
+handoffs in the new payload. Validators still run for the new source. Omitted
+partitions, uncertain dependencies, changed instructions, or changed routing
+require fresh inspection. Legacy audits without partitions retain whole-audit
+reuse behavior; a delta audit is not itself a fresh partition origin.
+
+Synthesis bundles expose `plan_context.validation_environments` by validator
+node ID. Copy its executor `platform` into validation reconciliation; use its
+digest-bound `environment` and `features`, together with execution evidence and
+limitations, to distinguish native runs, emulation, and unexecuted target cells.
+
+For external staging with unchanged reviewed content, use
+`resume-after-external-metadata --input <request.json> --output <result.json>`.
+Supply the existing `plan`, `source_state`, `dispatches_path`, `journal_path`,
+immediately preceding `previous_capture`, fresh `new_capture`, and a new
+external `artifact_store`. Include existing `external_metadata_transitions`
+from the lifecycle input when resuming again. The runtime proves baseline or
+worktree scope, complete path identities (including types/modes), applicable
+instructions, HEAD, branch, and boundaries unchanged. Staged/branch targets
+require replanning. No Git command changes the index and no repair epoch is
+consumed.
+
+Follow the returned continuation paths. The review's original `source_state`
+remains its identity; actual before/after fingerprints and both snapshots are
+retained in `external_metadata_transitions`. In-flight content audits can
+compile across this verified transition. Mark `git_sensitive: true` when an
+audit judgment depends on the index or other Git metadata; command-dependent
+audits are also conservatively rechecked. Validators and synthesis restart on
+the new metadata state. Scheduling, workspace snapshots, and final proof accept
+only the latest verified capture. Never rewrite fingerprints or undo staging.

--- a/agents/.agents/skills/review-graph/scripts/review_graph_coverage.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_coverage.py
@@ -1,0 +1,72 @@
+"""Explicit audit coverage partitions and content-bound delta decisions."""
+
+from typing import Any, cast
+
+from review_graph_reuse import AuditInputIdentity, AuditReuseTransition, ReviewSourceSnapshot, verify_reuse_inputs
+
+
+def validate_coverage_units(payload: dict[str, Any], owned_paths: tuple[str, ...]) -> None:
+    """Require a complete partition with explicit dependencies and finding ownership."""
+    units = payload.get("coverage_units", [])
+    if not units:
+        return
+    paths = [path for unit in units for path in unit["owned_paths"]]
+    identities = [unit["unit_id"] for unit in units]
+    findings = [ordinal for unit in units for ordinal in unit["finding_indices"]]
+    dependencies = {path for unit in units for path in unit["dependency_paths"]}
+    if len(identities) != len(set(identities)) or len(paths) != len(set(paths)) or set(paths) != set(owned_paths):
+        msg = "coverage units must uniquely partition every owned path"
+        raise ValueError(msg)
+    if sorted(findings) != list(range(1, len(payload["findings"]) + 1)):
+        msg = "coverage units must assign every finding exactly once using one-based indices"
+        raise ValueError(msg)
+    if not set(payload["nearby_contract_owners"]) <= dependencies:
+        msg = "coverage units must account for every inspected nearby dependency"
+        raise ValueError(msg)
+
+
+def coverage_decisions(
+    payload: dict[str, Any], origin: ReviewSourceSnapshot, target: ReviewSourceSnapshot, inputs: AuditInputIdentity, transition: AuditReuseTransition
+) -> list[dict[str, Any]]:
+    """Prove each partition separately; uncertainty always requires fresh inspection."""
+    validate_coverage_units(payload, inputs.owned_paths)
+    decisions = []
+    for unit in payload.get("coverage_units", []):
+        reason = unit["dependency_uncertainty"]
+        if not reason:
+            unit_inputs = AuditInputIdentity(
+                tuple(unit["owned_paths"]), tuple(unit["owned_paths"]), tuple(unit["dependency_paths"]), inputs.instruction_digests
+            )
+            try:
+                verify_reuse_inputs(origin, target, unit_inputs, transition)
+            except ValueError as error:
+                reason = str(error)
+        decisions.append(
+            {
+                **unit,
+                "disposition": "recheck" if reason else "reused",
+                "reason": reason or "Exact content, modes, dependencies, and instructions are unchanged.",
+            }
+        )
+    return decisions
+
+
+def reused_paths(context: dict[str, Any] | None) -> tuple[str, ...]:
+    """Return only paths proved reusable by a compiler-bound delta context."""
+    return tuple(cast("str", path) for unit in (context or {}).get("units", []) if unit["disposition"] == "reused" for path in unit["owned_paths"])
+
+
+def combined_findings(payload: dict[str, Any], context: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Keep reused judgments and original provenance alongside fresh findings."""
+    if context is None:
+        return payload["findings"]
+    indices = {ordinal for unit in context["units"] if unit["disposition"] == "reused" for ordinal in unit["finding_indices"]}
+    preserved = [
+        {
+            **{key: value for key, value in finding.items() if key != "finding_id"},
+            "source_findings": [{"evidence_id": context["evidence_id"], "finding_id": finding["finding_id"]}],
+        }
+        for ordinal, finding in enumerate(context["original_findings"], start=1)
+        if ordinal in indices
+    ]
+    return [*preserved, *payload["findings"]]

--- a/agents/.agents/skills/review-graph/scripts/review_graph_plan.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_plan.py
@@ -16,7 +16,7 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any
 
 from capture_scope import _scope_data
-from review_graph_reuse import AuditInputIdentity, AuditReuseTransition, ReviewSourceSnapshot, verify_reuse_inputs
+from review_graph_reuse import AuditInputIdentity, AuditReuseTransition, ExternalMetadataTransition, ReviewSourceSnapshot, metadata_states, verify_reuse_inputs
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
@@ -525,6 +525,7 @@ class GraphPlan:
     audit_reuse_transitions: tuple[AuditReuseTransition, ...] = ()
     reuse_source_snapshots: tuple[ReviewSourceSnapshot, ...] = ()
     validation_exclusions: tuple[ValidationExclusion, ...] = ()
+    audit_delta_reviews: tuple[dict[str, Any], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -534,6 +535,11 @@ class FingerprintEvidence:
     expected: tuple[str, str, str]
     before: tuple[str, str, str]
     after: tuple[str, str, str]
+    metadata_transitions: tuple[ExternalMetadataTransition, ...] = ()
+
+    def matches(self, observed: tuple[str, str, str]) -> bool:
+        """Match an observed capture through an explicit content-equivalence proof."""
+        return observed in metadata_states(self.expected, self.metadata_transitions)
 
 
 @dataclass(frozen=True)
@@ -558,6 +564,7 @@ class ReviewEvidenceExpectation:
     planned_paths: tuple[str, ...] = ()
     planned_path_line_bounds: tuple[tuple[str, int], ...] = ()
     audit_input_identity: AuditInputIdentity | None = None
+    coverage_reuse: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -2311,6 +2318,8 @@ def _identifier_tuple_blockers(values: Sequence[str], *, label: str) -> tuple[st
 def graph_plan_digest(plan: GraphPlan) -> str:
     """Hash a plan without empty optional fields absent from legacy identities."""
     document = asdict(plan)
+    if not plan.audit_delta_reviews:
+        document.pop("audit_delta_reviews")
     if not plan.validation_exclusions:
         document.pop("validation_exclusions")
     if not plan.audit_reuse_transitions:
@@ -2327,6 +2336,10 @@ def graph_plan_digest_matches(plan: GraphPlan, digest: str) -> bool:
     legacy = asdict(plan)
     if not plan.validation_exclusions:
         legacy.pop("validation_exclusions")
+    if digest == _sha256_json(legacy):
+        return True
+    if not plan.audit_delta_reviews:
+        legacy.pop("audit_delta_reviews")
     return digest == _sha256_json(legacy)
 
 
@@ -2722,6 +2735,9 @@ def _fix_change_blockers(state_verification: str, changes: str, expectation: Rev
 
 def _native_state_verification_blockers(body: str, fingerprints: FingerprintEvidence, *, status: str, changed_as_reported: bool = False) -> tuple[str, ...]:
     blockers: list[str] = []
+    if fingerprints.metadata_transitions:
+        transitions = json.dumps([asdict(item) for item in fingerprints.metadata_transitions], sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        blockers.extend(_native_values_blockers(body, section="State Verification", label="External metadata transitions", expected=(transitions,)))
     for ordinal, label in enumerate(("Observed scope fingerprint", "Observed worktree fingerprint", "Observed repository state fingerprint")):
         blockers.extend(
             _native_values_blockers(
@@ -2772,6 +2788,9 @@ def _ordinary_review_native_blockers(  # noqa: C901, PLR0912
         )
     )
     scope = sections["## Scope Inspected"]
+    if expectation.coverage_reuse is not None:
+        serialized_reuse = json.dumps(expectation.coverage_reuse, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+        blockers.extend(_native_values_blockers(scope, section="Scope Inspected", label="Coverage reuse", expected=(serialized_reuse,)))
     if expectation.audit_input_identity is not None:
         serialized_inputs = json.dumps(asdict(expectation.audit_input_identity), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
         blockers.extend(_native_values_blockers(scope, section="Scope Inspected", label="Audit input identity", expected=(serialized_inputs,)))
@@ -2856,6 +2875,11 @@ def _independent_review_native_blockers(  # noqa: C901, PLR0912, PLR0915
         )
     )
     envelope = sections["## Review Graph Envelope"]
+    if evidence.fingerprints.metadata_transitions:
+        transitions = json.dumps(
+            [asdict(item) for item in evidence.fingerprints.metadata_transitions], sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        )
+        blockers.extend(_native_values_blockers(envelope, section="Review Graph Envelope", label="External metadata transitions", expected=(transitions,)))
     blockers.extend(_native_nonempty_section_blockers(envelope, section="Review Graph Envelope"))
     for label, expected in (
         ("Node ID", evidence.node_id),
@@ -3690,9 +3714,13 @@ def assess_review_evidence(expectation: ReviewEvidenceExpectation, evidence: Rev
     satisfies = evidence.status in {"completed", "no-findings"}
     if satisfies:
         expected_after = expectation.expected_after_state or expectation.source_state
-        if evidence.fingerprints.before != expectation.source_state:
+        if not evidence.fingerprints.matches(evidence.fingerprints.before):
             blockers.append("review evidence before fingerprints do not match the captured source state")
-        if evidence.fingerprints.after != expected_after:
+        if not (
+            evidence.fingerprints.matches(evidence.fingerprints.after)
+            if expected_after == expectation.source_state
+            else evidence.fingerprints.after == expected_after
+        ):
             blockers.append("review evidence after fingerprints do not match the expected source state")
         if evidence.git_mutated is not False:
             blockers.append("accepted review evidence mutated Git state")
@@ -3772,7 +3800,7 @@ def assess_validation_evidence(  # noqa: C901, PLR0912, PLR0915
 
     state_checked_status = evidence.status in {"passed", "failed", "reused", "not-applicable"}
     if state_checked_status:
-        if evidence.fingerprints.before != expectation.source_state or evidence.fingerprints.after != expectation.source_state:
+        if not evidence.fingerprints.matches(evidence.fingerprints.before) or not evidence.fingerprints.matches(evidence.fingerprints.after):
             blockers.append("validation evidence did not preserve the captured source state")
         if evidence.source_mutated is not False or evidence.git_mutated is not False:
             blockers.append("validation evidence mutated source or Git state")

--- a/agents/.agents/skills/review-graph/scripts/review_graph_reuse.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_reuse.py
@@ -110,6 +110,51 @@ class AuditInputIdentity:
 
 
 @dataclass(frozen=True)
+class ExternalMetadataTransition:
+    """Observed external staging, retaining both complete captures unchanged."""
+
+    before: ReviewSourceSnapshot
+    after: ReviewSourceSnapshot
+
+    def verify(self) -> None:
+        """Permit only index changes with identical worktree, scope, and Git base."""
+        self.before.verify()
+        self.after.verify()
+        if self.before.capture_mode not in {"baseline", "worktree"}:
+            msg = "external metadata resume requires baseline or worktree scope; staged and branch targets require replanning"
+            raise ValueError(msg)
+        before, after = asdict(self.before), asdict(self.after)
+        for field in ("index_fingerprint", "repository_state_fingerprint"):
+            before.pop(field)
+            after.pop(field)
+        if before != after or self.before.index_fingerprint == self.after.index_fingerprint:
+            msg = "external metadata transition must change only the index, preserving all content, modes, scope, instructions, HEAD, and branch"
+            raise ValueError(msg)
+
+
+def metadata_transition(raw: dict[str, Any]) -> ExternalMetadataTransition:
+    """Parse and verify an externally observed metadata transition."""
+    if not isinstance(raw, dict) or any(not isinstance(raw.get(field), dict) for field in ("before", "after")):
+        msg = "external metadata transition requires before and after snapshot objects"
+        raise ValueError(msg)
+    result = ExternalMetadataTransition(source_snapshot(raw["before"]), source_snapshot(raw["after"]))
+    result.verify()
+    return result
+
+
+def metadata_states(origin: tuple[str, str, str], transitions: tuple[ExternalMetadataTransition, ...]) -> tuple[tuple[str, str, str], ...]:
+    """Follow a verified chain without relabeling any historical source triple."""
+    states = [origin]
+    for transition in transitions:
+        transition.verify()
+        if transition.before.source_state != states[-1]:
+            msg = "external metadata transitions do not form a chain from the reviewed source"
+            raise ValueError(msg)
+        states.append(transition.after.source_state)
+    return tuple(states)
+
+
+@dataclass(frozen=True)
 class AuditReuseTransition:
     """A non-executable claim retaining the original artifact and source state."""
 
@@ -120,13 +165,16 @@ class AuditReuseTransition:
     artifact_path: str
     metadata_path: str
     instruction_digests: tuple[tuple[str, str], ...]
+    metadata_transitions: tuple[ExternalMetadataTransition, ...] = ()
 
 
 def verify_reuse_inputs(origin: ReviewSourceSnapshot, target: ReviewSourceSnapshot, inputs: AuditInputIdentity, transition: AuditReuseTransition) -> None:
     """Prove unchanged review inputs across two independently bound captures."""
     origin.verify()
     target.verify()
-    if origin.source_state != transition.source_state or target.source_state != transition.target_state or origin.boundary != target.boundary:
+    metadata_states(origin.source_state, transition.metadata_transitions)
+    boundary = transition.metadata_transitions[-1].after.boundary if transition.metadata_transitions else origin.boundary
+    if origin.source_state != transition.source_state or target.source_state != transition.target_state or boundary != target.boundary:
         msg = "audit reuse changes source identity, capture boundary, or Git state"
         raise ValueError(msg)
     if not inputs.owned_paths or set(inputs.inspected_paths) != set(inputs.owned_paths):

--- a/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_runtime.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, cast
 
 from review_graph_bootstrap import bootstrap_document
+from review_graph_coverage import combined_findings, coverage_decisions, reused_paths, validate_coverage_units
 from review_graph_plan import (
     _COMPACT_ROUTING_OVERRIDE_FIELDS,
     DEFAULT_ROUTING_CATALOG,
@@ -83,8 +84,18 @@ from review_graph_plan import (
     validation_evidence_expectation,
     validation_requirements_from_document,
 )
-from review_graph_reuse import SNAPSHOT_FORMAT, AuditInputIdentity, AuditReuseTransition, source_snapshot, verify_reuse_inputs
+from review_graph_reuse import (
+    SNAPSHOT_FORMAT,
+    AuditInputIdentity,
+    AuditReuseTransition,
+    ExternalMetadataTransition,
+    metadata_states,
+    metadata_transition,
+    source_snapshot,
+    verify_reuse_inputs,
+)
 from review_graph_schema import SchemaValidationError, require_schema, require_schema_definition
+from review_graph_synthesis import synthesis_fields, validate_synthesis
 
 _READ_ONLY_MODES = frozenset({"audit", "revalidation", "synthesis"})
 _REVIEW_MODES = _READ_ONLY_MODES | {"fix"}
@@ -94,6 +105,7 @@ _JOURNAL_STATUSES = frozenset({"accepted", "awaiting-replan", "blocked", "in-fli
 _SCHEMA_ROOT = Path(__file__).resolve().parents[1] / "references" / "schemas"
 _PLANNING_INPUT_SCHEMA = _SCHEMA_ROOT / "planning-input-v1.schema.json"
 _REVIEW_PAYLOAD_SCHEMA = _SCHEMA_ROOT / "review-payload-v1.schema.json"
+_SYNTHESIS_PAYLOAD_SCHEMA = _SCHEMA_ROOT / "synthesis-payload-v1.schema.json"
 _VALIDATION_PAYLOAD_SCHEMA = _SCHEMA_ROOT / "validation-payload-v2.schema.json"
 _RUNTIME_OPERATION_INPUT_SCHEMA = _SCHEMA_ROOT / "runtime-operation-inputs-v1.schema.json"
 _RUNTIME_OPERATION_EXAMPLES = Path(__file__).resolve().parents[1] / "references" / "runtime-operation-examples-v1.json"
@@ -486,6 +498,11 @@ def _state_verification(dispatch: dict[str, Any], evidence: ReviewEvidence, chan
             f"  - Result: {after_result}",
             f"- Changed repository paths: {', '.join(changed_paths) or 'none'}",
             f"- HEAD, branch, or index mutated: {'yes' if evidence.git_mutated else 'no'}",
+            *(
+                (f"- External metadata transitions: {_canonical_json([asdict(item) for item in evidence.fingerprints.metadata_transitions])}",)
+                if evidence.fingerprints.metadata_transitions
+                else ()
+            ),
         )
     )
 
@@ -610,18 +627,23 @@ def _predecessor_body(dispatch: dict[str, Any], evidence: ReviewEvidence) -> str
 
 
 def _review_normalized_record(payload: dict[str, Any], expectation: ReviewEvidenceExpectation, evidence: ReviewEvidence) -> dict[str, Any]:
-    findings = _finding_records(payload, evidence.node_id)
+    findings = _finding_records({**payload, "findings": combined_findings(payload, expectation.coverage_reuse)}, evidence.node_id)
     validations = _validation_records(payload)
     handoffs = _handoff_records(payload, evidence.node_id)
     changes = tuple({"change_id": f"{evidence.node_id}-change-{ordinal}", **change} for ordinal, change in enumerate(_records(payload, "changes"), start=1))
     return {
+        **(synthesis_fields(payload) if evidence.mode == "synthesis" else {}),
+        **({"coverage_units": payload["coverage_units"]} if "coverage_units" in payload else {}),
+        **({"coverage_reuse": expectation.coverage_reuse} if expectation.coverage_reuse is not None else {}),
         "artifact_digest": evidence.raw_result_digest,
         "artifact_id": evidence.raw_result_artifact_id,
         "changes": list(changes),
         "command_policy_attested": payload.get("command_policy_attested", False),
+        **({"git_sensitive": payload["git_sensitive"]} if "git_sensitive" in payload else {}),
         "commands_executed": list(_text_list(payload, "commands_executed")),
         "evidence_id": evidence.evidence_id,
         "files_inspected": list(_text_list(payload, "files_inspected")),
+        "observed_source_state": list(evidence.fingerprints.after),
         "findings": [{"finding_id": finding_id, **finding} for finding_id, finding in findings],
         "handoffs": [{"handoff_id": handoff_id, **handoff} for handoff_id, handoff in handoffs],
         "limitations": list(_text_list(payload, "limitations")),
@@ -806,6 +828,9 @@ def _review_scope_coverage_blockers(dispatch: dict[str, Any], payload: dict[str,
         blockers.append("audit files_inspected must be unique")
     owned = set(owned_paths)
     inspected = set(inspected_paths)
+    reused = set(reused_paths(dispatch.get("coverage_reuse")))
+    if reused - owned or reused & inspected:
+        blockers.append("delta audit must inspect only recheck paths and preserve its bound reused coverage")
     outside = tuple(path for path in inspected_paths if path not in owned)
     if outside:
         blockers.append("audit files_inspected contains paths outside dispatch ownership: " + ", ".join(outside))
@@ -815,7 +840,7 @@ def _review_scope_coverage_blockers(dispatch: dict[str, Any], payload: dict[str,
     invalid_limitations = tuple(path for path in limitation_paths if path not in owned or path in inspected)
     if invalid_limitations:
         blockers.append("audit scope_limitations must name omitted owned paths: " + ", ".join(invalid_limitations))
-    omitted = tuple(path for path in owned_paths if path not in inspected)
+    omitted = tuple(path for path in owned_paths if path not in inspected | reused)
     if status == "no-findings" and omitted:
         blockers.append("audit no-findings requires inspection of every owned path; omitted: " + ", ".join(omitted))
     elif status == "completed" and set(limitation_paths) != set(omitted):
@@ -839,7 +864,7 @@ def _compiled_audit_inputs(dispatch: dict[str, Any], payload: dict[str, Any]) ->
     )
 
 
-def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  # noqa: C901, PLR0915
+def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  # noqa: C901, PLR0912, PLR0915
     """Compile one compact semantic payload into the legacy verified artifact."""
     dispatch = document.get("dispatch")
     payload = document.get("payload")
@@ -850,6 +875,25 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
     if mode not in _REVIEW_MODES:
         msg = f"compact compiler does not support mode {mode}"
         raise ValueError(msg)
+    if mode == "synthesis":
+        require_schema(payload, _SYNTHESIS_PAYLOAD_SCHEMA)
+        validate_synthesis(payload, _text_list(dispatch, "predecessor_evidence_ids"), dispatch.get("synthesis_bundle"))
+    coverage_reuse = dispatch.get("coverage_reuse")
+    if coverage_reuse is not None:
+        _verify_delta_context(coverage_reuse, dispatch)
+        old_requirements = {item["requirement_id"] for item in coverage_reuse["original_validation_requirements"]}
+        old_handoffs = {item["catalog_id"] for item in coverage_reuse["original_handoffs"]}
+        if not old_requirements <= {item["requirement_id"] for item in payload["validation_requirements"]} or not old_handoffs <= {
+            item["catalog_id"] for item in payload["handoffs"]
+        }:
+            msg = "delta review must reconcile original validation requirements and routing handoffs"
+            raise ValueError(msg)
+    if payload.get("coverage_units"):
+        if mode != "audit" or coverage_reuse is not None:
+            msg = "coverage partitions apply only to complete fresh audits"
+            raise ValueError(msg)
+        require_schema(payload, _REVIEW_PAYLOAD_SCHEMA)
+        validate_coverage_units(payload, _text_list(dispatch, "owned_paths"))
     status = _required_text(payload, "status")
     if status not in _REVIEW_STATUSES:
         msg = f"invalid review status {status}"
@@ -890,7 +934,7 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
     authorization = _required_text(dispatch, "authorization")
     planned_paths = _text_list(dispatch, "planned_paths") if mode == "fix" else ()
     changed_paths = _text_list(dispatch, "changed_paths") if source_mutated else ()
-    findings = _finding_records(payload, node_id)
+    findings = _finding_records({**payload, "findings": combined_findings(payload, coverage_reuse)}, node_id)
     validations = _validation_records(payload)
     handoffs = _handoff_records(payload, node_id)
     policy_blockers = _review_command_policy_blockers(dispatch, payload)
@@ -904,14 +948,21 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
     if status == "blocked" and not limitations:
         msg = "blocked payload requires a limitation"
         raise ValueError(msg)
-    files_inspected = _text_list(payload, "files_inspected", required=status != "blocked" and mode != "synthesis")
+    files_inspected = _text_list(payload, "files_inspected", required=status != "blocked" and mode != "synthesis" and not reused_paths(coverage_reuse))
     nearby_contract_owners = _text_list(payload, "nearby_contract_owners")
     audit_inputs = _compiled_audit_inputs(dispatch, payload)
     requirement_ids = _text_list(dispatch, "requirement_ids")
     predecessor_evidence_ids = _text_list(dispatch, "predecessor_evidence_ids")
     evidence_id = _required_text(dispatch, "evidence_id")
     artifact_id = _required_text(dispatch, "artifact_id")
-    fingerprints = FingerprintEvidence(expected=expected, before=before, after=after)
+    fingerprints = _dispatch_fingerprints(dispatch)
+    if (
+        fingerprints.metadata_transitions
+        and _git_sensitive_review(payload)
+        and (before != after or after != fingerprints.metadata_transitions[-1].after.source_state)
+    ):
+        msg = "Git-sensitive audit must be rechecked entirely on the current metadata state"
+        raise ValueError(msg)
     expectation = ReviewEvidenceExpectation(
         node_id=node_id,
         requirement_ids=requirement_ids,
@@ -929,6 +980,7 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
         predecessor_evidence_ids=predecessor_evidence_ids,
         planned_paths=planned_paths,
         audit_input_identity=audit_inputs,
+        coverage_reuse=coverage_reuse,
     )
     evidence = ReviewEvidence(
         schema_version=EVIDENCE_SCHEMA_VERSION,
@@ -1008,6 +1060,7 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
                 f"- Worker payload digest: {_sha256_bytes(canonical_payload.encode())}",
                 f"- Canonical worker payload: {canonical_payload}",
                 *((f"- Audit input identity: {_canonical_json(asdict(audit_inputs))}",) if audit_inputs is not None else ()),
+                *((f"- Coverage reuse: {_canonical_json(coverage_reuse)}",) if coverage_reuse is not None else ()),
             )
         ),
         "## Findings": _findings_body(findings),
@@ -1037,6 +1090,9 @@ def compile_review(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  #
         "## Machine Evidence",
     )
     body = "\n\n".join(f"{section}\n\n{section_bodies[section]}" for section in sections[:-1])
+    if mode == "synthesis":
+        body += "\n\n### Readiness Verdict\n\n" + payload["readiness_verdict"] + "\n\n" + "; ".join(payload["verdict_reasons"])
+        body += "\n\n### Synthesis Reconciliation\n\n" + _canonical_json(synthesis_fields(payload))
     content = (
         f"# Review Node Result\n\n{_review_header(expectation, evidence)}\n\n{body}\n\n## Machine Evidence\n\n"
         f"{NATIVE_EVIDENCE_BLOCK_OPEN}{_canonical_json(machine_payload)}{NATIVE_EVIDENCE_BLOCK_CLOSE}\n"
@@ -1242,7 +1298,8 @@ def compile_independent_review(document: dict[str, Any], native_content: bytes) 
             git_mutated=False,
         ),
     )
-    if before != expected or after != expected:
+    observed_fingerprints = _dispatch_fingerprints(dispatch)
+    if not observed_fingerprints.matches(before) or not observed_fingerprints.matches(after) or before != after:
         native_state_blockers = (*native_state_blockers, "independent review observed fingerprints differ from the dispatched expected fingerprints")
     if native_state_blockers:
         input_blockers.append("independent native state proof failed validation: " + "; ".join(native_state_blockers))
@@ -1269,7 +1326,7 @@ def compile_independent_review(document: dict[str, Any], native_content: bytes) 
     evidence_id = _required_text(dispatch, "evidence_id")
     artifact_id = _required_text(dispatch, "artifact_id")
     reference_digests = tuple((str(path), _file_identity_digest(str(path))) for path in reference_paths)
-    fingerprints = FingerprintEvidence(expected=expected, before=before, after=after)
+    fingerprints = observed_fingerprints
     expectation = ReviewEvidenceExpectation(
         node_id=node_id,
         requirement_ids=_text_list(dispatch, "requirement_ids"),
@@ -1318,7 +1375,7 @@ def compile_independent_review(document: dict[str, Any], native_content: bytes) 
             for handoff_id, record in handoffs
         ),
     )
-    results = tuple("matched" if observed == expected else "mismatched" for observed in (before, after))
+    results = tuple("matched" if fingerprints.matches(observed) else "mismatched" for observed in (before, after))
     envelope = "\n".join(
         (
             f"- Node ID: {node_id}",
@@ -1343,6 +1400,11 @@ def compile_independent_review(document: dict[str, Any], native_content: bytes) 
             f"  - Result: {results[1]}",
             "- Source-controlled files changed: none",
             "- Git state mutated: no",
+            *(
+                (f"- External metadata transitions: {_canonical_json([asdict(item) for item in fingerprints.metadata_transitions])}",)
+                if fingerprints.metadata_transitions
+                else ()
+            ),
             f"- Limitations: {'; '.join(limitations) or 'none'}",
         )
     )
@@ -1456,6 +1518,7 @@ def _independent_normalized_record(content: bytes, expectation: ReviewEvidenceEx
         "changes": [],
         "evidence_id": evidence.evidence_id,
         "files_inspected": list(expectation.planned_paths),
+        "observed_source_state": list(evidence.fingerprints.after),
         "findings": findings,
         "handoffs": handoffs,
         "limitations": [] if limitations == ("none",) else list(limitations),
@@ -1565,7 +1628,23 @@ def _path_line_bounds(raw: dict[str, Any], name: str) -> tuple[tuple[str, int], 
 
 
 def _fingerprint_evidence(raw: dict[str, Any]) -> FingerprintEvidence:
-    return FingerprintEvidence(expected=_state(raw, "expected"), before=_state(raw, "before"), after=_state(raw, "after"))
+    return FingerprintEvidence(
+        expected=_state(raw, "expected"),
+        before=_state(raw, "before"),
+        after=_state(raw, "after"),
+        metadata_transitions=tuple(metadata_transition(item) for item in _records(raw, "metadata_transitions")),
+    )
+
+
+def _dispatch_fingerprints(dispatch: dict[str, Any]) -> FingerprintEvidence:
+    return _fingerprint_evidence(
+        {
+            "expected": dispatch["source_state"],
+            "before": dispatch["before_state"],
+            "after": dispatch["after_state"],
+            "metadata_transitions": dispatch.get("external_metadata_transitions", []),
+        }
+    )
 
 
 def _audit_input_identity(raw: object) -> AuditInputIdentity | None:
@@ -1603,6 +1682,7 @@ def _review_expectation(raw: dict[str, Any]) -> ReviewEvidenceExpectation:
         planned_paths=_string_tuple(raw, "planned_paths"),
         planned_path_line_bounds=_path_line_bounds(raw, "planned_path_line_bounds"),
         audit_input_identity=_audit_input_identity(raw.get("audit_input_identity")),
+        coverage_reuse=raw.get("coverage_reuse"),
     )
 
 
@@ -1711,6 +1791,11 @@ def _validation_state_verification(dispatch: dict[str, Any], evidence: Validatio
             f"  - Observed worktree fingerprint: {evidence.fingerprints.after[1]}",
             f"  - Observed repository state fingerprint: {evidence.fingerprints.after[2]}",
             f"  - Result: {result}",
+            *(
+                (f"- External metadata transitions: {_canonical_json([asdict(item) for item in evidence.fingerprints.metadata_transitions])}",)
+                if evidence.fingerprints.metadata_transitions
+                else ()
+            ),
         )
     )
 
@@ -1875,6 +1960,7 @@ def _validation_reuse_body(unit: ValidationUnit, evidence: ValidationEvidence, c
 
 def _validation_normalized_record(payload: dict[str, Any], evidence: ValidationEvidence) -> dict[str, Any]:
     return {
+        "observed_source_state": list(evidence.fingerprints.after),
         "artifact_digest": evidence.raw_result_digest,
         "artifact_id": evidence.raw_result_artifact_id,
         "artifacts": list(_records(payload, "artifacts")),
@@ -2109,7 +2195,7 @@ def _validation_workspace_audit(dispatch: dict[str, Any], unit: ValidationUnit) 
     }
 
 
-def compile_validation(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  # noqa: PLR0915
+def compile_validation(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]:  # noqa: C901, PLR0915
     """Compile one exact validation execution payload into verified evidence."""
     dispatch = document.get("dispatch")
     payload = document.get("payload")
@@ -2140,7 +2226,12 @@ def compile_validation(document: dict[str, Any]) -> tuple[bytes, dict[str, Any]]
         msg = "every compact validator worker requires fresh_context=true"
         raise ValueError(msg)
     expected = unit.source_state
-    fingerprints = FingerprintEvidence(expected=expected, before=_state(dispatch, "before_state"), after=_state(dispatch, "after_state"))
+    fingerprints = _dispatch_fingerprints({**dispatch, "source_state": list(expected)})
+    if fingerprints.metadata_transitions and (
+        fingerprints.before != fingerprints.after or fingerprints.after != fingerprints.metadata_transitions[-1].after.source_state or status == "reused"
+    ):
+        msg = "validation must execute entirely on the current external metadata state"
+        raise ValueError(msg)
     expectation = validation_evidence_expectation(
         unit,
         skill_path=str(skill_path),
@@ -2427,10 +2518,12 @@ def _graph_plan(raw: dict[str, Any]) -> GraphPlan:
                 artifact_path=_required_text(item, "artifact_path"),
                 metadata_path=_required_text(item, "metadata_path"),
                 instruction_digests=_string_pairs(item, "instruction_digests"),
+                metadata_transitions=tuple(metadata_transition(raw) for raw in _records(item, "metadata_transitions")),
             )
             for item in _records(raw, "audit_reuse_transitions")
         ),
         reuse_source_snapshots=tuple(source_snapshot(item) for item in _records(raw, "reuse_source_snapshots")),
+        audit_delta_reviews=_records(raw, "audit_delta_reviews"),
         validation_exclusions=tuple(
             ValidationExclusion(
                 originating_evidence_id=_required_text(item, "originating_evidence_id"),
@@ -2515,6 +2608,11 @@ def _load_evidence_source(  # noqa: C901, PLR0912, PLR0915
     if kind == "review":
         expectation = _review_expectation(expectation_raw)
         evidence = _review_evidence(evidence_raw)
+        if expectation.coverage_reuse is not None:
+            _verify_delta_context(
+                expectation.coverage_reuse,
+                {**expectation_raw, "owned_paths": list(expectation.audit_input_identity.owned_paths) if expectation.audit_input_identity else []},
+            )
         assessment = assess_review_evidence(expectation, evidence)
         blockers = (*assessment.blockers, *_review_native_result_blockers(content, expectation, evidence))
     else:
@@ -2539,6 +2637,9 @@ def _load_evidence_source(  # noqa: C901, PLR0912, PLR0915
                 recomputed = _independent_normalized_record(content, expectation, evidence)
             else:
                 payload = _canonical_worker_payload(content)
+                if expectation.mode == "synthesis":
+                    require_schema(payload, _SYNTHESIS_PAYLOAD_SCHEMA)
+                    validate_synthesis(payload, expectation.predecessor_evidence_ids)
                 payload_digest = _sha256_bytes(_canonical_json(payload).encode())
                 if metadata.get("payload_digest") != payload_digest:
                     msg = f"worker payload digest does not match compiled artifact: {artifact_path}"
@@ -2624,6 +2725,7 @@ def _synthesis_plan_context(plan: GraphPlan, records: list[dict[str, Any]]) -> d
         "exact_reused_review_evidence": [list(item) for item in plan.exact_reused_review_evidence],
         "requirement_to_node": [list(item) for item in plan.requirement_to_node],
         "validation_evidence_mapping": [asdict(item) for item in plan.validation_evidence_mapping],
+        "validation_environments": {unit.node_id: json.loads(_validation_environment_identity(unit)) for unit in plan.coalesced_validation_units},
         "validation_exclusions": [asdict(item) for item in plan.validation_exclusions],
         "validation_reconciliation": _validation_reconciliation(plan, records),
         "handoff_reconciliation": {"handoffs": handoffs, "unresolved_handoff_ids": list(unresolved), "blockers": list(blockers)},
@@ -2978,16 +3080,23 @@ def _worker_prompt(contract: str, dispatch: dict[str, Any]) -> str:
     audit_scope_text = (
         " For audit payloads, files_inspected names dispatch-owned reads; nearby_contract_owners names inspected read-only dependency/context provenance and "
         "may be outside dispatch ownership; scope_limitations is reserved exclusively for omitted dispatch-owned paths and must equal owned_paths minus "
-        "files_inspected. Narrative limitations do not create omitted scope or artifact write targets."
+        "files_inspected and runtime-proved reused paths. When coverage_reuse is present, inspect only recheck units, preserve their prior findings and "
+        "reconcile original validation needs/handoffs; do not claim fresh reads of reused paths. For broad fresh audits, use optional coverage_units when "
+        "you can partition contracts with explicit dependencies and uncertainty. Mark git_sensitive when judgments depend on Git metadata. "
+        "Narrative limitations do not create omitted scope or artifact write targets."
         if dispatch.get("mode") == "audit"
         else ""
     )
     return (
         f"Return only the canonical {contract} payload using field names from {schema_text}. "
         "Every field shown in payload_schema.required_shape is required whenever its parent object is present. "
-        "Do not author fingerprints, evidence IDs, artifact IDs, or digests. "
+        "Do not author fingerprints, evidence IDs, artifact IDs, or digests. Copy supplied evidence/finding IDs only into schema-defined reference fields. "
         f"Command policy: {command_policy}{validation_text}{audit_scope_text}{persistence_text}{shared_text}"
     )
+
+
+def _review_payload_schema(dispatch: dict[str, Any]) -> Path:
+    return _SYNTHESIS_PAYLOAD_SCHEMA if dispatch.get("mode") == "synthesis" else _REVIEW_PAYLOAD_SCHEMA
 
 
 def _validate_worker_payload_bytes(contract_document: dict[str, Any], payload_bytes: bytes) -> dict[str, Any] | None:
@@ -2998,7 +3107,7 @@ def _validate_worker_payload_bytes(contract_document: dict[str, Any], payload_by
         if not isinstance(payload, dict):
             msg = "compact worker payload root must be an object"
             raise TypeError(msg)
-        schema = _REVIEW_PAYLOAD_SCHEMA if contract == "compact-review" else _VALIDATION_PAYLOAD_SCHEMA
+        schema = _review_payload_schema(contract_document) if contract == "compact-review" else _VALIDATION_PAYLOAD_SCHEMA
         require_schema(payload, schema)
         if contract == "compact-review":
             blockers = _review_scope_coverage_blockers(contract_document, payload, status=_required_text(payload, "status"))
@@ -3201,6 +3310,7 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
         msg = "inspection_profile must be independent-source or shared-read-only"
         raise ValueError(msg)
     review_schema = _schema_reference(_REVIEW_PAYLOAD_SCHEMA)
+    synthesis_schema = _schema_reference(_SYNTHESIS_PAYLOAD_SCHEMA)
     validation_schema = _schema_reference(_VALIDATION_PAYLOAD_SCHEMA)
     catalog_path = Path(document.get("routing_catalog_path", DEFAULT_ROUTING_CATALOG)).resolve()
     if not catalog_path.is_file():
@@ -3311,6 +3421,13 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
             },
             "worker_created": location == "worker",
         }
+        deltas = [item for item in plan.audit_delta_reviews if item["node_id"] == node.node_id]
+        if deltas:
+            if len(deltas) != 1:
+                msg = "delta audit requires exactly one bound coverage context"
+                raise ValueError(msg)
+            _verify_delta_context(deltas[0], common)
+            common["coverage_reuse"] = deltas[0]
         if node.node_id in inspection_groups:
             common["shared_inspection_evidence"] = inspection_groups[node.node_id]
         if node.mode == "validation":
@@ -3354,9 +3471,10 @@ def materialize_dispatches(  # noqa: C901, PLR0912, PLR0915
                 common["adversarial_checks"] = list(_independent_adversarial_checks(node.coverage))
                 contract = "native-independent-review"
             else:
-                common["payload_schema"] = review_schema
+                common["payload_schema"] = synthesis_schema if node.mode == "synthesis" else review_schema
                 contract = "compact-review"
         persistence_contract = {
+            **({"coverage_reuse": common["coverage_reuse"]} if "coverage_reuse" in common else {}),
             "mode": node.mode,
             "node_id": node.node_id,
             "owned_paths": list(node.coverage),
@@ -3412,6 +3530,7 @@ def _epoch_scoped_plan(plan: GraphPlan, epoch: int) -> GraphPlan:
     units = tuple(replace(unit, node_id=node_ids[unit.node_id]) for unit in plan.coalesced_validation_units)
     return replace(
         plan,
+        audit_delta_reviews=tuple({**item, "node_id": node_ids[item["node_id"]]} for item in plan.audit_delta_reviews),
         actual_worker_nodes=nodes,
         coalesced_validation_units=units,
         current_epoch_node_ids=tuple(node_ids[node_id] for node_id in plan.current_epoch_node_ids),
@@ -3448,7 +3567,7 @@ def _capture_path_fingerprints(capture: dict[str, Any], *, label: str) -> dict[s
 
 def _mutation_path_delta(document: dict[str, Any], previous: dict[str, Any], current: dict[str, Any]) -> tuple[str, ...]:
     previous_state = tuple(_required_text(previous, field) for field in ("scope_fingerprint", "captured_worktree_fingerprint", "repository_state_fingerprint"))
-    if previous_state != _state(document, "source_state"):
+    if previous_state != _current_metadata_state(document):
         msg = "previous_capture must match the immediately prior plan source_state"
         raise ValueError(msg)
     for field in ("repository_root", "capture_mode", "base_ref", "merge_base", "requested_paths", "head", "branch"):
@@ -3566,7 +3685,12 @@ def _compact_reuse_overrides(plan: GraphPlan, reused_requirements: dict[str, str
     overrides = []
     for decision in plan.routing_decisions:
         if decision.requirement_id in reused_requirements:
-            decision = replace(decision, disposition="exact-evidence-reused", evidence_id=reused_requirements[decision.requirement_id])
+            decision = replace(
+                decision,
+                disposition="exact-evidence-reused",
+                evidence_id=reused_requirements[decision.requirement_id],
+                review_surface=tuple(sorted(decision.review_surface)),
+            )
         overrides.append({key: value for key, value in asdict(decision).items() if key in _COMPACT_ROUTING_OVERRIDE_FIELDS and value is not None})
     return json.loads(_canonical_json(overrides))
 
@@ -3583,7 +3707,7 @@ def _audit_reuse_blocker(record: dict[str, Any], *, invalidated: bool) -> tuple[
     return None
 
 
-def _carry_forward_audits(  # noqa: C901, PLR0913, PLR0915 - preserve provenance and report every reuse rejection.
+def _carry_forward_audits(  # noqa: C901, PLR0912, PLR0913, PLR0915 - preserve provenance and report every reuse rejection.
     document: dict[str, Any],
     old_plan: GraphPlan,
     candidate_plan: GraphPlan,
@@ -3609,6 +3733,9 @@ def _carry_forward_audits(  # noqa: C901, PLR0913, PLR0915 - preserve provenance
     target = source_snapshot(current)
     target.verify()
     snapshots = {item.source_state: item for item in old_plan.reuse_source_snapshots}
+    for item in _records(document, "external_metadata_transitions"):
+        transition = metadata_transition(item)
+        snapshots.update({transition.before.source_state: transition.before, transition.after.source_state: transition.after})
     if previous.get("repository_state_format") == SNAPSHOT_FORMAT:
         origin = source_snapshot(previous)
         origin.verify()
@@ -3654,6 +3781,7 @@ def _carry_forward_audits(  # noqa: C901, PLR0913, PLR0915 - preserve provenance
             artifact_path=str(Path(_required_text(source, "artifact_path")).resolve()),
             metadata_path=str(Path(_required_text(source, "metadata_path")).resolve()),
             instruction_digests=tuple((path, _file_identity_digest(path)) for path in instructions),
+            metadata_transitions=_metadata_chain_from(document, origin.source_state),
         )
         try:
             verify_reuse_inputs(origin, target, inputs, transition)
@@ -3688,6 +3816,230 @@ def _carry_forward_audits(  # noqa: C901, PLR0913, PLR0915 - preserve provenance
             msg = "rerouted audit reuse is inconsistent: " + "; ".join(blockers)
             raise ValueError(msg)
     return routed, list(decisions.values())
+
+
+def _verify_delta_context(context: dict[str, Any], dispatch: dict[str, Any]) -> None:
+    """Replay the original immutable partition proof at materialization and acceptance."""
+    origin, target = source_snapshot(context["origin"]), source_snapshot(context["target"])
+    if target.source_state != _state(dispatch, "source_state"):
+        msg = "delta coverage target differs from the dispatched source state"
+        raise ValueError(msg)
+    _kind, expectation, evidence, _content, record = _load_evidence_source(context, require_normalized=True)
+    inputs = expectation.audit_input_identity if isinstance(expectation, ReviewEvidenceExpectation) else None
+    if not isinstance(expectation, ReviewEvidenceExpectation) or not isinstance(evidence, ReviewEvidence) or inputs is None or record is None:
+        msg = "delta coverage requires compiler-bound audit input identities"
+        raise ValueError(msg)
+    if expectation.coverage_reuse is not None or _audit_reuse_blocker(record, invalidated=False) is not None:
+        msg = "delta coverage origin must be a complete fresh audit without unresolved limitations"
+        raise ValueError(msg)
+    if (origin.source_state, inputs.owned_paths, evidence.skill_id, evidence.skill_path, evidence.requirement_ids) != (
+        expectation.source_state,
+        _text_list(dispatch, "owned_paths"),
+        dispatch["skill_id"],
+        dispatch["skill_path"],
+        _text_list(dispatch, "requirement_ids"),
+    ):
+        msg = "delta coverage changes original routing, ownership, or source identity"
+        raise ValueError(msg)
+    transition = AuditReuseTransition(
+        evidence.evidence_id,
+        origin.source_state,
+        target.source_state,
+        evidence.raw_result_digest,
+        context["artifact_path"],
+        context["metadata_path"],
+        _string_pairs(context, "instruction_digests"),
+        tuple(metadata_transition(item) for item in _records(context, "metadata_transitions")),
+    )
+    decisions = coverage_decisions(record, origin, target, inputs, transition)
+    if (
+        context["units"] != decisions
+        or context["original_findings"] != record["findings"]
+        or context["original_validation_requirements"] != record["validation_requirements"]
+        or context["original_handoffs"] != record["handoffs"]
+        or context["evidence_id"] != evidence.evidence_id
+        or context["artifact_digest"] != evidence.raw_result_digest
+    ):
+        msg = "delta coverage differs from original immutable findings or verified unit decisions"
+        raise ValueError(msg)
+    if not reused_paths(context):
+        msg = "delta coverage has no reusable units"
+        raise ValueError(msg)
+
+
+def _plan_delta_audits(
+    document: dict[str, Any], previous: GraphPlan, candidate: GraphPlan, sources: dict[str, tuple[dict[str, Any], dict[str, Any]]]
+) -> tuple[GraphPlan, list[dict[str, Any]]]:
+    """Retain full specialist ownership while dispatching only stale partitions for reads."""
+    if any(document[field].get("repository_state_format") != SNAPSHOT_FORMAT for field in ("previous_capture", "new_capture")):
+        return candidate, []
+    origin, target = (source_snapshot(document[field]) for field in ("previous_capture", "new_capture"))
+    snapshots = {item.source_state: item for item in previous.reuse_source_snapshots}
+    snapshots[origin.source_state] = origin
+    for item in _records(document, "external_metadata_transitions"):
+        transition = metadata_transition(item)
+        snapshots.update({transition.before.source_state: transition.before, transition.after.source_state: transition.after})
+    contexts = []
+    reviews = []
+    for source, record in sources.values():
+        if not record.get("coverage_units") or record.get("coverage_reuse") or _audit_reuse_blocker(record, invalidated=False):
+            continue
+        _kind, expectation, evidence, _content, _record = _load_evidence_source(source, require_normalized=True)
+        if not isinstance(expectation, ReviewEvidenceExpectation) or not isinstance(evidence, ReviewEvidence) or expectation.audit_input_identity is None:
+            continue
+        for node in candidate.actual_worker_nodes:
+            if node.mode != "audit" or node.predecessors or node.requirement_ids != evidence.requirement_ids:
+                continue
+            inputs = expectation.audit_input_identity
+            chain = _metadata_chain_from(document, expectation.source_state)
+            audit_origin = snapshots.get(expectation.source_state)
+            if audit_origin is None or (node.skill_digest, node.reference_digests, node.coverage) != (
+                evidence.skill_digest,
+                evidence.reference_digests,
+                inputs.owned_paths,
+            ):
+                continue
+            instructions = _applicable_instruction_paths(Path(target.repository_root), node.coverage, node.instruction_paths)
+            transition = AuditReuseTransition(
+                evidence.evidence_id,
+                origin.source_state,
+                target.source_state,
+                evidence.raw_result_digest,
+                source["artifact_path"],
+                source["metadata_path"],
+                tuple((path, _file_identity_digest(path)) for path in instructions),
+                chain,
+            )
+            transition = replace(transition, source_state=audit_origin.source_state)
+            units = coverage_decisions(record, audit_origin, target, inputs, transition)
+            reviews.append({"node_id": node.node_id, "evidence_id": evidence.evidence_id, "units": units})
+            if not any(unit["disposition"] == "reused" for unit in units):
+                continue
+            context = {
+                **source,
+                "node_id": node.node_id,
+                "origin": asdict(audit_origin),
+                "target": asdict(target),
+                "units": units,
+                "evidence_id": evidence.evidence_id,
+                "artifact_digest": evidence.raw_result_digest,
+                "original_findings": record["findings"],
+                "original_validation_requirements": record["validation_requirements"],
+                "original_handoffs": record["handoffs"],
+                "instruction_digests": list(transition.instruction_digests),
+                "metadata_transitions": [asdict(item) for item in chain],
+            }
+            contexts.append(json.loads(_canonical_json(context)))
+    return replace(candidate, audit_delta_reviews=tuple(contexts)), reviews
+
+
+def _git_sensitive_review(record: dict[str, Any]) -> bool:
+    """Unknown executed commands and explicit Git judgments require revalidation."""
+    return bool(record.get("git_sensitive", False)) or any(
+        not re.match(r"^(?:cat|rg|head|tail|wc|ls)\s", command) or bool(re.search(r"[;&|`$\n]|\bgit\b|--pre", command))
+        for command in record.get("commands_executed", [])
+    )
+
+
+def _metadata_chain_from(document: dict[str, Any], state: tuple[str, str, str]) -> tuple[ExternalMetadataTransition, ...]:
+    transitions = tuple(metadata_transition(item) for item in _records(document, "external_metadata_transitions"))
+    for ordinal, transition in enumerate(transitions):
+        if transition.before.source_state == state:
+            return transitions[ordinal:]
+    for reuse in _records(document.get("plan", {}), "audit_reuse_transitions"):
+        if _state(reuse, "source_state") == state:
+            return tuple(metadata_transition(item) for item in _records(reuse, "metadata_transitions"))
+    return ()
+
+
+def _current_metadata_state(document: dict[str, Any]) -> tuple[str, str, str]:
+    transitions = tuple(metadata_transition(item) for item in _records(document, "external_metadata_transitions"))
+    return metadata_states(_state(document, "source_state"), transitions)[-1]
+
+
+def _metadata_evidence_blockers(document: dict[str, Any], records: list[dict[str, Any]]) -> list[str]:
+    if not document.get("external_metadata_transitions"):
+        return []
+    current = _current_metadata_state(document)
+    return [
+        f"Git-sensitive evidence requires revalidation after external staging: {record['evidence_id']}"
+        for record in records
+        if (record.get("mode") != "audit" or _git_sensitive_review(record)) and tuple(record.get("observed_source_state", ())) != current
+    ]
+
+
+def resume_after_external_metadata(document: dict[str, Any]) -> dict[str, Any]:
+    """Publish a new continuation while preserving original audit and Git provenance."""
+    transition = metadata_transition({"before": document["previous_capture"], "after": document["new_capture"]})
+    if transition.before.source_state != _current_metadata_state(document):
+        msg = "external metadata previous capture differs from the current reviewed state"
+        raise ValueError(msg)
+    plan = _graph_plan(document["plan"])
+    state = _state(document, "source_state")
+    entries = _dispatches_by_node(_read_json_object(Path(document["dispatches_path"])), plan=plan, source_state=state)
+    events, lifecycle, _head = read_execution_journal(Path(document["journal_path"]), plan=plan, source_state=state)
+    sources, records = _accepted_journal_sources(plan, state, events, entries, include_blocked=True)
+    by_node = {record["node_id"]: record for record in records}
+    for node in plan.actual_worker_nodes:
+        dispatch = entries[node.node_id]["dispatch"]
+        current_instructions = _applicable_instruction_paths(Path(transition.after.repository_root), node.coverage, node.instruction_paths)
+        expected_instructions = _string_pairs(dispatch, "instruction_digests")
+        if (
+            tuple((path, _file_identity_digest(path)) for path in current_instructions) != expected_instructions
+            or _file_identity_digest(node.skill_path) != node.skill_digest
+            or any(_file_identity_digest(path) != digest for path, digest in node.reference_digests)
+        ):
+            msg = "external metadata resume requires unchanged applicable instructions, skills, and references"
+            raise ValueError(msg)
+    preserved = {
+        node.node_id: entries[node.node_id]
+        for node in plan.actual_worker_nodes
+        if node.mode == "audit"
+        and not node.predecessors
+        and lifecycle.get(node.node_id) in {"accepted", "in-flight"}
+        and not _git_sensitive_review(by_node.get(node.node_id, {}))
+    }
+    transitions = [*_records(document, "external_metadata_transitions"), asdict(transition)]
+    continuation = json.loads(_canonical_json({"plan": asdict(plan), "source_state": list(state), "external_metadata_transitions": transitions}))
+    root = Path(document["artifact_store"]).resolve()
+    first_entry = next(iter(entries.values()), None)
+    if first_entry is None:
+        msg = "external metadata resume requires a materialized review graph"
+        raise ValueError(msg)
+    materialized = materialize_dispatches(
+        {
+            "plan": document["plan"],
+            "source_state": list(state),
+            "artifact_store": str(root),
+            "repository_root": transition.after.repository_root,
+            "authorization": first_entry["dispatch"]["authorization"],
+            "state_verification_command": first_entry["dispatch"]["state_verification_command"],
+        },
+        preserved_entries=preserved,
+    )
+    paths = {
+        "lifecycle_input_path": root / "lifecycle.json",
+        "dispatches_path": root / "dispatches.json",
+        "capture_path": root / "capture.json",
+        "journal_path": root / "execution.jsonl",
+    }
+    for field, value in (("lifecycle_input_path", continuation), ("dispatches_path", materialized), ("capture_path", document["new_capture"])):
+        _write_text_once(paths[field], json.dumps(value, indent=2, sort_keys=True) + "\n")
+    _write_text_once(paths["journal_path"], "")
+    for node_id in preserved:
+        request = JournalEventRequest(node_id, lifecycle[node_id], source=sources.get(node_id))
+        append_journal_event(paths["journal_path"], continuation, request)
+    return {
+        "status": "resumed",
+        "transition_kind": "observed-external-git-metadata",
+        "lifecycle_input": continuation,
+        "dispatch_set": materialized,
+        "original_source_state": list(state),
+        "current_source_state": list(transition.after.source_state),
+        "preserved_node_ids": sorted(preserved),
+        "recheck_node_ids": sorted(set(entries) - set(preserved)),
+        **{key: str(path) for key, path in paths.items()},
+    }
 
 
 def advance_after_mutation(document: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
@@ -3736,6 +4088,7 @@ def advance_after_mutation(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
         raise ValueError(msg)
     invalidated = _mutation_invalidated_nodes(old_plan, new_plan, changed_paths, repository_root, sources)
     new_plan, reuse_decisions = _carry_forward_audits(document, old_plan, new_plan, planning_input, invalidated=invalidated, sources=sources)
+    new_plan, coverage_reviews = _plan_delta_audits(document, old_plan, new_plan, sources)
     new_plan = _epoch_scoped_plan(new_plan, epoch)
     reused_ids = {item.evidence_id for item in new_plan.audit_reuse_transitions}
     artifact_store = Path(_required_text(document, "artifact_store")).resolve() / f"repair-epoch-{epoch:03d}"
@@ -3793,6 +4146,7 @@ def advance_after_mutation(document: dict[str, Any]) -> dict[str, Any]:  # noqa:
         "preservation_policy": "verified-unchanged-audit-inputs",
         "reused_evidence_ids": sorted(reused_ids),
         "reuse_decisions": sorted(reuse_decisions, key=lambda item: item["node_id"]),
+        "coverage_reuse_decisions": [{**item, "node_id": f"repair-epoch-{epoch:03d}-" + item["node_id"]} for item in coverage_reviews],
         "unaffected_node_ids": [node.node_id for node in unaffected],
         "repair_epoch": {
             "changed_paths": list(changed_paths),
@@ -4227,7 +4581,7 @@ def next_ready_nodes(document: dict[str, Any], *, journal_events: tuple[dict[str
     plan = _graph_plan(raw_plan)
     source_state = _state(document, "source_state")
     current_source_state = _state(document, "current_source_state")
-    if current_source_state != source_state:
+    if current_source_state != _current_metadata_state(document):
         msg = "next-ready current recapture differs from the plan-bound source state"
         raise ValueError(msg)
     reused_sources = _verified_reused_sources(plan, source_state)
@@ -4235,6 +4589,7 @@ def next_ready_nodes(document: dict[str, Any], *, journal_events: tuple[dict[str
     dispatches = _dispatches_by_node(dispatch_set, plan=plan, source_state=source_state)
     _sources, records = _accepted_journal_sources(plan, source_state, journal_events, dispatches)
     validation_reconciliation = _validation_reconciliation(plan, records)
+    metadata_blockers = _metadata_evidence_blockers(document, records)
     accepted = {node_id for node_id, lifecycle in state.items() if lifecycle == "accepted"}
     blocked = {node_id for node_id, lifecycle in state.items() if lifecycle == "blocked"}
     invalidated = {node_id for node_id, lifecycle in state.items() if lifecycle == "invalidated"}
@@ -4242,6 +4597,7 @@ def next_ready_nodes(document: dict[str, Any], *, journal_events: tuple[dict[str
     in_flight = {node_id for node_id, lifecycle in state.items() if lifecycle == "in-flight"}
     blockers = ["blocked nodes prevent completion: " + ", ".join(sorted(blocked))] if blocked else []
     blockers.extend(validation_reconciliation["blockers"])
+    blockers.extend(metadata_blockers)
     pending_validation = sorted(
         {item["validation_unit_id"] for item in validation_reconciliation["requirements"] if item["resolution"] == "planned"} - accepted
     )
@@ -4702,7 +5058,7 @@ def finalize_proof(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, P
     plan = _graph_plan(raw_plan)
     source_state = _state(document, "source_state")
     current_source_state = _state(document, "current_source_state")
-    if current_source_state != source_state:
+    if current_source_state != _current_metadata_state(document):
         msg = "finalize-proof current recapture differs from the plan-bound source state"
         raise ValueError(msg)
     expectation = repository_review_proof_expectation(plan, source_state=source_state)
@@ -4719,6 +5075,15 @@ def finalize_proof(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, P
             duplicate_evidence.add(evidence.evidence_id)
         loaded[evidence.evidence_id] = (kind, record_expectation, evidence, content, normalized)
     preblockers = list(_text_list(document, "lifecycle_blockers"))
+    normalized_records = [record for *_rest, record in loaded.values() if record is not None]
+    synthesis_bundle = {"records": normalized_records, "plan_context": _synthesis_plan_context(plan, normalized_records)}
+    for _kind, record_expectation, evidence, content, _record in loaded.values():
+        if isinstance(record_expectation, ReviewEvidenceExpectation) and record_expectation.mode == "synthesis":
+            try:
+                validate_synthesis(_canonical_worker_payload(content), record_expectation.predecessor_evidence_ids, synthesis_bundle)
+            except ValueError as error:
+                preblockers.append(f"synthesis reconciliation failed for {evidence.evidence_id}: {error}")
+    preblockers.extend(_metadata_evidence_blockers(document, [record for *_rest, record in loaded.values() if record is not None]))
     if duplicate_evidence:
         preblockers.append("duplicate evidence sources: " + ", ".join(sorted(duplicate_evidence)))
 
@@ -4891,6 +5256,7 @@ def finalize_proof(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, P
         if isinstance(evidence, ReviewEvidence) and evidence.mode == "independent-review":
             accepted_independent_list.append(evidence_id)
     accepted_independent = tuple(accepted_independent_list)
+    final_record = loaded[final_synthesis_evidence_id][4] if final_synthesis_evidence_id in loaded else None
     return {
         "artifact_manifest": asdict(manifest),
         "blockers": list(blockers),
@@ -4904,6 +5270,10 @@ def finalize_proof(document: dict[str, Any]) -> dict[str, Any]:  # noqa: C901, P
         },
         "proof": asdict(proof),
         "repository_validation_status": repository_validation_status,
+        "repository_readiness": final_record.get("readiness_verdict", "blocked") if final_record and not blockers else "blocked",
+        "reviewed_source_state": list(source_state),
+        "current_source_state": list(current_source_state),
+        "external_metadata_transitions": document.get("external_metadata_transitions", []),
         "validation_reconciliation": validation_reconciliation,
         "schema_version": 1,
         "status": graph_proof_status,
@@ -4932,6 +5302,9 @@ def _runtime_subparser(subparsers: Any, operation: str, help_text: str, *, contr
 def _argument_parser() -> argparse.ArgumentParser:  # noqa: PLR0915
     parser = argparse.ArgumentParser(description=__doc__)
     subparsers = parser.add_subparsers(dest="operation", required=True)
+    resume_parser = _runtime_subparser(subparsers, "resume-after-external-metadata", "resume after verified external staging without changing Git")
+    resume_parser.add_argument("--input", type=Path, required=True)
+    resume_parser.add_argument("--output", type=Path, required=True)
     compile_parser = _runtime_subparser(subparsers, "compile-review", "compile a compact review payload")
     compile_parser.add_argument("--input", type=Path, required=True)
     compile_parser.add_argument("--artifact", type=Path, required=True)
@@ -5192,14 +5565,14 @@ def _lifecycle_dispatch(document: dict[str, Any], dispatches_path: Path, node_id
 def _snapshot_workspace_from_files(document: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
     _plan, entry = _lifecycle_dispatch(document, args.dispatches, args.node_id)
     source_state = _state(document, "source_state")
-    if _capture_source_state(args.current_capture) != source_state:
+    if _capture_source_state(args.current_capture) != _current_metadata_state(document):
         msg = "workspace snapshot capture differs from the plan-bound source state"
         raise ValueError(msg)
     dispatch = entry.get("dispatch")
     if not isinstance(dispatch, dict) or entry.get("result_contract") != "compact-validation":
         msg = f"workspace snapshots apply only to validation nodes: {args.node_id}"
         raise ValueError(msg)
-    return capture_workspace_snapshot(dispatch)
+    return {**capture_workspace_snapshot(dispatch), "observed_source_state": list(_capture_source_state(args.current_capture))}
 
 
 def _independent_status(native_content: bytes, explicit: str | None) -> str:
@@ -5209,8 +5582,13 @@ def _independent_status(native_content: bytes, explicit: str | None) -> str:
     return "no-findings" if sections["## Findings"].strip() == "No findings." else "completed"
 
 
-def _workspace_records(path: Path, *, node_id: str, source_state: tuple[str, str, str]) -> list[dict[str, Any]]:
+def _workspace_records(
+    path: Path, *, node_id: str, source_state: tuple[str, str, str], observed_state: tuple[str, str, str] | None = None
+) -> list[dict[str, Any]]:
     snapshot = _read_json_object(path)
+    if observed_state is not None and tuple(snapshot.get("observed_source_state", ())) != observed_state:
+        msg = "workspace snapshot predates the current external metadata state"
+        raise ValueError(msg)
     if snapshot.get("node_id") != node_id or _state(snapshot, "source_state") != source_state:
         msg = f"workspace snapshot belongs to a different node or source state: {path}"
         raise ValueError(msg)
@@ -5253,14 +5631,20 @@ def _compile_node_from_files(document: dict[str, Any], args: argparse.Namespace)
     source_state = _state(document, "source_state")
     before_state = _capture_source_state(args.before_capture)
     after_state = _capture_source_state(args.after_capture)
-    if before_state != source_state or after_state != source_state:
+    states = metadata_states(source_state, tuple(metadata_transition(item) for item in _records(document, "external_metadata_transitions")))
+    if before_state not in states or after_state != states[-1]:
         msg = "compile-node capture differs from the plan-bound source state"
         raise ValueError(msg)
     raw_dispatch = entry.get("dispatch")
     if not isinstance(raw_dispatch, dict):
         msg = f"materialized node has no dispatch object: {args.node_id}"
         raise TypeError(msg)
-    dispatch = {**raw_dispatch, "after_state": list(after_state), "before_state": list(before_state)}
+    dispatch = {
+        **raw_dispatch,
+        "after_state": list(after_state),
+        "before_state": list(before_state),
+        "external_metadata_transitions": document.get("external_metadata_transitions", []),
+    }
     contract = _required_text(entry, "result_contract")
     payload_path = Path(_required_text(entry, "worker_payload_path")).resolve()
     if _required_text(raw_dispatch, "worker_payload_path") != str(payload_path):
@@ -5277,8 +5661,12 @@ def _compile_node_from_files(document: dict[str, Any], args: argparse.Namespace)
         if args.workspace_before is None or args.workspace_after is None:
             msg = "validation compile-node requires --workspace-before and --workspace-after"
             raise ValueError(msg)
-        dispatch["workspace_before"] = _workspace_records(args.workspace_before, node_id=args.node_id, source_state=source_state)
-        dispatch["workspace_after"] = _workspace_records(args.workspace_after, node_id=args.node_id, source_state=source_state)
+        dispatch["workspace_before"] = _workspace_records(
+            args.workspace_before, node_id=args.node_id, source_state=source_state, observed_state=before_state if len(states) > 1 else None
+        )
+        dispatch["workspace_after"] = _workspace_records(
+            args.workspace_after, node_id=args.node_id, source_state=source_state, observed_state=after_state if len(states) > 1 else None
+        )
     elif args.workspace_before is not None or args.workspace_after is not None:
         msg = "workspace snapshots apply only to validation compile-node operations"
         raise ValueError(msg)
@@ -5288,7 +5676,12 @@ def _compile_node_from_files(document: dict[str, Any], args: argparse.Namespace)
         if not isinstance(payload, dict):
             msg = "compact worker payload root must be an object"
             raise TypeError(msg)
-        require_schema(payload, _REVIEW_PAYLOAD_SCHEMA if contract == "compact-review" else _VALIDATION_PAYLOAD_SCHEMA)
+        require_schema(payload, _review_payload_schema(dispatch) if contract == "compact-review" else _VALIDATION_PAYLOAD_SCHEMA)
+        if dispatch.get("mode") == "synthesis":
+            events, _lifecycle, _head = read_execution_journal(args.journal, plan=plan, source_state=source_state)
+            entries = _dispatches_by_node(_read_json_object(args.dispatches), plan=plan, source_state=source_state)
+            sources, _records_view = _accepted_journal_sources(plan, source_state, events, entries)
+            dispatch["synthesis_bundle"] = build_synthesis_bundle({**document, "sources": list(sources.values())})
         compiler_input = {"dispatch": dispatch, "payload": payload}
         content, metadata = compile_review(compiler_input) if contract == "compact-review" else compile_validation(compiler_input)
     elif contract == "native-independent-review":
@@ -5405,6 +5798,8 @@ def _json_operation_output(document: dict[str, Any], args: argparse.Namespace) -
         return build_routing_projection_document(document, catalog_path=args.catalog, skill_roots=tuple(args.skill_root or (DEFAULT_SKILL_ROOT,)))
     if args.operation == "advance-after-mutation":
         return advance_after_mutation(document)
+    if args.operation == "resume-after-external-metadata":
+        return resume_after_external_metadata(document)
     if args.operation == "reconcile-handoffs":
         return reconcile_handoffs(document)
     if args.operation in {"reconcile-validation-requirements", "fallback-to-coordinator"}:
@@ -5437,7 +5832,7 @@ def _run_operation(document: dict[str, Any], args: argparse.Namespace) -> int:  
     if args.operation in {"compile-independent-review", "compile-review", "compile-validation"}:
         if args.operation in {"compile-review", "compile-validation"}:
             payload = document.get("payload")
-            schema_path = _REVIEW_PAYLOAD_SCHEMA if args.operation == "compile-review" else _VALIDATION_PAYLOAD_SCHEMA
+            schema_path = _review_payload_schema(document["dispatch"]) if args.operation == "compile-review" else _VALIDATION_PAYLOAD_SCHEMA
             require_schema(payload, schema_path)
         if args.operation == "compile-review":
             content, metadata = compile_review(document)

--- a/agents/.agents/skills/review-graph/scripts/review_graph_synthesis.py
+++ b/agents/.agents/skills/review-graph/scripts/review_graph_synthesis.py
@@ -1,0 +1,77 @@
+"""Typed synthesis judgments, distinct from graph completion and validator success."""
+
+from typing import Any
+
+
+def validate_synthesis(payload: dict[str, Any], predecessors: tuple[str, ...], bundle: dict[str, Any] | None = None) -> None:  # noqa: C901, PLR0912, PLR0915
+    """Reconcile coverage and finding provenance without deciding semantic severity."""
+    coverage = payload["predecessor_coverage"]
+    covered = [item["evidence_id"] for item in coverage]
+    if len(covered) != len(set(covered)) or set(covered) != set(predecessors):
+        msg = "synthesis coverage must name every dispatched predecessor exactly once"
+        raise ValueError(msg)
+    references = {(ref["evidence_id"], ref["finding_id"]) for item in payload["findings"] for ref in item["source_findings"]}
+    if any(evidence_id not in predecessors for evidence_id, _ in references):
+        msg = "synthesis finding provenance references an unknown predecessor"
+        raise ValueError(msg)
+    validations = payload["validation_reconciliation"]
+    validation_ids = [item["evidence_id"] for item in validations]
+    if len(validation_ids) != len(set(validation_ids)) or not set(validation_ids) <= set(predecessors):
+        msg = "synthesis validation reconciliation has duplicate or unknown evidence"
+        raise ValueError(msg)
+    if bundle is not None:
+        context = bundle.get("plan_context", {})
+        exact_reused = {key for _requirement, key in context.get("exact_reused_review_evidence", [])}
+        records = {item["evidence_id"]: item for item in bundle["records"] if item["evidence_id"] in predecessors}
+        if set(records) != set(predecessors):
+            msg = "synthesis bundle does not contain all dispatched predecessors"
+            raise ValueError(msg)
+        for item in coverage:
+            record = records[item["evidence_id"]]
+            disposition = "reused" if record.get("reuse") or item["evidence_id"] in exact_reused else "blocked" if record["status"] == "blocked" else "accepted"
+            if set(item["requirement_ids"]) != set(record["requirement_ids"]) or item["disposition"] != disposition:
+                msg = "synthesis predecessor coverage contradicts accepted evidence"
+                raise ValueError(msg)
+        source_findings = {(key, finding["finding_id"]) for key, record in records.items() for finding in record.get("findings", [])}
+        if references != source_findings:
+            msg = "synthesis must preserve every source finding and cannot invent source-finding references"
+            raise ValueError(msg)
+        expected_validations = {key: record for key, record in records.items() if record["record_type"] == "validation"}
+        if set(validation_ids) != set(expected_validations):
+            msg = "synthesis must reconcile every predecessor validator"
+            raise ValueError(msg)
+        for item in validations:
+            record = expected_validations[item["evidence_id"]]
+            if item["result"] != record["status"] or set(item["requirement_ids"]) != set(record["requirement_ids"]):
+                msg = "synthesis validation result contradicts accepted evidence"
+                raise ValueError(msg)
+            if "validation_environments" in context:
+                environment = context["validation_environments"].get(record["node_id"])
+                if environment is None or item["platform"] != environment["platform"]:
+                    msg = "synthesis validation platform contradicts the bound executor environment"
+                    raise ValueError(msg)
+        closure = payload["routing_closure"]
+        unresolved = context.get("handoff_reconciliation", {}).get("unresolved_handoff_ids", [])
+        complete = context.get("routing_catalog_closed", False) and not context.get("routing_completion_blockers") and not unresolved
+        if closure != {"complete": complete, "unresolved_handoff_ids": unresolved, "user_excluded_catalog_ids": context.get("user_excluded_catalog_ids", [])}:
+            msg = "synthesis routing closure contradicts the plan bundle"
+            raise ValueError(msg)
+    unfinished = any(item["disposition"] in {"remaining", "blocked"} for item in payload["findings"])
+    failed = any(item["result"] in {"failed", "blocked"} or item["execution_mode"] == "unexecuted" for item in validations)
+    incomplete = not payload["routing_closure"]["complete"] or bool(payload["routing_closure"]["unresolved_handoff_ids"])
+    incomplete |= any(item["disposition"] == "blocked" for item in coverage) or payload["status"] == "blocked"
+    if payload["readiness_verdict"] == "ready" and (unfinished or failed or incomplete):
+        msg = "ready synthesis contradicts remaining findings, validation gaps, or incomplete coverage"
+        raise ValueError(msg)
+    if incomplete and payload["readiness_verdict"] != "blocked":
+        msg = "incomplete synthesis requires a blocked readiness verdict"
+        raise ValueError(msg)
+
+
+def synthesis_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    """Retain dedicated judgments in compiler output and downstream bundles."""
+    return {
+        key: payload[key]
+        for key in ("readiness_verdict", "verdict_reasons", "predecessor_coverage", "routing_closure", "validation_reconciliation", "cross_surface_risks")
+        if key in payload
+    }

--- a/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
+++ b/agents/.agents/skills/review-graph/scripts/test_review_graph_runtime.py
@@ -333,6 +333,44 @@ def _dispatch(*, mode: str = "audit") -> dict[str, object]:
     }
 
 
+def _typed_synthesis_payload(dispatch: dict[str, Any], payload: dict[str, Any], plan: GraphPlan | None = None) -> dict[str, Any]:
+    if dispatch.get("mode") != "synthesis":
+        return payload
+    requirements = (
+        {f"{'validation' if node.mode == 'validation' else 'review'}:{node.node_id}": list(node.requirement_ids) for node in plan.actual_worker_nodes}
+        if plan
+        else {}
+    )
+    reused = {key for _requirement, key in plan.exact_reused_review_evidence} if plan else set()
+    platforms = {f"validation:{unit.node_id}": unit.platform for unit in plan.coalesced_validation_units} if plan else {}
+    if plan:
+        for requirement, evidence_id in plan.exact_reused_review_evidence:
+            requirements.setdefault(evidence_id, []).append(requirement)
+    return {
+        "changes": [],
+        **payload,
+        "readiness_verdict": "ready",
+        "verdict_reasons": ["All required evidence reconciles."],
+        "predecessor_coverage": [
+            {"evidence_id": key, "requirement_ids": requirements.get(key, []), "disposition": "reused" if key in reused else "accepted"}
+            for key in dispatch["predecessor_evidence_ids"]
+        ],
+        "routing_closure": {"complete": True, "unresolved_handoff_ids": [], "user_excluded_catalog_ids": []},
+        "validation_reconciliation": [
+            {
+                "evidence_id": key,
+                "requirement_ids": requirements.get(key, []),
+                "result": "passed",
+                "platform": platforms.get(key, "current host"),
+                "execution_mode": "native",
+            }
+            for key in dispatch["predecessor_evidence_ids"]
+            if key.startswith("validation:")
+        ],
+        "cross_surface_risks": [],
+    }
+
+
 def test_compile_review_builds_verified_artifact_from_compact_payload() -> None:
     content, metadata = compile_review(
         {
@@ -839,7 +877,7 @@ def _mutation_with_audit_source(
         "status": "no-findings",
         "validation_requirements": [],
     }
-    content, metadata = compile_review({"dispatch": dispatch, "payload": payload})
+    content, metadata = compile_review({"dispatch": dispatch, "payload": _typed_synthesis_payload(dispatch, payload)})
     artifact_path = Path(entry["artifact_path"])
     metadata_path = Path(entry["metadata_path"])
     artifact_path.write_bytes(content)
@@ -1005,7 +1043,7 @@ def _compile_repair_fixture_entry(entry: dict[str, Any], lifecycle: dict[str, An
             "status": "no-findings",
             "validation_requirements": [],
         }
-        content, metadata = compile_review({"dispatch": dispatch, "payload": payload})
+        content, metadata = compile_review({"dispatch": dispatch, "payload": _typed_synthesis_payload(dispatch, payload, _graph_plan(lifecycle["plan"]))})
     Path(entry["artifact_path"]).write_bytes(content)
     Path(entry["metadata_path"]).write_text(json.dumps(metadata), encoding="utf-8")
     source: dict[str, str] = {"artifact_path": entry["artifact_path"], "metadata_path": entry["metadata_path"]}
@@ -3646,7 +3684,7 @@ none
                 "validation_requirements": [],
             }
             require_schema(payload, SCHEMA_ROOT / "review-payload-v1.schema.json")
-            content, metadata = compile_review({"dispatch": dispatch, "payload": payload})
+            content, metadata = compile_review({"dispatch": dispatch, "payload": _typed_synthesis_payload(dispatch, payload, plan)})
             kind = "review"
         artifact_path = Path(entry["artifact_path"])
         metadata_path = Path(entry["metadata_path"])
@@ -3776,6 +3814,7 @@ def _compile_materialized_evidence(  # noqa: PLR0913
     skip_node_ids: tuple[str, ...] = (),
     late_requirements: list[dict[str, Any]] | None = None,
     reference_planned_validation: bool = False,
+    audit_findings: list[dict[str, Any]] | None = None,
 ) -> tuple[GraphPlan, list[dict[str, str]]]:
     plan = plan or _sparse_plan()
     materialized = materialize_dispatches(
@@ -3865,7 +3904,9 @@ def _compile_materialized_evidence(  # noqa: PLR0913
                 "status": "no-findings",
                 "validation_requirements": validation_requirements,
             }
-            content, metadata = compile_review({"dispatch": dispatch, "payload": payload})
+            if audit_findings and dispatch["mode"] == "audit":
+                payload.update({"status": "completed", "findings": audit_findings})
+            content, metadata = compile_review({"dispatch": dispatch, "payload": _typed_synthesis_payload(dispatch, payload, plan)})
             kind = "review"
         artifact_path = Path(entry["artifact_path"])
         metadata_path = Path(entry["metadata_path"])
@@ -3873,6 +3914,29 @@ def _compile_materialized_evidence(  # noqa: PLR0913
         metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
         sources.append({"artifact_path": str(artifact_path), "kind": kind, "metadata_path": str(metadata_path)})
     return plan, sources
+
+
+def test_diagnostic_synthesis_cannot_hide_predecessor_findings_from_final_proof(tmp_path: Path) -> None:
+    finding = {
+        "severity": "P1",
+        "location": f"{STATE_FIXTURE}:1",
+        "summary": "An invalid transition remains",
+        "evidence": "The transition loses its required state.",
+        "remediation": "Preserve the state invariant.",
+    }
+    plan, sources = _compile_materialized_evidence(tmp_path, audit_findings=[finding])
+    final = finalize_proof(
+        {
+            "plan": _json_plan(plan),
+            "sources": sources,
+            "source_state": ["scope", "worktree", "repository"],
+            "current_source_state": ["scope", "worktree", "repository"],
+        }
+    )
+    assert final["status"] == "incomplete"
+    assert final["repository_validation_status"] == "passed"
+    assert final["repository_readiness"] == "blocked"
+    assert any("preserve every source finding" in blocker for blocker in final["blockers"])
 
 
 def _source_by_node(sources: list[dict[str, str]]) -> dict[str, dict[str, str]]:
@@ -4237,6 +4301,7 @@ def test_bundle_only_synthesis_persists_and_compiles_without_reading_source(tmp_
         "limitations": [],
         "scope_limitations": [],
     }
+    payload = _typed_synthesis_payload(entry["dispatch"], payload)
     _publish_worker_bytes(entry, json.dumps(payload).encode())
     dispatch = {**entry["dispatch"], "before_state": materialized["source_state"], "after_state": materialized["source_state"]}
     content, metadata = compile_review({"dispatch": dispatch, "payload": json.loads(Path(entry["worker_payload_path"]).read_text())})
@@ -4277,6 +4342,7 @@ def test_plan_digest_keeps_existing_journals_compatible_without_optional_reuse_f
     plan = _sparse_plan()
     legacy = _json_plan(plan)
     legacy.pop("validation_exclusions")
+    legacy.pop("audit_delta_reviews")
     legacy.pop("audit_reuse_transitions")
     legacy.pop("reuse_source_snapshots")
     expected = "sha256:" + hashlib.sha256(json.dumps(legacy, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
@@ -4289,6 +4355,7 @@ def test_plan_digest_retains_nonempty_reuse_fields(tmp_path: Path) -> None:
     result = advance_after_mutation(request)
     plan = _graph_plan(json.loads(json.dumps(result["new_plan"])))
     document = _json_plan(plan)
+    document.pop("audit_delta_reviews")
     document.pop("validation_exclusions")
     expected = "sha256:" + hashlib.sha256(json.dumps(document, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 

--- a/agents/.agents/skills/review-graph/scripts/test_review_graph_transitions.py
+++ b/agents/.agents/skills/review-graph/scripts/test_review_graph_transitions.py
@@ -1,0 +1,663 @@
+"""Live repository regressions for partial coverage, external staging, and readiness."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from capture_scope import _scope_data
+from review_graph_bootstrap import bootstrap_document
+from review_graph_plan import plan_from_document
+from review_graph_runtime import (
+    JournalEventRequest,
+    _graph_plan,
+    advance_after_mutation,
+    append_journal_event,
+    build_synthesis_bundle,
+    compile_independent_review,
+    compile_review,
+    compile_validation,
+    finalize_proof,
+    main,
+    materialize_dispatches,
+    next_ready_nodes,
+    read_execution_journal,
+    resume_after_external_metadata,
+)
+from review_graph_schema import SchemaValidationError, require_schema_definition
+from review_graph_synthesis import validate_synthesis
+from test_review_graph_runtime import (
+    INDEPENDENT_NATIVE_EXAMPLE,
+    ROUTING_CATALOG,
+    SCHEMA_ROOT,
+    SKILL_ROOT,
+    STATE_FIXTURE,
+    _baseline_mutation_fixture,
+    _json_plan,
+    _publish_worker_bytes,
+    _run_test_git,
+    _sparse_plan_document,
+)
+
+
+def _payload(paths: list[str]) -> dict[str, Any]:
+    return {
+        "status": "no-findings",
+        "files_inspected": paths,
+        "findings": [],
+        "changes": [],
+        "handoffs": [],
+        "limitations": [],
+        "scope_limitations": [],
+        "nearby_contract_owners": [],
+        "validation_requirements": [],
+        "commands_executed": [],
+        "command_policy_attested": True,
+    }
+
+
+def _synthesis_payload(dispatch: dict[str, Any], bundle: dict[str, Any]) -> dict[str, Any]:
+    records = [record for record in bundle["records"] if record["evidence_id"] in dispatch["predecessor_evidence_ids"]]
+    findings = [
+        {
+            **{key: finding[key] for key in ("severity", "location", "summary", "evidence", "remediation")},
+            "owner": record["skill_id"],
+            "disposition": "remaining",
+            "source_findings": [{"evidence_id": record["evidence_id"], "finding_id": finding["finding_id"]}],
+        }
+        for record in records
+        for finding in record.get("findings", [])
+    ]
+    return {
+        **_payload([]),
+        "status": "completed" if findings else "no-findings",
+        "findings": findings,
+        "readiness_verdict": "not-ready" if findings else "ready",
+        "verdict_reasons": ["Findings remain." if findings else "Required evidence reconciles."],
+        "predecessor_coverage": [
+            {"evidence_id": record["evidence_id"], "requirement_ids": record["requirement_ids"], "disposition": "reused" if record.get("reuse") else "accepted"}
+            for record in records
+        ],
+        "routing_closure": {"complete": True, "unresolved_handoff_ids": [], "user_excluded_catalog_ids": []},
+        "validation_reconciliation": [
+            {
+                "evidence_id": record["evidence_id"],
+                "requirement_ids": record["requirement_ids"],
+                "result": record["status"],
+                "platform": bundle["plan_context"]["validation_environments"][record["node_id"]]["platform"],
+                "execution_mode": "native",
+            }
+            for record in records
+            if record["record_type"] == "validation"
+        ],
+        "cross_surface_risks": [],
+    }
+
+
+def _materialize(tmp_path: Path, capture: dict[str, Any], plan: Any) -> tuple[dict[str, Any], dict[str, Any], Path]:
+    state = [capture[key] for key in ("scope_fingerprint", "captured_worktree_fingerprint", "repository_state_fingerprint")]
+    lifecycle = {"plan": _json_plan(plan), "source_state": state}
+    entries = materialize_dispatches(
+        {
+            **lifecycle,
+            "artifact_store": str(tmp_path / "old"),
+            "repository_root": capture["repository_root"],
+            "authorization": "review-only",
+            "state_verification_command": "capture_scope.py --mode baseline",
+        }
+    )
+    dispatches = tmp_path / "dispatches.json"
+    dispatches.write_text(json.dumps(entries))
+    return lifecycle, entries, dispatches
+
+
+@pytest.mark.parametrize("dependency", ["independent", "manifest", "uncertain"])
+def test_manifest_delta_reuses_implementation_and_preserves_findings(tmp_path: Path, dependency: str) -> None:
+    git, repository, template, _capture, _plan = _baseline_mutation_fixture(tmp_path)
+    (repository / "pyproject.toml").write_text('[project]\nname = "example"\nversion = "0.1.0"\ndependencies = []\n')
+    _run_test_git(git, "-C", str(repository), "add", "pyproject.toml")
+    _run_test_git(git, "-C", str(repository), "commit", "-m", "manifest")
+    template["routing_overrides"].append(
+        {
+            "catalog_id": "python.cli",
+            "disposition": "selected",
+            "reason": "CLI and installation contracts",
+            "applicability_evidence": ["tool.py"],
+            "owners": ["python"],
+            "review_surface": ["tool.py", "pyproject.toml"],
+        }
+    )
+    capture = _scope_data(git, repository, "baseline", None, ())
+    plan = plan_from_document(bootstrap_document(capture, template), catalog_path=ROUTING_CATALOG, skill_roots=(SKILL_ROOT,), repository_root=repository)
+    lifecycle, entries, _dispatches = _materialize(tmp_path, capture, plan)
+    entry = next(item for item in entries["dispatches"] if item["dispatch"]["skill_id"] == "python-cli-review")
+    payload = _payload(entry["dispatch"]["owned_paths"])
+    payload.update(
+        {
+            "status": "completed",
+            "findings": [
+                {
+                    "severity": "P2",
+                    "location": "tool.py:1",
+                    "summary": "Exit status contract is missing",
+                    "evidence": "The tool does not implement its documented exit contract.",
+                    "remediation": "Return the documented exit status.",
+                }
+            ],
+            "coverage_units": [
+                {"unit_id": "implementation", "owned_paths": ["tool.py"], "dependency_paths": [], "dependency_uncertainty": "", "finding_indices": [1]},
+                {"unit_id": "installation", "owned_paths": ["pyproject.toml"], "dependency_paths": [], "dependency_uncertainty": "", "finding_indices": []},
+            ],
+        }
+    )
+    if dependency == "manifest":
+        payload["coverage_units"][0]["dependency_paths"] = ["pyproject.toml"]
+    elif dependency == "uncertain":
+        payload["coverage_units"][0]["dependency_uncertainty"] = "Installation may affect command discovery."
+    content, metadata = compile_review(
+        {"dispatch": {**entry["dispatch"], "before_state": lifecycle["source_state"], "after_state": lifecycle["source_state"]}, "payload": payload}
+    )
+    Path(entry["artifact_path"]).write_bytes(content)
+    Path(entry["metadata_path"]).write_text(json.dumps(metadata))
+    original = Path(entry["artifact_path"]).read_bytes()
+    (repository / "pyproject.toml").write_text('[project]\nname = "example"\nversion = "0.1.0"\ndependencies = ["rust-just==1.58.0"]\n')
+    result = advance_after_mutation(
+        {
+            **lifecycle,
+            "previous_capture": capture,
+            "new_capture": _scope_data(git, repository, "baseline", None, ()),
+            "planning_template": template,
+            "authorization_before": "review-only",
+            "authorization_after": "review-and-fix",
+            "repair_epoch": 1,
+            "changed_paths": ["pyproject.toml"],
+            "artifact_store": str(tmp_path / "repair"),
+            "state_verification_command": "capture_scope.py --mode baseline",
+            "sources": [{"artifact_path": entry["artifact_path"], "metadata_path": entry["metadata_path"]}],
+        }
+    )
+    delta = next(item for item in result["dispatch_set"]["dispatches"] if item["dispatch"]["skill_id"] == "python-cli-review")
+    if dependency != "independent":
+        assert "coverage_reuse" not in delta["dispatch"]
+        decisions = next(item["units"] for item in result["coverage_reuse_decisions"] if item["node_id"] == delta["node_id"])
+        assert all(unit["disposition"] == "recheck" and unit["reason"] for unit in decisions)
+        assert set(delta["dispatch"]["owned_paths"]) == {"tool.py", "pyproject.toml"}
+        return
+    assert {unit["unit_id"]: unit["disposition"] for unit in delta["dispatch"]["coverage_reuse"]["units"]} == {
+        "implementation": "reused",
+        "installation": "recheck",
+    }
+    updated = {**_payload(["pyproject.toml"]), "status": "completed"}
+    contract = json.loads(Path(delta["worker_payload_contract_path"]).read_text())
+    require_schema_definition(contract, SCHEMA_ROOT / "runtime-operation-inputs-v1.schema.json", "stdinWorkerPayloadContract")
+    _publish_worker_bytes(delta, json.dumps(updated).encode())
+    state = result["new_source_state"]
+    compiled, metadata = compile_review({"dispatch": {**delta["dispatch"], "before_state": state, "after_state": state}, "payload": updated})
+    assert metadata["normalized_record"]["files_inspected"] == ["pyproject.toml"]
+    assert metadata["normalized_record"]["findings"][0]["source_findings"][0]["evidence_id"] == entry["dispatch"]["evidence_id"]
+    assert b"Exit status contract is missing" in compiled
+    assert Path(entry["artifact_path"]).read_bytes() == original
+    assert (
+        main(
+            [
+                "compile-node",
+                "--input",
+                result["lifecycle_input_path"],
+                "--dispatches",
+                result["dispatches_path"],
+                "--journal",
+                result["journal_path"],
+                "--node-id",
+                delta["node_id"],
+                "--before-capture",
+                result["capture_path"],
+                "--after-capture",
+                result["capture_path"],
+                "--output",
+                str(tmp_path / "delta-result.json"),
+            ]
+        )
+        == 0
+    )
+    with pytest.raises(ValueError, match="structured scope limitation"):
+        compile_review({"dispatch": {**delta["dispatch"], "before_state": state, "after_state": state}, "payload": {**_payload([]), "status": "completed"}})
+    tampered = json.loads(json.dumps(delta["dispatch"]))
+    tampered["coverage_reuse"]["units"][1]["disposition"] = "reused"
+    with pytest.raises(ValueError, match="verified unit decisions"):
+        compile_review({"dispatch": {**tampered, "before_state": state, "after_state": state}, "payload": updated})
+
+
+def _staging_fixture(tmp_path: Path) -> tuple[str, Path, dict[str, Any], dict[str, Any], dict[str, Any]]:
+    git, repository, template, _capture, _plan = _baseline_mutation_fixture(tmp_path)
+    (repository / "tool.py").write_text("value = 2\n")
+    capture = _scope_data(git, repository, "baseline", None, ())
+    plan = plan_from_document(bootstrap_document(capture, template), catalog_path=ROUTING_CATALOG, skill_roots=(SKILL_ROOT,), repository_root=repository)
+    lifecycle, entries, dispatches = _materialize(tmp_path, capture, plan)
+    journal = tmp_path / "old.jsonl"
+    audit = next(item for item in entries["dispatches"] if item["dispatch"].get("mode") == "audit")
+    _publish_worker_bytes(audit, json.dumps(_payload(audit["dispatch"]["owned_paths"])).encode())
+    append_journal_event(journal, lifecycle, JournalEventRequest(audit["node_id"], "in-flight"))
+    _run_test_git(git, "-C", str(repository), "add", "tool.py")
+    request = {
+        **lifecycle,
+        "previous_capture": capture,
+        "new_capture": _scope_data(git, repository, "baseline", None, ()),
+        "dispatches_path": str(dispatches),
+        "journal_path": str(journal),
+        "artifact_store": str(tmp_path / "resumed"),
+    }
+    return git, repository, request, audit, entries
+
+
+@pytest.mark.parametrize("remaining_findings", [False, True])
+def test_external_staging_between_dispatch_and_compile_completes_without_rollback(tmp_path: Path, remaining_findings: bool) -> None:  # noqa: PLR0915
+    git, repository, request, audit, _entries = _staging_fixture(tmp_path)
+    if remaining_findings:
+        payload = _payload(audit["dispatch"]["owned_paths"])
+        payload.update(
+            {
+                "status": "completed",
+                "findings": [
+                    {
+                        "severity": "P2",
+                        "location": "tool.py:1",
+                        "summary": "Exit contract",
+                        "evidence": "Failure exits zero.",
+                        "remediation": "Set an error exit status.",
+                    }
+                ],
+            }
+        )
+        _publish_worker_bytes(audit, json.dumps(payload).encode())
+    result = resume_after_external_metadata(request)
+    assert result["original_source_state"] != result["current_source_state"]
+    assert audit["node_id"] in result["preserved_node_ids"]
+    before = tmp_path / "before.json"
+    before.write_text(json.dumps(request["previous_capture"]))
+    argv = [
+        "compile-node",
+        "--input",
+        result["lifecycle_input_path"],
+        "--dispatches",
+        result["dispatches_path"],
+        "--journal",
+        result["journal_path"],
+        "--node-id",
+        audit["node_id"],
+        "--before-capture",
+        str(before),
+        "--after-capture",
+        result["capture_path"],
+        "--output",
+        str(tmp_path / "first-result.json"),
+    ]
+    assert main(argv) == 0
+    metadata = json.loads(Path(audit["metadata_path"]).read_text())
+    assert metadata["evidence"]["fingerprints"]["before"] == result["original_source_state"]
+    assert metadata["evidence"]["fingerprints"]["after"] == result["current_source_state"]
+    assert metadata["evidence"]["git_mutated"] is False
+    lifecycle = json.loads(Path(result["lifecycle_input_path"]).read_text())
+    plan = _graph_plan(lifecycle["plan"])
+    sources = [{"artifact_path": audit["artifact_path"], "metadata_path": audit["metadata_path"]}]
+    for _ in range(plan.complete_node_count):
+        events, _states, _head = read_execution_journal(Path(result["journal_path"]), plan=plan, source_state=tuple(lifecycle["source_state"]))
+        ready = next_ready_nodes(
+            {**lifecycle, "current_source_state": result["current_source_state"]}, journal_events=events, dispatch_set=result["dispatch_set"]
+        )
+        if ready["complete"]:
+            break
+        assert ready["ready_dispatches"], ready
+        for entry in ready["ready_dispatches"]:
+            dispatch = entry["dispatch"]
+            workspace_args = []
+            if entry["result_contract"] == "compact-validation":
+                unit = dispatch["validation_unit"]
+                payload = {
+                    "status": "passed",
+                    "limitations": [],
+                    "executions": [
+                        {
+                            "command": command,
+                            "working_directory": directory,
+                            "executor": "fixture",
+                            "result": "passed",
+                            "exit_code": 0,
+                            "elapsed": "0s",
+                            "evidence": "true completed",
+                            "artifact_paths": [],
+                        }
+                        for command, directory in zip(unit["commands"], unit["working_directories"], strict=True)
+                    ],
+                }
+                for phase in ("before", "after"):
+                    snapshot = tmp_path / f"{entry['node_id']}-{phase}.json"
+                    assert (
+                        main(
+                            [
+                                "snapshot-workspace",
+                                "--input",
+                                result["lifecycle_input_path"],
+                                "--dispatches",
+                                result["dispatches_path"],
+                                "--node-id",
+                                entry["node_id"],
+                                "--current-capture",
+                                result["capture_path"],
+                                "--output",
+                                str(snapshot),
+                            ]
+                        )
+                        == 0
+                    )
+                    workspace_args.extend([f"--workspace-{phase}", str(snapshot)])
+            elif dispatch["mode"] == "synthesis":
+                payload = _synthesis_payload(dispatch, build_synthesis_bundle({**lifecycle, "sources": sources}))
+            else:
+                payload = _payload(dispatch["owned_paths"])
+            _publish_worker_bytes(entry, json.dumps(payload).encode())
+            assert (
+                main(
+                    [
+                        "compile-node",
+                        "--input",
+                        result["lifecycle_input_path"],
+                        "--dispatches",
+                        result["dispatches_path"],
+                        "--journal",
+                        result["journal_path"],
+                        "--node-id",
+                        entry["node_id"],
+                        "--before-capture",
+                        result["capture_path"],
+                        "--after-capture",
+                        result["capture_path"],
+                        "--output",
+                        str(tmp_path / f"{entry['node_id']}-result.json"),
+                        *workspace_args,
+                    ]
+                )
+                == 0
+            )
+            sources.append({"artifact_path": entry["artifact_path"], "metadata_path": entry["metadata_path"]})
+    proof = finalize_proof({**lifecycle, "current_source_state": result["current_source_state"], "sources": sources})
+    assert proof["status"] == "complete", proof["blockers"]
+    assert proof["repository_validation_status"] == "passed"
+    assert proof["repository_readiness"] == ("not-ready" if remaining_findings else "ready")
+    assert _scope_data(git, repository, "baseline", None, ())["index_fingerprint"] == request["new_capture"]["index_fingerprint"]
+    template = _sparse_plan_document()
+    template["consulted_routers"] = ["review-graph", "rust-review-orchestrator", "python-review-orchestrator"]
+    template["routing_overrides"][0]["review_surface"] = ["state.rs"]
+    template["validation_requirements"][0]["working_directories"] = [str(repository)]
+    (repository / "tool.py").write_text("value = 3\n")
+    advanced = advance_after_mutation(
+        {
+            **lifecycle,
+            "previous_capture": request["new_capture"],
+            "new_capture": _scope_data(git, repository, "baseline", None, ()),
+            "changed_paths": ["tool.py"],
+            "planning_template": template,
+            "sources": sources,
+            "authorization_before": "review-only",
+            "authorization_after": "review-and-fix",
+            "repair_epoch": 1,
+            "artifact_store": str(tmp_path / "after-staging-repair"),
+            "state_verification_command": "capture_scope.py --mode baseline",
+        }
+    )
+    assert advanced["status"] == "advanced"
+    assert advanced["reused_evidence_ids"]
+
+
+def test_independent_review_can_revalidate_on_resumed_metadata(tmp_path: Path) -> None:
+    _git, _repository, request, _audit, _entries = _staging_fixture(tmp_path)
+    resumed = resume_after_external_metadata(request)
+    original, current = request["source_state"], resumed["current_source_state"]
+    native = INDEPENDENT_NATIVE_EXAMPLE.read_text().replace(STATE_FIXTURE, "state.rs")
+    native = native.replace("Scope fingerprint: scope", f"Scope fingerprint: {original[0]}")
+    native = native.replace("Worktree fingerprint: worktree", f"Worktree fingerprint: {original[1]}")
+    native = native.replace("Repository state fingerprint: repository", f"Repository state fingerprint: {original[2]}", 1)
+    native = native.replace("Repository state fingerprint: repository", f"Repository state fingerprint: {current[2]}")
+    dispatch = {
+        "adversarial_checks": ["fallback absence and failure", "platform seams", "parser suffixes and error branches", "unexpected exception types"],
+        "artifact_id": "artifact://independent-staging",
+        "authorization": "review-only",
+        "change_target": "git diff -- state.rs",
+        "evidence_id": "review:independent-staging",
+        "execution_location": "worker",
+        "execution_profile": "grouped",
+        "fresh_context": True,
+        "handoff_catalog_ids": [],
+        "mode": "independent-review",
+        "node_id": "independent-staging",
+        "planned_path_line_bounds": [["state.rs", 1]],
+        "planned_paths": ["state.rs"],
+        "reference_paths": [],
+        "requirement_ids": ["repo.independent"],
+        "selection_reason": "concrete worktree change",
+        "skill_id": "repository-independent-review",
+        "skill_path": str(SKILL_ROOT / "repository-independent-review" / "SKILL.md"),
+        "source_state": original,
+        "before_state": current,
+        "after_state": current,
+        "worker_created": True,
+        "external_metadata_transitions": resumed["lifecycle_input"]["external_metadata_transitions"],
+    }
+    content, metadata = compile_independent_review({"dispatch": dispatch, "limitations": [], "status": "no-findings"}, native.encode())
+    assert metadata["normalized_record"]["observed_source_state"] == current
+    assert b"External metadata transitions:" in content
+
+
+def test_compound_git_command_is_rechecked_after_staging(tmp_path: Path) -> None:
+    _git, _repository, request, audit, _entries = _staging_fixture(tmp_path)
+    payload = _payload(audit["dispatch"]["owned_paths"])
+    payload["commands_executed"] = ["rg value tool.py && git diff --cached --stat"]
+    content, metadata = compile_review(
+        {"dispatch": {**audit["dispatch"], "before_state": request["source_state"], "after_state": request["source_state"]}, "payload": payload}
+    )
+    Path(audit["artifact_path"]).write_bytes(content)
+    Path(audit["metadata_path"]).write_text(json.dumps(metadata))
+    append_journal_event(
+        Path(request["journal_path"]),
+        request,
+        JournalEventRequest(audit["node_id"], "accepted", source={"artifact_path": audit["artifact_path"], "metadata_path": audit["metadata_path"]}),
+    )
+    resumed = resume_after_external_metadata(request)
+    assert audit["node_id"] in resumed["recheck_node_ids"]
+    assert audit["node_id"] not in resumed["preserved_node_ids"]
+
+
+@pytest.mark.parametrize("mode", ["staged", "branch"])
+def test_external_metadata_resume_rejects_git_sensitive_scope(tmp_path: Path, mode: str) -> None:
+    git, repository, request, _audit, _entries = _staging_fixture(tmp_path)
+    base = "HEAD" if mode == "branch" else None
+    request["previous_capture"] = _scope_data(git, repository, mode, base, ())
+    request["new_capture"] = request["previous_capture"]
+    with pytest.raises(ValueError, match="staged and branch targets"):
+        resume_after_external_metadata(request)
+
+
+def test_external_metadata_resume_rejects_content_changes(tmp_path: Path) -> None:
+    git, repository, request, _audit, _entries = _staging_fixture(tmp_path)
+    (repository / "tool.py").write_text("value = 3\n")
+    request["new_capture"] = _scope_data(git, repository, "baseline", None, ())
+    with pytest.raises(ValueError, match="only the index"):
+        resume_after_external_metadata(request)
+
+
+def test_synthesis_cannot_use_generic_payload_or_ready_with_remaining_findings(tmp_path: Path) -> None:
+    _git, _repository, _template, capture, plan = _baseline_mutation_fixture(tmp_path)
+    lifecycle, entries, _dispatches = _materialize(tmp_path, capture, plan)
+    entry = next(item for item in entries["dispatches"] if item["dispatch"].get("mode") == "synthesis")
+    dispatch = {**entry["dispatch"], "before_state": lifecycle["source_state"], "after_state": lifecycle["source_state"]}
+    assert dispatch["payload_schema"]["id"].endswith("synthesis-payload-v1.schema.json")
+    with pytest.raises(SchemaValidationError, match="readiness_verdict"):
+        compile_review({"dispatch": dispatch, "payload": _payload([])})
+    payload = {
+        **_payload([]),
+        "status": "completed",
+        "readiness_verdict": "not-ready",
+        "verdict_reasons": ["Exit contract remains broken."],
+        "predecessor_coverage": [{"evidence_id": key, "requirement_ids": [], "disposition": "accepted"} for key in dispatch["predecessor_evidence_ids"]],
+        "routing_closure": {"complete": True, "unresolved_handoff_ids": [], "user_excluded_catalog_ids": []},
+        "validation_reconciliation": [],
+        "cross_surface_risks": [],
+        "findings": [
+            {
+                "severity": "P2",
+                "location": "tool.py:1",
+                "summary": "Exit contract",
+                "evidence": "Failure exits zero.",
+                "remediation": "Set an error exit status.",
+                "owner": "python-cli-review",
+                "disposition": "remaining",
+                "source_findings": [],
+            }
+        ],
+    }
+    _content, metadata = compile_review({"dispatch": dispatch, "payload": payload})
+    assert metadata["evidence"]["status"] == "completed"
+    assert metadata["normalized_record"]["readiness_verdict"] == "not-ready"
+    with pytest.raises(ValueError, match="ready synthesis contradicts"):
+        compile_review({"dispatch": dispatch, "payload": {**payload, "readiness_verdict": "ready"}})
+
+
+@pytest.mark.parametrize("transition", [{}, {"before": {}}, {"before": None, "after": {}}])
+def test_malformed_metadata_transition_is_a_cli_error_without_publication(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], transition: dict[str, Any]
+) -> None:
+    git, repository, request, _audit, _entries = _staging_fixture(tmp_path)
+    request["external_metadata_transitions"] = [transition]
+    request_path = tmp_path / "malformed.json"
+    request_path.write_text(json.dumps(request))
+    output = tmp_path / "result.json"
+    assert main(["resume-after-external-metadata", "--input", str(request_path), "--output", str(output)]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "before and after snapshot objects" in captured.err
+    assert "Traceback" not in captured.err
+    assert not output.exists()
+    assert not Path(request["artifact_store"]).exists()
+    assert _scope_data(git, repository, "baseline", None, ())["index_fingerprint"] == request["new_capture"]["index_fingerprint"]
+
+
+@pytest.mark.parametrize("staged_before_repairs", [False, True])
+def test_partitioned_audit_retains_original_capture_across_multiple_repairs(tmp_path: Path, staged_before_repairs: bool) -> None:
+    git, repository, template, _capture, _plan = _baseline_mutation_fixture(tmp_path)
+    (repository / "pyproject.toml").write_text('[project]\nname="example"\nversion="0.1.0"\n')
+    _run_test_git(git, "-C", str(repository), "add", "pyproject.toml")
+    _run_test_git(git, "-C", str(repository), "commit", "-m", "manifest")
+    (repository / "tool.py").write_text("value = 2\n")
+    template["routing_overrides"].append(
+        {
+            "catalog_id": "python.cli",
+            "disposition": "selected",
+            "reason": "CLI and manifest contracts",
+            "applicability_evidence": ["tool.py"],
+            "owners": ["python"],
+            "review_surface": ["tool.py", "pyproject.toml"],
+        }
+    )
+    capture = _scope_data(git, repository, "baseline", None, ())
+    plan = plan_from_document(bootstrap_document(capture, template), catalog_path=ROUTING_CATALOG, skill_roots=(SKILL_ROOT,), repository_root=repository)
+    lifecycle, entries, _dispatches = _materialize(tmp_path, capture, plan)
+    entry = next(item for item in entries["dispatches"] if item["dispatch"]["skill_id"] == "python-cli-review")
+    payload = _payload(entry["dispatch"]["owned_paths"])
+    payload["coverage_units"] = [
+        {"unit_id": path, "owned_paths": [path], "dependency_paths": [], "dependency_uncertainty": "", "finding_indices": []}
+        for path in ("tool.py", "pyproject.toml")
+    ]
+    content, metadata = compile_review(
+        {"dispatch": {**entry["dispatch"], "before_state": lifecycle["source_state"], "after_state": lifecycle["source_state"]}, "payload": payload}
+    )
+    Path(entry["artifact_path"]).write_bytes(content)
+    Path(entry["metadata_path"]).write_text(json.dumps(metadata))
+    sources = [{"artifact_path": entry["artifact_path"], "metadata_path": entry["metadata_path"]}]
+    origin = capture
+    if staged_before_repairs:
+        _run_test_git(git, "-C", str(repository), "add", "tool.py")
+        capture = _scope_data(git, repository, "baseline", None, ())
+        lifecycle["external_metadata_transitions"] = [{"before": origin, "after": capture}]
+    repairs: list[dict[str, Any]] = []
+    for epoch, (path, replacement) in enumerate(
+        [("state.rs", "pub fn changed() {}\n"), ("pyproject.toml", '[project]\nname="example"\nversion="0.2.0"\n')], start=1
+    ):
+        (repository / path).write_text(replacement)
+        after = _scope_data(git, repository, "baseline", None, ())
+        result = advance_after_mutation(
+            {
+                **lifecycle,
+                "previous_capture": capture,
+                "new_capture": after,
+                "planning_template": template,
+                "authorization_before": "review-and-fix",
+                "authorization_after": "review-and-fix",
+                "repair_epoch": epoch,
+                "changed_paths": [path],
+                "artifact_store": str(tmp_path / f"repair-{epoch}"),
+                "state_verification_command": "capture_scope.py --mode baseline",
+                "sources": sources,
+            }
+        )
+        assert result["status"] == "advanced"
+        repairs.append(result)
+        if epoch == 1:
+            assert result["reused_evidence_ids"] == [entry["dispatch"]["evidence_id"]]
+        lifecycle = json.loads(Path(result["lifecycle_input_path"]).read_text())
+        capture = after
+    result = repairs[-1]
+    delta = next(item for item in result["dispatch_set"]["dispatches"] if item["dispatch"]["skill_id"] == "python-cli-review")
+    context = delta["dispatch"]["coverage_reuse"]
+    assert context["origin"]["repository_state_fingerprint"] == origin["repository_state_fingerprint"]
+    assert {unit["unit_id"]: unit["disposition"] for unit in context["units"]} == {"tool.py": "reused", "pyproject.toml": "recheck"}
+    state = result["new_source_state"]
+    _content, updated = compile_review(
+        {"dispatch": {**delta["dispatch"], "before_state": state, "after_state": state}, "payload": _payload(["pyproject.toml"])}
+    )
+    assert updated["normalized_record"]["files_inspected"] == ["pyproject.toml"]
+    assert Path(entry["artifact_path"]).read_bytes() == content
+    assert _scope_data(git, repository, "baseline", None, ())["index_fingerprint"] == capture["index_fingerprint"]
+
+
+def test_synthesis_uses_bound_validator_platform_and_exposes_execution_configuration(tmp_path: Path) -> None:
+    git, repository, template, _capture, _plan = _baseline_mutation_fixture(tmp_path)
+    template["validation_requirements"][0].update(
+        {"platform": "macos-arm64", "environment": "Linux boundary emulation on macOS", "features": ["mode=emulated"]}
+    )
+    capture = _scope_data(git, repository, "baseline", None, ())
+    plan = plan_from_document(bootstrap_document(capture, template), catalog_path=ROUTING_CATALOG, skill_roots=(SKILL_ROOT,), repository_root=repository)
+    lifecycle, entries, _dispatches = _materialize(tmp_path, capture, plan)
+    entry = next(item for item in entries["dispatches"] if item["result_contract"] == "compact-validation")
+    unit = entry["dispatch"]["validation_unit"]
+    executions = [
+        {
+            "command": command,
+            "working_directory": directory,
+            "executor": "macOS fixture",
+            "result": "passed",
+            "exit_code": 0,
+            "elapsed": "0s",
+            "evidence": "Modeled Linux boundary passed on macOS.",
+            "artifact_paths": [],
+        }
+        for command, directory in zip(unit["commands"], unit["working_directories"], strict=True)
+    ]
+    content, metadata = compile_validation(
+        {
+            "dispatch": {**entry["dispatch"], "before_state": lifecycle["source_state"], "after_state": lifecycle["source_state"]},
+            "payload": {"status": "passed", "limitations": ["Linux boundary emulation only."], "executions": executions},
+        }
+    )
+    Path(entry["artifact_path"]).write_bytes(content)
+    Path(entry["metadata_path"]).write_text(json.dumps(metadata))
+    bundle = build_synthesis_bundle({**lifecycle, "sources": [{"artifact_path": entry["artifact_path"], "metadata_path": entry["metadata_path"]}]})
+    configuration = bundle["plan_context"]["validation_environments"][entry["node_id"]]
+    assert configuration["platform"] == "macos-arm64"
+    assert configuration["environment"] == "Linux boundary emulation on macOS"
+    assert configuration["features"] == ["mode=emulated"]
+    predecessor = entry["dispatch"]["evidence_id"]
+    payload = _synthesis_payload({"predecessor_evidence_ids": [predecessor]}, bundle)
+    payload["validation_reconciliation"][0]["execution_mode"] = "emulated"
+    validate_synthesis(payload, (predecessor,), bundle)
+    payload["validation_reconciliation"][0]["platform"] = "linux-native"
+    with pytest.raises(ValueError, match="bound executor environment"):
+        validate_synthesis(payload, (predecessor,), bundle)

--- a/agents/.agents/skills/rust-production-review/SKILL.md
+++ b/agents/.agents/skills/rust-production-review/SKILL.md
@@ -98,4 +98,12 @@ For every finding, show file/line evidence, the trigger and observable consequen
 
 ## Final Report
 
+In graph synthesis mode, return the dispatched
+[SynthesisPayload](../review-graph/references/schemas/synthesis-payload-v1.schema.json):
+typed `readiness_verdict` (`ready`, `not-ready`, `blocked`) and `verdict_reasons`,
+canonical findings with owner/disposition/source references, predecessor
+coverage, routing closure, validation reconciliation, and cross-surface risks.
+Remaining actionable findings mean `not-ready`; missing required evidence
+means `blocked`. Keep readiness separate from graph completion and validator success.
+
 Lead with unresolved P0/P1 findings. Include the readiness verdict, findings by severity, prior specialist outcomes and resolved contradictions, dependency/unsafe/deletion candidates, validators and exact results, supported configurations actually demonstrated, deferred work and residual risk, files changed, and confirmation that no git state mutation occurred when true.

--- a/justfile
+++ b/justfile
@@ -10,7 +10,7 @@ python_primary_paths := "agents/.agents/skills scripts"
 python_paths := python_primary_paths + " " + python_fixture_paths
 dprint_version := "0.57.4"
 just_version := "1.58.0"
-rumdl_version := "0.2.68"
+rumdl_version := "0.2.69"
 uv_version := "0.12.10"
 zizmor_version := "1.30.0"
 

--- a/uv.lock
+++ b/uv.lock
@@ -764,11 +764,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.7"
+version = "4.11.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/b7/802a56eca9f2fac455b8bab5375a2647b0f0e14a2cd63ef077de3c4a7658/platformdirs-4.11.7.tar.gz", hash = "sha256:4f41487eeeeeb07f3a6625e61d9bc0ae6809f92d3386dbd74392fbb76108104d", size = 35127, upload-time = "2026-09-01T13:35:10.502Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/18/f3bb8ef0d3b930692343da8aa4d3cbcd6749477c053959395ac81965a6e9/platformdirs-4.11.8.tar.gz", hash = "sha256:f23abafea7dd4276d1f29104b83598d7dcc567cafd07c9c951e66665645437fc", size = 37182, upload-time = "2026-09-08T22:20:42.866Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/6e/80993e10a0482f630cef528635789233224f36b1ffd11592aa15d13ff9ce/platformdirs-4.11.7-py3-none-any.whl", hash = "sha256:8a02cb259042c79d1cd0450facc2fe6dc9d303ae7901afbe33bf8ea0b188cef6", size = 23938, upload-time = "2026-09-01T13:35:09.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e1/5b7b8bbb55084d1425bcb9bc823ff519e1b2be05f6ebb0089e2eacc38413/platformdirs-4.11.8-py3-none-any.whl", hash = "sha256:52f2f181bbfde907966932cc8312d967d02976422d66d537ea16092b8e291081", size = 24027, upload-time = "2026-09-08T22:20:41.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Reuse unchanged audit coverage across repairs while preserving dependency checks, original captures, and finding provenance.
- Resume baseline and worktree reviews after external staging without altering the index, and rerun Git-sensitive work.
- Require typed synthesis that reconciles findings, coverage, and validator platforms while separating readiness from proof completion.
- Update rumdl to 0.2.69 and platformdirs to 4.11.8.

Fixes #58
Fixes #59
Fixes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added structured review-readiness results with clear `ready`, `not-ready`, and `blocked` outcomes.
  - Added detailed reporting for findings, evidence coverage, validation status, routing, and cross-surface risks.
  - Added support for resuming reviews after unchanged external metadata updates while preserving verified findings.
  - Added partitioned audit reuse, rechecking only coverage affected by stale or uncertain evidence.
  - Added safeguards for Git-sensitive reviews and incomplete or inconsistent validation evidence.

- **Documentation**
  - Expanded guidance for review lifecycle transitions, evidence reuse, metadata staging, and readiness reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->